### PR TITLE
gitignore: remove src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.swp
 *.bk
 .DS_Store
-**/src
 **/target
 tmp
 bin/configlet


### PR DESCRIPTION
Now that we have an empty src/lib.rs for each exercise as of
https://github.com/exercism/rust/pull/270, we should ease the process of
adding the file by no longer ignoring it.