### PR TITLE
Added pig-latin exercise and Windows Testing Notes

### DIFF
--- a/_test/WINDOWS_README.md
+++ b/_test/WINDOWS_README.md
@@ -1,0 +1,44 @@
+# check_exercises.sh for Windows Rust Developers
+
+It is possible to run `check-exercises.sh` on Windows 10, pointing to the Windows location for your GitHub repository.  This is done with the Ubuntu on Windows subsystem.
+
+## Enable Developer Mode
+To run Ubuntu on Windows, you need to be in Developer Mode.
+
+ - Open Settings
+ - Open Update and Security
+ - Select For Developers on Left Side
+ - Change to Developer Mode from Sideload Apps
+
+## Install
+
+Start a PowerShell as Administrator.
+
+Run the following:
+
+    Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
+
+## Run bash
+
+The `bash` command now gives you a terminal in a Ubuntu Linux instance.  You have access to Windows files via /mnt/[drive_letter]
+
+Example: Windows user directory would be
+
+    /mnt/c/Users/username
+
+## Installing Rust
+
+Inside bash, you will not have access to Window's Rust.  You need to install the Linux version of Rust.
+
+    curl -sf -L https://static.rust-lang.org/rustup.sh | sh
+
+You also need to install a cc linker for Rust.
+
+    sudo apt-get install build-essential
+
+## Running Tests
+
+    cd /mnt/c/[path of github project]
+    _test/check_exercises.sh
+
+This will re-download and build any crates needed, as they only existed in your Windows Rust.

