### PR TITLE
clock: Add exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -167,6 +167,18 @@
       ]
     },
     {
+      "uuid": "543a3ca2-fb9b-4f20-a873-ff23595d41df",
+      "slug": "clock",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "traits",
+        "derive",
+        "struct"
+      ]
+    },
+    {
       "uuid": "2874216a-0822-4ec2-892e-d451fd89646a",
       "slug": "hamming",
       "core": false,

--- a/exercises/clock/.meta/hints.md
+++ b/exercises/clock/.meta/hints.md
@@ -1,0 +1,10 @@
+## Rust Traits for .to_string()
+
+Did you implement .to_string() for the Clock struct?
+
+If so, try implementing the
+[Display trait](https://doc.rust-lang.org/std/fmt/trait.Display.html) for Clock instead.
+
+Traits allow for a common way to implement functionality for various types.
+
+For additional learning, how would you implement String::from for the Clock type?

--- a/exercises/clock/Cargo.lock
+++ b/exercises/clock/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "clock"
+version = "1.0.0"
+

--- a/exercises/clock/Cargo.toml
+++ b/exercises/clock/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "clock"
+version = "1.0.0"
+authors = ["sacherjj <sacherjj@gmail.com>"]
+
+[dependencies]

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -1,0 +1,57 @@
+# Clock
+
+Implement a clock that handles times without dates.
+
+You should be able to add and subtract minutes to it.
+
+Two clocks that represent the same time should be equal to each other.
+
+## Rust Traits for .to_string()
+
+Did you implement .to_string() for the Clock struct?
+
+If so, try implementing the
+[Display trait](https://doc.rust-lang.org/std/fmt/trait.Display.html) for Clock instead.
+
+Traits allow for a common way to implement functionality for various types.
+
+For additional learning, how would you implement String::from for the Clock type?
+
+
+## Rust Installation
+
+Refer to the [exercism help page][help-page] for Rust installation and learning
+resources.
+
+## Writing the Code
+
+Execute the tests with:
+
+```bash
+$ cargo test
+```
+
+All but the first test have been ignored.  After you get the first test to
+pass, remove the ignore flag (`#[ignore]`) from the next test and get the tests
+to pass again.  The test file is located in the `tests` directory.   You can
+also remove the ignore flag from all the tests to get them to run all at once
+if you wish.
+
+Make sure to read the [Crates and Modules](https://doc.rust-lang.org/stable/book/crates-and-modules.html) chapter if you
+haven't already, it will help you with organizing your files.
+
+## Feedback, Issues, Pull Requests
+
+The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the [rust track team](https://github.com/orgs/exercism/teams/rust) are happy to help!
+
+If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
+
+[help-page]: http://exercism.io/languages/rust
+[crates-and-modules]: http://doc.rust-lang.org/stable/book/crates-and-modules.html
+
+## Source
+
+Pairing session with Erin Drummond [https://twitter.com/ebdrummond](https://twitter.com/ebdrummond)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/clock/example.rs
+++ b/exercises/clock/example.rs
@@ -1,0 +1,32 @@
+use std::fmt;
+
+#[derive(Eq,PartialEq,Debug)]
+pub struct Clock {
+    minutes: i32
+}
+
+impl fmt::Display for Clock {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let hours = self.minutes / 60;
+        let mins = self.minutes % 60;
+        write!(f, "{:02}:{:02}", hours, mins)
+    }
+}
+
+impl Clock {
+    pub fn new(hour: i32, minute: i32) -> Self {
+        Clock::build(hour * 60 + minute)
+    }
+
+    fn build(minutes: i32) -> Self {
+        let mut mins = minutes;
+        while mins < 0 {
+            mins += 1440;
+        }
+        Clock { minutes: mins % 1440 }
+    }
+
+    pub fn add_minutes(&mut self, minutes: i32) -> Self {
+        Clock::build(self.minutes + minutes)
+    }
+}

--- a/exercises/clock/tests/clock.rs
+++ b/exercises/clock/tests/clock.rs
@@ -1,0 +1,331 @@
+extern crate clock;
+
+use clock::Clock;
+
+//
+// Clock Creation
+//
+
+#[test]
+fn test_on_the_hour() {
+    assert_eq!(Clock::new(8, 0).to_string(), "08:00");
+}
+
+#[test]
+#[ignore]
+fn test_past_the_hour() {
+    assert_eq!(Clock::new(11, 9).to_string(), "11:09");
+}
+
+#[test]
+#[ignore]
+fn test_midnight_is_zero_hours() {
+    assert_eq!(Clock::new(24, 0).to_string(), "00:00");
+}
+
+#[test]
+#[ignore]
+fn test_hour_rolls_over() {
+    assert_eq!(Clock::new(25, 0).to_string(), "01:00");
+}
+
+#[test]
+#[ignore]
+fn test_hour_rolls_over_continuously() {
+    assert_eq!(Clock::new(100, 0).to_string(), "04:00");
+}
+
+#[test]
+#[ignore]
+fn test_sixty_minutes_is_next_hour() {
+    assert_eq!(Clock::new(1, 60).to_string(), "02:00");
+}
+
+#[test]
+#[ignore]
+fn test_minutes_roll_over() {
+    assert_eq!(Clock::new(0, 160).to_string(), "02:40");
+}
+
+#[test]
+#[ignore]
+fn test_minutes_roll_over_continuously() {
+    assert_eq!(Clock::new(0, 1723).to_string(), "04:43");
+}
+
+#[test]
+#[ignore]
+fn test_hours_and_minutes_roll_over() {
+    assert_eq!(Clock::new(25, 160).to_string(), "03:40");
+}
+
+#[test]
+#[ignore]
+fn test_hours_and_minutes_roll_over_continuously() {
+    assert_eq!(Clock::new(201, 3001).to_string(), "11:01");
+}
+
+#[test]
+#[ignore]
+fn test_hours_and_minutes_roll_over_to_exactly_midnight() {
+    assert_eq!(Clock::new(72, 8640).to_string(), "00:00");
+}
+
+#[test]
+#[ignore]
+fn test_negative_hour() {
+    assert_eq!(Clock::new(-1, 15).to_string(), "23:15");
+}
+
+#[test]
+#[ignore]
+fn test_negative_hour_roll_over() {
+    assert_eq!(Clock::new(-25, 00).to_string(), "23:00");
+}
+
+#[test]
+#[ignore]
+fn test_negative_hour_roll_over_continuously() {
+    assert_eq!(Clock::new(-91, 00).to_string(), "05:00");
+}
+
+
+#[test]
+#[ignore]
+fn test_negative_minutes() {
+    assert_eq!(Clock::new(1, -40).to_string(), "00:20");
+}
+
+#[test]
+#[ignore]
+fn test_negative_minutes_roll_over() {
+    assert_eq!(Clock::new(1, -160).to_string(), "22:20");
+}
+
+#[test]
+#[ignore]
+fn test_negative_minutes_roll_over_continuously() {
+    assert_eq!(Clock::new(1, -4820).to_string(), "16:40");
+}
+
+#[test]
+#[ignore]
+fn test_negative_hour_and_minutes_both_roll_over() {
+    assert_eq!(Clock::new(-25, -160).to_string(), "20:20");
+}
+
+#[test]
+#[ignore]
+fn test_negative_hour_and_minutes_both_roll_over_continuously() {
+    assert_eq!(Clock::new(-121, -5810).to_string(), "22:10");
+}
+
+//
+// Clock Math
+//
+
+#[test]
+#[ignore]
+fn test_add_minutes() {
+    let clock = Clock::new(10, 0).add_minutes(3);
+    assert_eq!(clock.to_string(), "10:03");
+}
+
+#[test]
+#[ignore]
+fn test_add_no_minutes() {
+    let clock = Clock::new(6, 41).add_minutes(0);
+    assert_eq!(clock.to_string(), "06:41");
+}
+
+#[test]
+#[ignore]
+fn test_add_to_next_hour() {
+    let clock = Clock::new(0, 45).add_minutes(40);
+    assert_eq!(clock.to_string(), "01:25");
+}
+
+#[test]
+#[ignore]
+fn test_add_more_than_one_hour() {
+    let clock = Clock::new(10, 0).add_minutes(61);
+    assert_eq!(clock.to_string(), "11:01");
+}
+
+#[test]
+#[ignore]
+fn test_add_more_than_two_hours_with_carry() {
+    let clock = Clock::new(0, 45).add_minutes(160);
+    assert_eq!(clock.to_string(), "03:25");
+}
+
+#[test]
+#[ignore]
+fn test_add_across_midnight() {
+    let clock = Clock::new(23, 59).add_minutes(2);
+    assert_eq!(clock.to_string(), "00:01");
+}
+
+#[test]
+#[ignore]
+fn test_add_more_than_one_day() {
+    let clock = Clock::new(5, 32).add_minutes(1500);
+    assert_eq!(clock.to_string(), "06:32");
+}
+
+#[test]
+#[ignore]
+fn test_add_more_than_two_days() {
+    let clock = Clock::new(1, 1).add_minutes(3500);
+    assert_eq!(clock.to_string(), "11:21");
+}
+
+#[test]
+#[ignore]
+fn test_subtract_minutes() {
+    let clock = Clock::new(10, 3).add_minutes(-3);
+    assert_eq!(clock.to_string(), "10:00");
+}
+
+#[test]
+#[ignore]
+fn test_subtract_to_previous_hour() {
+    let clock = Clock::new(10, 3).add_minutes(-30);
+    assert_eq!(clock.to_string(), "09:33");
+}
+
+#[test]
+#[ignore]
+fn test_subtract_more_than_an_hour() {
+    let clock = Clock::new(10, 3).add_minutes(-70);
+    assert_eq!(clock.to_string(), "08:53");
+}
+
+#[test]
+#[ignore]
+fn test_subtract_across_midnight() {
+    let clock = Clock::new(0, 3).add_minutes(-4);
+    assert_eq!(clock.to_string(), "23:59");
+}
+
+#[test]
+#[ignore]
+fn test_subtract_more_than_two_hours() {
+    let clock = Clock::new(0, 0).add_minutes(-160);
+    assert_eq!(clock.to_string(), "21:20");
+}
+
+#[test]
+#[ignore]
+fn test_subtract_more_than_two_hours_with_borrow() {
+    let clock = Clock::new(6, 15).add_minutes(-160);
+    assert_eq!(clock.to_string(), "03:35");
+}
+
+#[test]
+#[ignore]
+fn test_subtract_more_than_one_day() {
+    let clock = Clock::new(5, 32).add_minutes(-1500);
+    assert_eq!(clock.to_string(), "04:32");
+}
+
+#[test]
+#[ignore]
+fn test_subtract_mores_than_two_days() {
+    let clock = Clock::new(2, 20).add_minutes(-3000);
+    assert_eq!(clock.to_string(), "00:20");
+}
+
+//
+// Test Equality
+//
+
+#[test]
+#[ignore]
+fn test_compare_clocks_for_equality() {
+    assert_eq!(Clock::new(15, 37), Clock::new(15, 37));
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_a_minute_apart() {
+    assert_ne!(Clock::new(15, 36), Clock::new(15, 37));
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_an_hour_apart() {
+    assert_ne!(Clock::new(14, 37), Clock::new(15, 37));
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_with_hour_overflow() {
+    assert_eq!(Clock::new(10, 37), Clock::new(34, 37));
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_with_hour_overflow_by_several_days() {
+    assert_eq!(Clock::new(3, 11), Clock::new(99, 11));
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_with_negative_hour() {
+    assert_eq!(Clock::new(22, 40), Clock::new(-2, 40));
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_with_negative_hour_that_wraps() {
+    assert_eq!(Clock::new(17, 3), Clock::new(-31, 3));
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_with_negative_hour_that_wraps_multiple_times() {
+    assert_eq!(Clock::new(13, 49), Clock::new(-83, 49));
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_with_minutes_overflow() {
+    assert_eq!(Clock::new(0, 1), Clock::new(0, 1441));
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_with_minutes_overflow_by_several_days() {
+    assert_eq!(Clock::new(2, 2), Clock::new(2, 4322));
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_with_negative_minute() {
+    assert_eq!(Clock::new(2, 40), Clock::new(3, -20))
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_with_negative_minute_that_wraps() {
+    assert_eq!(Clock::new(4, 10), Clock::new(5, -1490))
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_with_negative_minute_that_wraps_multiple() {
+    assert_eq!(Clock::new(6, 15), Clock::new(6, -4305))
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_with_negative_hours_and_minutes() {
+    assert_eq!(Clock::new(7, 32), Clock::new(-12, -268))
+}
+
+#[test]
+#[ignore]
+fn test_compare_clocks_with_negative_hours_and_minutes_that_wrap() {
+    assert_eq!(Clock::new(18, 7), Clock::new(-54, -11513))
+}


### PR DESCRIPTION
I think we found the winner of the most test cases.   Test Driven Drudgery.

Is there a not equal assert?   I changed to assert!( 1 != 2 ).

Thought about using Add trait for adding int to Clock as minutes add, but thought it would get too confusing.  I figured the Display trait was enough.   Thoughts?