### PR TITLE
Remove redundant key/value pairs from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -534,7 +534,6 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -1,7 +1,5 @@
 {
-  "slug": "rust",
   "language": "Rust",
-  "repository": "https://github.com/exercism/rust",
   "active": true,
   "exercises": [
     {
@@ -536,6 +534,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+
       ]
     },
     {


### PR DESCRIPTION
The slug is not used anywhere. We initialize a track based on knowing the Track ID.
Since the repository is always named after the track ID, this field, too, is redundant,
as it can be inferred.


See https://github.com/exercism/meta/issues/19