--- a/config.json
+++ b/config.json
@@ -530,6 +530,15 @@
       ]
     },
     {
+      "uuid": "c21c379b-fb23-449b-809a-3c6ef1c31221",
+      "slug": "pig-latin",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+      ]
+    },
+    {
       "uuid": "f3172997-91f5-4941-a76e-91c4b8eed401",
       "slug": "anagram",
       "core": false,

--- a/exercises/pig-latin/Cargo-example.toml
+++ b/exercises/pig-latin/Cargo-example.toml
@@ -1,0 +1,8 @@
+[package]
+name = "pig-latin"
+version = "1.0.0"
+authors = ["sacherjj <sacherjj@gmail.com>"]
+
+[dependencies]
+regex = "0.2"
+lazy_static = "0.2"

--- a/exercises/pig-latin/Cargo.lock
+++ b/exercises/pig-latin/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "pig-latin"
+version = "1.0.0"
+

--- a/exercises/pig-latin/Cargo.toml
+++ b/exercises/pig-latin/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "pig-latin"
+version = "1.0.0"
+authors = ["sacherjj <sacherjj@gmail.com>"]
+
+[dependencies]

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -1,0 +1,56 @@
+# Pig Latin
+
+Implement a program that translates from English to Pig Latin.
+
+Pig Latin is a made-up children's language that's intended to be
+confusing. It obeys a few simple rules (below), but when it's spoken
+quickly it's really difficult for non-children (and non-native speakers)
+to understand.
+
+- **Rule 1**: If a word begins with a vowel sound, add an "ay" sound to
+  the end of the word.
+- **Rule 2**: If a word begins with a consonant sound, move it to the
+  end of the word, and then add an "ay" sound to the end of the word.
+
+There are a few more rules for edge cases, and there are regional
+variants too.
+
+See <http://en.wikipedia.org/wiki/Pig_latin> for more details.
+
+## Rust Installation
+
+Refer to the [exercism help page][help-page] for Rust installation and learning
+resources.
+
+## Writing the Code
+
+Execute the tests with:
+
+```bash
+$ cargo test
+```
+
+All but the first test have been ignored.  After you get the first test to
+pass, remove the ignore flag (`#[ignore]`) from the next test and get the tests
+to pass again.  The test file is located in the `tests` directory.   You can
+also remove the ignore flag from all the tests to get them to run all at once
+if you wish.
+
+Make sure to read the [Crates and Modules](https://doc.rust-lang.org/stable/book/crates-and-modules.html) chapter if you
+haven't already, it will help you with organizing your files.
+
+## Feedback, Issues, Pull Requests
+
+The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the [rust track team](https://github.com/orgs/exercism/teams/rust) are happy to help!
+
+If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
+
+[help-page]: http://exercism.io/languages/rust
+[crates-and-modules]: http://doc.rust-lang.org/stable/book/crates-and-modules.html
+
+## Source
+
+The Pig Latin exercise at Test First Teaching by Ultrasaurus [https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/](https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pig-latin/example.rs
+++ b/exercises/pig-latin/example.rs
@@ -1,0 +1,28 @@
+#[macro_use] extern crate lazy_static;
+extern crate regex;
+
+use regex::Regex;
+
+// Regular expressions from Python version of exercism
+
+pub fn translate_word(word: &str) -> String {
+    // Prevent creation and compilation at every call.
+    // These are compiled exactly once
+    lazy_static! {
+        // Detects if it starts with a vowel
+        static ref VOWEL: Regex = Regex::new(r"^([aeiou]|y[^aeiou]|xr)[a-z]*").unwrap();
+        // Detects splits for initial consonants
+        static ref CONSONANTS: Regex = Regex::new(r"^([^aeiou]?qu|[^aeiou]+)([a-z]*)").unwrap();
+    }
+
+    if VOWEL.is_match(word) {
+        String::from(word) + "ay"
+    } else {
+        let caps = CONSONANTS.captures(word).unwrap();
+        String::from(&caps[2]) + &caps[1] + "ay"
+    }
+}
+
+pub fn translate(text: &str) -> String {
+    text.split(" ").map(|w| translate_word(w)).collect::<Vec<_>>().join(" ")
+}

--- a/exercises/pig-latin/tests/pig-latin.rs
+++ b/exercises/pig-latin/tests/pig-latin.rs
@@ -1,0 +1,120 @@
+extern crate pig_latin as pl;
+
+#[test]
+fn test_word_beginning_with_a() {
+    assert_eq!(pl::translate("apple"), "appleay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_e() {
+    assert_eq!(pl::translate("ear"), "earay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_i() {
+    assert_eq!(pl::translate("igloo"), "iglooay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_o() {
+    assert_eq!(pl::translate("object"), "objectay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_u() {
+    assert_eq!(pl::translate("under"), "underay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_a_vowel_and_followed_by_a_qu() {
+    assert_eq!(pl::translate("equal"), "equalay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_p() {
+    assert_eq!(pl::translate("pig"), "igpay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_k() {
+    assert_eq!(pl::translate("koala"), "oalakay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_y() {
+    assert_eq!(pl::translate("yellow"), "ellowyay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_x() {
+    assert_eq!(pl::translate("xenon"), "enonxay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_q_without_a_following_u() {
+    assert_eq!(pl::translate("qat"), "atqay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_ch() {
+    assert_eq!(pl::translate("chair"), "airchay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_qu() {
+    assert_eq!(pl::translate("queen"), "eenquay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_qu_and_a_preceding_consonant() {
+    assert_eq!(pl::translate("square"), "aresquay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_th() {
+    assert_eq!(pl::translate("therapy"), "erapythay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_thr() {
+    assert_eq!(pl::translate("thrush"), "ushthray");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_sch() {
+    assert_eq!(pl::translate("school"), "oolschay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_yt() {
+    assert_eq!(pl::translate("yttria"), "yttriaay");
+}
+
+#[test]
+#[ignore]
+fn test_word_beginning_with_xr() {
+    assert_eq!(pl::translate("xray"), "xrayay");
+}
+
+#[test]
+#[ignore]
+fn test_a_whole_phrase() {
+    assert_eq!(pl::translate("quick fast run"), "ickquay astfay unray");
+}


### PR DESCRIPTION
Implementation of the pig-latin exercise.   This is much less of a mess than my last pull request.   Not sure if difficultly level (2) is right in the JSON.   Someone that has more experience where this would fit in might tweak that value, before going live.  

I also added a file in _test with instructions for running check-exercises.sh for Windows Rust users.  This includes setting up the Ubuntu on Windows sub system and testing against Windows file system hosted files.  With this, I was able to run tests to completion on WIndows.