### PR TITLE
Update chrono to 0.4, for UTC -> Utc change.

### DIFF
--- a/exercises/gigasecond/Cargo.lock
+++ b/exercises/gigasecond/Cargo.lock
@@ -2,12 +2,12 @@
 name = "gigasecond"
 version = "1.0.0"
 dependencies = [
- "chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -87,7 +87,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d9123be86fd2a8f627836c235ecdf331fdd067ecf7ac05aa1a68fbcf2429f056"
+"checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e7eb6b826bfc1fdea7935d46556250d1799b7fe2d9f7951071f4291710665e3e"
 "checksum num 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "2c3a3dc9f30bf824141521b30c908a859ab190b76e20435fcd89f35eb6583887"

--- a/exercises/gigasecond/Cargo.toml
+++ b/exercises/gigasecond/Cargo.toml
@@ -3,5 +3,5 @@ name = "gigasecond"
 version = "1.0.0"
 
 [dependencies]
-chrono = "0.3"
+chrono = "0.4"
 

--- a/exercises/gigasecond/example.rs
+++ b/exercises/gigasecond/example.rs
@@ -1,6 +1,6 @@
 extern crate chrono;
 use chrono::*;
 
-pub fn after(start: DateTime<UTC>) -> DateTime<UTC> {
+pub fn after(start: DateTime<Utc>) -> DateTime<Utc> {
     start + Duration::seconds(1_000_000_000)
 }

--- a/exercises/gigasecond/src/lib.rs
+++ b/exercises/gigasecond/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate chrono;
 use chrono::*;
 
-// Returns a UTC DateTime one billion seconds after start.
-pub fn after(start: DateTime<UTC>) -> DateTime<UTC> {
+// Returns a Utc DateTime one billion seconds after start.
+pub fn after(start: DateTime<Utc>) -> DateTime<Utc> {
     unimplemented!()
 }

--- a/exercises/gigasecond/tests/gigasecond.rs
+++ b/exercises/gigasecond/tests/gigasecond.rs
@@ -17,34 +17,34 @@ use chrono::*;
 
 #[test]
 fn test_date() {
-    let start_date = UTC.ymd(2011, 4, 25).and_hms(0,0,0);
-    assert_eq!(gigasecond::after(start_date), UTC.ymd(2043, 1, 1).and_hms(1,46,40));
+    let start_date = Utc.ymd(2011, 4, 25).and_hms(0,0,0);
+    assert_eq!(gigasecond::after(start_date), Utc.ymd(2043, 1, 1).and_hms(1,46,40));
 }
 
 #[test]
 #[ignore]
 fn test_another_date() {
-    let start_date = UTC.ymd(1977, 6, 13).and_hms(0,0,0);
-    assert_eq!(gigasecond::after(start_date), UTC.ymd(2009, 2, 19).and_hms(1,46,40));
+    let start_date = Utc.ymd(1977, 6, 13).and_hms(0,0,0);
+    assert_eq!(gigasecond::after(start_date), Utc.ymd(2009, 2, 19).and_hms(1,46,40));
 }
 
 #[test]
 #[ignore]
 fn test_third_date() {
-    let start_date = UTC.ymd(1959, 7, 19).and_hms(0,0,0);
-    assert_eq!(gigasecond::after(start_date), UTC.ymd(1991, 3, 27).and_hms(1,46,40));
+    let start_date = Utc.ymd(1959, 7, 19).and_hms(0,0,0);
+    assert_eq!(gigasecond::after(start_date), Utc.ymd(1991, 3, 27).and_hms(1,46,40));
 }
 
 #[test]
 #[ignore]
 fn test_datetime() {
-    let start_date = UTC.ymd(2015, 1, 24).and_hms(22,0,0);
-    assert_eq!(gigasecond::after(start_date), UTC.ymd(2046, 10, 2).and_hms(23,46,40));
+    let start_date = Utc.ymd(2015, 1, 24).and_hms(22,0,0);
+    assert_eq!(gigasecond::after(start_date), Utc.ymd(2046, 10, 2).and_hms(23,46,40));
 }
 
 #[test]
 #[ignore]
 fn test_another_datetime() {
-    let start_date = UTC.ymd(2015, 1, 24).and_hms(23,59,59);
-    assert_eq!(gigasecond::after(start_date), UTC.ymd(2046, 10, 3).and_hms(1,46,39));
+    let start_date = Utc.ymd(2015, 1, 24).and_hms(23,59,59);
+    assert_eq!(gigasecond::after(start_date), Utc.ymd(2046, 10, 3).and_hms(1,46,39));
 }


### PR DESCRIPTION
When I tried to figure out issues on Playground, I noticed UTC -> Utc.  This looks like a change between 0.3 and 0.4 chrono.   I've updated to use 0.4 and updated the tests and lib.rs.  

Edit: And example.rs after second commit.