### PR TITLE
use assert_ne!(a, b) instead of assert!(a != b)

### DIFF
--- a/exercises/custom-set/tests/custom-set.rs
+++ b/exercises/custom-set/tests/custom-set.rs
@@ -142,7 +142,7 @@ fn empty_sets_are_equal() {
 fn empty_set_is_not_equal_to_a_non_empty_set() {
     let set1 = CustomSet::new(vec![]);
     let set2 = CustomSet::new(vec![1, 2, 3]);
-    assert!(set1 != set2);
+    assert_ne!(set1, set2);
 }
 
 #[test]
@@ -150,7 +150,7 @@ fn empty_set_is_not_equal_to_a_non_empty_set() {
 fn non_empty_set_is_not_equal_to_an_empty_set() {
     let set1 = CustomSet::new(vec![1, 2, 3]);
     let set2 = CustomSet::new(vec![]);
-    assert!(set1 != set2);
+    assert_ne!(set1, set2);
 }
 
 #[test]
@@ -166,7 +166,7 @@ fn sets_with_the_same_elements_are_equal() {
 fn sets_with_different_elements_are_not_equal() {
     let set1 = CustomSet::new(vec![1, 2, 3]);
     let set2 = CustomSet::new(vec![2, 1, 4]);
-    assert!(set1 != set2);
+    assert_ne!(set1, set2);
 }
 
 #[test]

--- a/exercises/rna-transcription/tests/rna-transcription.rs
+++ b/exercises/rna-transcription/tests/rna-transcription.rs
@@ -3,7 +3,7 @@ extern crate rna_transcription as dna;
 #[test]
 fn test_acid_equals_acid() {
     assert_eq!(dna::RibonucleicAcid::new("CGA"), dna::RibonucleicAcid::new("CGA"));
-    assert!(dna::RibonucleicAcid::new("CGA") != dna::RibonucleicAcid::new("AGC"));
+    assert_ne!(dna::RibonucleicAcid::new("CGA"), dna::RibonucleicAcid::new("AGC"));
 }
 
 #[test]

--- a/exercises/robot-name/tests/robot-name.rs
+++ b/exercises/robot-name/tests/robot-name.rs
@@ -42,7 +42,7 @@ fn test_name_is_persistent() {
 fn test_different_robots_have_different_names() {
     let r1 = robot::Robot::new();
     let r2 = robot::Robot::new();
-    assert!(r1.name() != r2.name(), "Robot names should be different");
+    assert_ne!(r1.name(), r2.name(), "Robot names should be different");
 }
 
 #[test]
@@ -69,5 +69,5 @@ fn test_new_name_is_different_from_old_name() {
     let n1 = r.name().to_string();
     r.reset_name();
     let n2 = r.name().to_string();
-    assert!(n1 != n2, "Robot name should change when reset");
+    assert_ne!(n1, n2, "Robot name should change when reset");
 }


### PR DESCRIPTION
This gives a better error message when the assertion is violated.

This was added in August 2016, after each of the changed tests were
added.