### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,14 +5,20 @@
   "active": true,
   "exercises": [
     {
+      "uuid": "13ec1ebe-d71b-436f-ab12-25305e814171",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "println!"
       ]
     },
     {
+      "uuid": "f880b1ef-8f66-41f3-bb89-f39a4ed592a2",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "crates",
@@ -20,7 +26,10 @@
       ]
     },
     {
+      "uuid": "ef52f576-9c33-4cc1-a018-803ace8897f6",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "math",
@@ -29,7 +38,10 @@
       ]
     },
     {
+      "uuid": "2c12be9b-3a02-4161-8eac-050642ad791f",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "case (or `format`)",
@@ -37,7 +49,10 @@
       ]
     },
     {
+      "uuid": "38ef1802-2730-4f94-bafe-d2cd6b3e7f95",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "chars",
@@ -45,7 +60,10 @@
       ]
     },
     {
+      "uuid": "bb42bc3a-139d-4cab-8b3a-2eac2e1b77b6",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "case",
@@ -55,7 +73,10 @@
       ]
     },
     {
+      "uuid": "aee49878-f727-400b-8fb5-eaf83447cf87",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "fold",
@@ -63,7 +84,10 @@
       ]
     },
     {
+      "uuid": "be90fe16-9947-45ef-ab8e-eeca4ce3a8c8",
       "slug": "sum-of-multiples",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "algorithm",
@@ -71,7 +95,10 @@
       ]
     },
     {
+      "uuid": "9e69dd5d-472d-43d7-a8bb-60e4a7bed175",
       "slug": "grains",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "math",
@@ -79,7 +106,10 @@
       ]
     },
     {
+      "uuid": "4dc9b165-792a-4438-be80-df9aab6f6a9c",
       "slug": "run-length-encoding",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "string concatenation",
@@ -89,14 +119,20 @@
       ]
     },
     {
+      "uuid": "2874216a-0822-4ec2-892e-d451fd89646a",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Result"
       ]
     },
     {
+      "uuid": "ddc0c1da-6b65-4ed1-8bdc-5e71cd05f720",
       "slug": "pascals-triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Math",
@@ -105,7 +141,10 @@
       ]
     },
     {
+      "uuid": "561cc4ff-5e74-4701-a7c2-c4edefa0d068",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "chaining higher-order functions",
@@ -113,7 +152,10 @@
       ]
     },
     {
+      "uuid": "a24cb7bf-3aac-4051-bcd1-952c2a806187",
       "slug": "pangram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "filter",
@@ -121,7 +163,10 @@
       ]
     },
     {
+      "uuid": "3f54853b-cc65-4282-ab25-8dc3fdf43c03",
       "slug": "nucleotide-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Result",
@@ -132,7 +177,10 @@
       ]
     },
     {
+      "uuid": "8d64bfc3-fc4b-45c4-85f0-e74dc2ea6812",
       "slug": "luhn",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "str to digits",
@@ -141,7 +189,10 @@
       ]
     },
     {
+      "uuid": "8679c221-d150-4230-b1cd-5ea78ae69db7",
       "slug": "largest-series-product",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Result",
@@ -151,7 +202,10 @@
       ]
     },
     {
+      "uuid": "6c5c0dc3-4f5b-4f83-bf67-a45bf4ea6be4",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "hashmap",
@@ -161,7 +215,10 @@
       ]
     },
     {
+      "uuid": "53298a14-76a9-4bb9-943a-57c5e79d9cf7",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "str vs string",
@@ -172,7 +229,10 @@
       ]
     },
     {
+      "uuid": "5dbecc83-2c8d-467d-be05-f28a08f7abcf",
       "slug": "rotational-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "str vs string",
@@ -183,14 +243,20 @@
       ]
     },
     {
+      "uuid": "0c8eeef7-4bab-4cf9-9047-c208b5618312",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "btree"
       ]
     },
     {
+      "uuid": "26a9102f-26f6-4238-858e-ba20db66f1a9",
       "slug": "acronym",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "map",
@@ -201,7 +267,10 @@
       ]
     },
     {
+      "uuid": "da784b42-1cec-469e-8e48-0be232b17003",
       "slug": "sieve",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "vector",
@@ -210,7 +279,10 @@
       ]
     },
     {
+      "uuid": "9a219d87-cd32-4e12-a879-bfb5747c2369",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Result",
@@ -220,7 +292,10 @@
       ]
     },
     {
+      "uuid": "c0bc2af6-d7af-401f-9ed8-bbe31977666c",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Math",
@@ -228,7 +303,10 @@
       ]
     },
     {
+      "uuid": "498be645-734a-49b7-aba7-aae1e051e1f0",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "mutable",
@@ -239,7 +317,10 @@
       ]
     },
     {
+      "uuid": "54c11dae-3878-4bec-b8d6-775b7d4f317b",
       "slug": "all-your-base",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Result",
@@ -249,7 +330,10 @@
       ]
     },
     {
+      "uuid": "5ca03812-c229-48db-b7fd-0889b22f8d1d",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "struct",
@@ -259,7 +343,10 @@
       ]
     },
     {
+      "uuid": "1beb8b0c-d06d-4569-80e5-866ed01a7a66",
       "slug": "robot-simulator",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Immutability",
@@ -267,7 +354,10 @@
       ]
     },
     {
+      "uuid": "40729822-4265-4c14-b03f-a00bff5f24bb",
       "slug": "bracket-push",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "From trait",
@@ -275,7 +365,10 @@
       ]
     },
     {
+      "uuid": "f9131b5d-91dd-4514-983d-4abc22bb5d5c",
       "slug": "luhn-from",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "from trait",
@@ -285,7 +378,10 @@
       ]
     },
     {
+      "uuid": "30c33e3d-8034-4618-8346-2ae906961579",
       "slug": "queen-attack",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "struct",
@@ -294,7 +390,10 @@
       ]
     },
     {
+      "uuid": "fec447a5-cf11-4ddd-b0fd-63bcc4e245cd",
       "slug": "bowling",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "struct",
@@ -303,7 +402,10 @@
       ]
     },
     {
+      "uuid": "644ffd17-548e-4405-bfd5-a58df74cc19d",
       "slug": "sublist",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "enum",
@@ -311,7 +413,10 @@
       ]
     },
     {
+      "uuid": "fa94645d-14e1-422d-a832-d24efbb493d8",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Custom Trait",
@@ -320,7 +425,10 @@
       ]
     },
     {
+      "uuid": "c32c0124-873d-45f4-9287-402aea29f129",
       "slug": "luhn-trait",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Custom Trait",
@@ -330,7 +438,10 @@
       ]
     },
     {
+      "uuid": "94f040d6-3f41-4950-8fe6-acf0945ac83d",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "struct",
@@ -341,7 +452,10 @@
       ]
     },
     {
+      "uuid": "f1371a9c-c2a4-4fc6-a5fd-3a57c4af16fa",
       "slug": "variable-length-quantity",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Encodings",
@@ -351,7 +465,10 @@
       ]
     },
     {
+      "uuid": "6abac1d1-0d85-4b51-8001-97a07990630d",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "option",
@@ -362,7 +479,10 @@
       ]
     },
     {
+      "uuid": "620b55bb-058e-4c6f-a966-ced3b41736db",
       "slug": "wordy",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "Result",
@@ -371,7 +491,10 @@
       ]
     },
     {
+      "uuid": "9a2406cc-5037-4761-b820-bb25b1d397c8",
       "slug": "tournament",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "enum",
@@ -381,7 +504,10 @@
       ]
     },
     {
+      "uuid": "9d652e63-6654-4dec-a99f-97e6bc8cf772",
       "slug": "custom-set",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "generic over type",
@@ -391,7 +517,10 @@
       ]
     },
     {
+      "uuid": "7450bd80-2388-42ac-a61f-097e82581475",
       "slug": "alphametics",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "string parsing",
@@ -401,7 +530,10 @@
       ]
     },
     {
+      "uuid": "f3172997-91f5-4941-a76e-91c4b8eed401",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "lifetimes",
@@ -412,7 +544,10 @@
       ]
     },
     {
+      "uuid": "4e01efbc-51ce-4d20-b093-b3d44c4be5e8",
       "slug": "protein-translation",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "struct",
@@ -422,7 +557,10 @@
       ]
     },
     {
+      "uuid": "ec7f66c2-749e-4d00-9c11-fa9d106632e4",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "struct",
@@ -433,7 +571,10 @@
       ]
     },
     {
+      "uuid": "704aab91-b83a-4e64-8c21-fb0be5076289",
       "slug": "ocr-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Lines",
@@ -442,14 +583,20 @@
       ]
     },
     {
+      "uuid": "e0037ac4-ae5f-4622-b3ad-915648263495",
       "slug": "minesweeper",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Board state"
       ]
     },
     {
+      "uuid": "5e6f6986-5011-427b-a992-d6d0c81f5101",
       "slug": "dominoes",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Graph theory",
@@ -457,14 +604,20 @@
       ]
     },
     {
+      "uuid": "e114b19f-9a9a-402d-a5cb-1cad8de5088e",
       "slug": "parallel-letter-frequency",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "multi-threading"
       ]
     },
     {
+      "uuid": "cc4ccd99-1c97-4ee7-890c-d629b4e1e46d",
       "slug": "rectangles",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Enum",
@@ -474,14 +627,20 @@
       ]
     },
     {
+      "uuid": "55976c49-1be5-4170-8aa3-056c2223abbb",
       "slug": "forth",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Parser reimplementation"
       ]
     },
     {
+      "uuid": "6ff1a539-251b-49d4-81b5-a6b1e9ba66a4",
       "slug": "circular-buffer",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Buffer reimplementation",
@@ -489,18 +648,27 @@
       ]
     },
     {
+      "uuid": "8708ccc7-711a-4862-b5a4-ff59fde2241c",
       "slug": "react",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
         "Lifetimes",
         "generics",
         "closures"
       ]
+    },
+    {
+      "uuid": "8dae8f4d-368d-477d-907e-bf746921bfbf",
+      "slug": "nucleotide-codons",
+      "deprecated": true
+    },
+    {
+      "uuid": "496fd79f-1678-4aa2-8110-c32c6aaf545e",
+      "slug": "hexadecimal",
+      "deprecated": true
     }
-  ],
-  "deprecated": [
-    "nucleotide-codons",
-    "hexadecimal"
   ],
   "foregone": [
     "binary",


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

active: false is the equivalent of _deprecated_, which was stored in a separate array. This array is being removed in this change.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

See https://github.com/exercism/meta/issues/16