### PR TITLE
docs: remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# xRust
+# Exercism Rust Track
 
-[![Build Status](https://travis-ci.org/exercism/xrust.svg?branch=master)](https://travis-ci.org/exercism/xrust)
-[![Join the chat at https://gitter.im/exercism/xrust](https://badges.gitter.im/exercism/xrust.svg)](https://gitter.im/exercism/xrust?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/exercism/rust.svg?branch=master)](https://travis-ci.org/exercism/rust)
+[![Join the chat at https://gitter.im/exercism/rust](https://badges.gitter.im/exercism/rust.svg)](https://gitter.im/exercism/rust?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Exercism exercises in Rust
 

--- a/problem_ordering.md
+++ b/problem_ordering.md
@@ -4,8 +4,8 @@ The actual source of truth of problem order and topics is [config.json](config.j
 
 ## Background
 
-- https://github.com/exercism/xrust/issues/126
-- https://github.com/exercism/xrust/issues/127
+- https://github.com/exercism/rust/issues/126
+- https://github.com/exercism/rust/issues/127
 - http://designisrefactoring.com/2016/07/09/exercism-shouldnt-make-you-cry/
 
 ## Our Approach


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed.

See https://github.com/exercism/meta/issues/1