### PR TITLE
Changes test assertions to compare wrapped values

### DIFF
--- a/exercises/all-your-base/tests/all-your-base.rs
+++ b/exercises/all-your-base/tests/all-your-base.rs
@@ -5,9 +5,9 @@ fn single_bit_one_to_decimal() {
     let input_base = 2;
     let input_digits = &[1];
     let output_base = 10;
-    let output_digits = &[1];
-    assert_eq!(ayb::convert(input_digits, input_base, output_base).unwrap().as_slice(),
-               output_digits);
+    let output_digits = vec![1];
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Ok(output_digits));
 }
 
 #[test]
@@ -16,9 +16,9 @@ fn binary_to_single_decimal() {
     let input_base = 2;
     let input_digits = &[1, 0, 1];
     let output_base = 10;
-    let output_digits = &[5];
-    assert_eq!(ayb::convert(input_digits, input_base, output_base).unwrap().as_slice(),
-               output_digits);
+    let output_digits = vec![5];
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Ok(output_digits));
 }
 
 #[test]
@@ -27,9 +27,9 @@ fn single_decimal_to_binary() {
     let input_base = 10;
     let input_digits = &[5];
     let output_base = 2;
-    let output_digits = &[1, 0, 1];
-    assert_eq!(ayb::convert(input_digits, input_base, output_base).unwrap().as_slice(),
-               output_digits);
+    let output_digits = vec![1, 0, 1];
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Ok(output_digits));
 }
 
 #[test]
@@ -38,9 +38,9 @@ fn binary_to_multiple_decimal() {
     let input_base = 2;
     let input_digits = &[1, 0, 1, 0, 1, 0];
     let output_base = 10;
-    let output_digits = &[4, 2];
-    assert_eq!(ayb::convert(input_digits, input_base, output_base).unwrap().as_slice(),
-               output_digits);
+    let output_digits = vec![4, 2];
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Ok(output_digits));
 }
 
 #[test]
@@ -49,9 +49,9 @@ fn decimal_to_binary() {
     let input_base = 10;
     let input_digits = &[4, 2];
     let output_base = 2;
-    let output_digits = &[1, 0, 1, 0, 1, 0];
-    assert_eq!(ayb::convert(input_digits, input_base, output_base).unwrap().as_slice(),
-               output_digits);
+    let output_digits = vec![1, 0, 1, 0, 1, 0];
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Ok(output_digits));
 }
 
 #[test]
@@ -60,9 +60,9 @@ fn trinary_to_hexadecimal() {
     let input_base = 3;
     let input_digits = &[1, 1, 2, 0];
     let output_base = 16;
-    let output_digits = &[2, 10];
-    assert_eq!(ayb::convert(input_digits, input_base, output_base).unwrap().as_slice(),
-               output_digits);
+    let output_digits = vec![2, 10];
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Ok(output_digits));
 }
 
 #[test]
@@ -71,9 +71,9 @@ fn hexadecimal_to_trinary() {
     let input_base = 16;
     let input_digits = &[2, 10];
     let output_base = 3;
-    let output_digits = &[1, 1, 2, 0];
-    assert_eq!(ayb::convert(input_digits, input_base, output_base).unwrap().as_slice(),
-               output_digits);
+    let output_digits = vec![1, 1, 2, 0];
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Ok(output_digits));
 }
 
 #[test]
@@ -82,9 +82,9 @@ fn fifteen_bit_integer() {
     let input_base = 97;
     let input_digits = &[3, 46, 60];
     let output_base = 73;
-    let output_digits = &[6, 10, 45];
-    assert_eq!(ayb::convert(input_digits, input_base, output_base).unwrap().as_slice(),
-               output_digits);
+    let output_digits = vec![6, 10, 45];
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Ok(output_digits));
 }
 
 #[test]
@@ -93,9 +93,9 @@ fn empty_list() {
     let input_base = 2;
     let input_digits = &[];
     let output_base = 10;
-    let output_digits = &[];
-    assert_eq!(ayb::convert(input_digits, input_base, output_base).unwrap().as_slice(),
-               output_digits);
+    let output_digits = vec![];
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Ok(output_digits));
 }
 
 #[test]
@@ -104,9 +104,9 @@ fn single_zero() {
     let input_base = 10;
     let input_digits = &[0];
     let output_base = 2;
-    let output_digits = &[];
-    assert_eq!(ayb::convert(input_digits, input_base, output_base).unwrap().as_slice(),
-               output_digits);
+    let output_digits = vec![];
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Ok(output_digits));
 }
 
 #[test]
@@ -115,9 +115,9 @@ fn multiple_zeros() {
     let input_base = 10;
     let input_digits = &[0, 0, 0];
     let output_base = 2;
-    let output_digits = &[];
-    assert_eq!(ayb::convert(input_digits, input_base, output_base).unwrap().as_slice(),
-               output_digits);
+    let output_digits = vec![];
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Ok(output_digits));
 }
 
 #[test]
@@ -126,9 +126,9 @@ fn leading_zeros() {
     let input_base = 7;
     let input_digits = &[0, 6, 0];
     let output_base = 10;
-    let output_digits = &[4, 2];
-    assert_eq!(ayb::convert(input_digits, input_base, output_base).unwrap().as_slice(),
-               output_digits);
+    let output_digits = vec![4, 2];
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Ok(output_digits));
 }
 
 #[test]

--- a/exercises/alphametics/tests/alphametics.rs
+++ b/exercises/alphametics/tests/alphametics.rs
@@ -2,9 +2,9 @@ extern crate alphametics;
 use std::collections::HashMap;
 
 fn assert_alphametic_solution_eq(puzzle: &str, solution: &[(char, u8)]) {
-    let answer = alphametics::solve(puzzle).unwrap();
+    let answer = alphametics::solve(puzzle);
     let solution: HashMap<char, u8> = solution.iter().cloned().collect();
-    assert_eq!(answer, solution);
+    assert_eq!(answer, Some(solution));
 }
 
 #[test]

--- a/exercises/bowling/tests/bowling.rs
+++ b/exercises/bowling/tests/bowling.rs
@@ -72,7 +72,7 @@ fn twenty_zero_pin_rolls_scores_zero() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score().unwrap(), 0);
+    assert_eq!(game.score(), Ok(0));
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn ten_frames_without_a_strike_or_spare() {
         let _ = game.roll(6);
     }
 
-    assert_eq!(game.score().unwrap(), 90);
+    assert_eq!(game.score(), Ok(90));
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn spare_in_the_first_frame_followed_by_zeros() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score().unwrap(), 10);
+    assert_eq!(game.score(), Ok(10));
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn points_scored_in_the_roll_after_a_spare_are_counted_twice_as_a_bonus() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score().unwrap(), 16);
+    assert_eq!(game.score(), Ok(16));
 }
 
 #[test]
@@ -134,7 +134,7 @@ fn consecutive_spares_each_get_a_one_roll_bonus() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score().unwrap(), 31);
+    assert_eq!(game.score(), Ok(31));
 }
 
 #[test]
@@ -150,7 +150,7 @@ fn if_the_last_frame_is_a_spare_you_get_one_extra_roll_that_is_scored_once() {
     let _ = game.roll(5);
     let _ = game.roll(7);
 
-    assert_eq!(game.score().unwrap(), 17);
+    assert_eq!(game.score(), Ok(17));
 }
 
 #[test]
@@ -164,7 +164,7 @@ fn a_strike_earns_ten_points_in_a_frame_with_a_single_roll() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score().unwrap(), 10);
+    assert_eq!(game.score(), Ok(10));
 }
 
 #[test]
@@ -180,7 +180,7 @@ fn points_scored_in_the_two_rolls_after_a_strike_are_counted_twice_as_a_bonus() 
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score().unwrap(), 26);
+    assert_eq!(game.score(), Ok(26));
 }
 
 #[test]
@@ -198,7 +198,7 @@ fn consecutive_strikes_each_get_the_two_roll_bonus() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score().unwrap(), 81);
+    assert_eq!(game.score(), Ok(81));
 }
 
 #[test]
@@ -214,7 +214,7 @@ fn a_strike_in_the_last_frame_earns_a_two_roll_bonus_that_is_counted_once() {
     let _ = game.roll(7);
     let _ = game.roll(1);
 
-    assert_eq!(game.score().unwrap(), 18);
+    assert_eq!(game.score(), Ok(18));
 }
 
 #[test]
@@ -230,7 +230,7 @@ fn a_spare_with_the_two_roll_bonus_does_not_get_a_bonus_roll() {
     let _ = game.roll(7);
     let _ = game.roll(3);
 
-    assert_eq!(game.score().unwrap(), 20);
+    assert_eq!(game.score(), Ok(20));
 }
 
 #[test]
@@ -246,7 +246,7 @@ fn strikes_with_the_two_roll_bonus_do_not_get_a_bonus_roll() {
     let _ = game.roll(10);
     let _ = game.roll(10);
 
-    assert_eq!(game.score().unwrap(), 30);
+    assert_eq!(game.score(), Ok(30));
 }
 
 #[test]
@@ -262,7 +262,7 @@ fn a_strike_with_the_one_roll_bonus_after_a_spare_in_the_last_frame_does_not_get
     let _ = game.roll(3);
     let _ = game.roll(10);
 
-    assert_eq!(game.score().unwrap(), 20);
+    assert_eq!(game.score(), Ok(20));
 }
 
 #[test]
@@ -274,7 +274,7 @@ fn all_strikes_is_a_perfect_score_of_300() {
         let _ = game.roll(10);
     }
 
-    assert_eq!(game.score().unwrap(), 300);
+    assert_eq!(game.score(), Ok(300));
 }
 
 #[test]

--- a/exercises/circular-buffer/tests/circular-buffer.rs
+++ b/exercises/circular-buffer/tests/circular-buffer.rs
@@ -16,7 +16,7 @@ mod tests {
     fn write_and_read_back_item() {
         let mut buffer = CircularBuffer::new(1);
         buffer.write('1');
-        assert_eq!('1', buffer.read().unwrap());
+        assert_eq!(Ok('1'), buffer.read());
         assert_eq!(Err(Error::EmptyBuffer), buffer.read());
     }
 
@@ -26,8 +26,8 @@ mod tests {
         let mut buffer = CircularBuffer::new(2);
         buffer.write('1');
         buffer.write('2');
-        assert_eq!('1', buffer.read().unwrap());
-        assert_eq!('2', buffer.read().unwrap());
+        assert_eq!(Ok('1'), buffer.read());
+        assert_eq!(Ok('2'), buffer.read());
         assert_eq!(Err(Error::EmptyBuffer), buffer.read());
     }
 
@@ -36,9 +36,9 @@ mod tests {
     fn alternate_write_and_read() {
         let mut buffer = CircularBuffer::new(2);
         buffer.write('1');
-        assert_eq!('1', buffer.read().unwrap());
+        assert_eq!(Ok('1'), buffer.read());
         buffer.write('2');
-        assert_eq!('2', buffer.read().unwrap());
+        assert_eq!(Ok('2'), buffer.read());
     }
 
     #[test]
@@ -52,9 +52,9 @@ mod tests {
         assert_eq!(Err(Error::EmptyBuffer), buffer.read());
         buffer.write('1');
         buffer.write('2');
-        assert_eq!('1', buffer.read().unwrap());
+        assert_eq!(Ok('1'), buffer.read());
         buffer.write('3');
-        assert_eq!('2', buffer.read().unwrap());
+        assert_eq!(Ok('2'), buffer.read());
     }
 
     #[test]
@@ -72,8 +72,8 @@ mod tests {
         let mut buffer = CircularBuffer::new(2);
         buffer.write('1');
         buffer.overwrite('2');
-        assert_eq!('1', buffer.read().unwrap());
-        assert_eq!('2', buffer.read().unwrap());
+        assert_eq!(Ok('1'), buffer.read());
+        assert_eq!(Ok('2'), buffer.read());
         assert_eq!(Err(Error::EmptyBuffer), buffer.read());
     }
 
@@ -84,8 +84,8 @@ mod tests {
         buffer.write('1');
         buffer.write('2');
         buffer.overwrite('A');
-        assert_eq!('2', buffer.read().unwrap());
-        assert_eq!('A', buffer.read().unwrap());
+        assert_eq!(Ok('2'), buffer.read());
+        assert_eq!(Ok('A'), buffer.read());
     }
 
     #[test]
@@ -94,10 +94,10 @@ mod tests {
         let mut buffer = CircularBuffer::new(2);
         buffer.write(1);
         buffer.write(2);
-        assert_eq!(1,buffer.read().unwrap());
+        assert_eq!(Ok(1), buffer.read());
         buffer.write(-1);
-        assert_eq!(2,buffer.read().unwrap());
-        assert_eq!(-1,buffer.read().unwrap());
+        assert_eq!(Ok(2), buffer.read());
+        assert_eq!(Ok(-1), buffer.read());
         assert_eq!(Err(Error::EmptyBuffer), buffer.read());
     }
 
@@ -107,7 +107,7 @@ mod tests {
         let mut buffer = CircularBuffer::new(2);
         buffer.write("".to_string());
         buffer.write("Testing".to_string());
-        assert_eq!(0,buffer.read().unwrap().len());
-        assert_eq!("Testing",buffer.read().unwrap());
+        assert_eq!(0, buffer.read().unwrap().len());
+        assert_eq!(Ok("Testing".to_string()), buffer.read());
     }
 }

--- a/exercises/hamming/tests/hamming.rs
+++ b/exercises/hamming/tests/hamming.rs
@@ -2,31 +2,31 @@ extern crate hamming;
 
 #[test]
 fn test_no_difference_between_empty_strands() {
-    assert_eq!(hamming::hamming_distance("", "").unwrap(), 0);
+    assert_eq!(hamming::hamming_distance("", ""), Ok(0));
 }
 
 #[test]
 #[ignore]
 fn test_no_difference_between_identical_strands() {
-    assert_eq!(hamming::hamming_distance("GGACTGA", "GGACTGA").unwrap(), 0);
+    assert_eq!(hamming::hamming_distance("GGACTGA", "GGACTGA"), Ok(0));
 }
 
 #[test]
 #[ignore]
 fn test_complete_hamming_distance_in_small_strand() {
-    assert_eq!(hamming::hamming_distance("ACT", "GGA").unwrap(), 3);
+    assert_eq!(hamming::hamming_distance("ACT", "GGA"), Ok(3));
 }
 
 #[test]
 #[ignore]
 fn test_small_hamming_distance_in_the_middle_somewhere() {
-    assert_eq!(hamming::hamming_distance("GGACG", "GGTCG").unwrap(), 1);
+    assert_eq!(hamming::hamming_distance("GGACG", "GGTCG"), Ok(1));
 }
 
 #[test]
 #[ignore]
 fn test_larger_distance() {
-    assert_eq!(hamming::hamming_distance("ACCAGGG", "ACTATGG").unwrap(), 2);
+    assert_eq!(hamming::hamming_distance("ACCAGGG", "ACTATGG"), Ok(2));
 }
 
 #[test]

--- a/exercises/largest-series-product/tests/largest-series-product.rs
+++ b/exercises/largest-series-product/tests/largest-series-product.rs
@@ -10,56 +10,56 @@ fn return_is_a_result() {
 #[test]
 #[ignore]
 fn find_the_largest_product_when_span_equals_length() {
-    assert_eq!(18, lsp("29", 2).unwrap());
+    assert_eq!(Ok(18), lsp("29", 2));
 }
 
 #[test]
 #[ignore]
 fn find_the_largest_product_of_two_with_numbers_in_order() {
-    assert_eq!(72, lsp("0123456789", 2).unwrap());
+    assert_eq!(Ok(72), lsp("0123456789", 2));
 }
 
 #[test]
 #[ignore]
 fn find_the_largest_product_of_two_with_numbers_not_in_order() {
-    assert_eq!(48, lsp("576802143", 2).unwrap());
+    assert_eq!(Ok(48), lsp("576802143", 2));
 }
 
 #[test]
 #[ignore]
 fn find_the_largest_product_of_three_with_numbers_in_order() {
-    assert_eq!(504, lsp("0123456789", 3).unwrap());
+    assert_eq!(Ok(504), lsp("0123456789", 3));
 }
 
 #[test]
 #[ignore]
 fn find_the_largest_product_of_three_with_numbers_not_in_order() {
-    assert_eq!(270, lsp("1027839564", 3).unwrap());
+    assert_eq!(Ok(270), lsp("1027839564", 3));
 }
 
 #[test]
 #[ignore]
 fn find_the_largest_product_of_five_with_numbers_in_order() {
-    assert_eq!(15120, lsp("0123456789", 5).unwrap());
+    assert_eq!(Ok(15120), lsp("0123456789", 5));
 }
 
 #[test]
 #[ignore]
 fn span_of_six_in_a_large_number() {
-    assert_eq!(23520,
-               lsp("73167176531330624919225119674426574742355349194934", 6).unwrap());
+    assert_eq!(Ok(23520),
+               lsp("73167176531330624919225119674426574742355349194934", 6));
 }
 
 #[test]
 #[ignore]
 fn returns_zero_if_number_is_zeros() {
-    assert_eq!(0, lsp("0000", 2).unwrap());
+    assert_eq!(Ok(0), lsp("0000", 2));
 }
 
 #[test]
 #[ignore]
 fn returns_zero_if_all_products_are_zero() {
-    assert_eq!(0, lsp("99099", 3).unwrap());
+    assert_eq!(Ok(0), lsp("99099", 3));
 }
 
 #[test]
@@ -83,13 +83,13 @@ fn a_span_is_longer_than_number_is_an_error() {
 #[test]
 #[ignore]
 fn an_empty_string_and_no_span_returns_one() {
-    assert_eq!(1, lsp("", 0).unwrap());
+    assert_eq!(Ok(1), lsp("", 0));
 }
 
 #[test]
 #[ignore]
 fn a_non_empty_string_and_no_span_returns_one() {
-    assert_eq!(1, lsp("123", 0).unwrap());
+    assert_eq!(Ok(1), lsp("123", 0));
 }
 
 #[test]

--- a/exercises/nucleotide-count/tests/nucleotide-count.rs
+++ b/exercises/nucleotide-count/tests/nucleotide-count.rs
@@ -9,7 +9,7 @@ fn check_dna(s: &str, pairs: &[(char, usize)]) {
     // check for the presence and value of each key in the given pairs vector.
     let mut m: HashMap<char, usize> = dna::nucleotide_counts(s).unwrap();
     for &(k, v) in pairs.iter() {
-        assert_eq!((k, m.remove(&k).unwrap()), (k, v));
+        assert_eq!((k, m.remove(&k)), (k, Some(v)));
     }
     // may fail with a message that clearly shows all extra pairs in the map
     assert_eq!(m.iter().collect::<Vec<(&char,&usize)>>(), vec!());
@@ -23,7 +23,7 @@ fn count_returns_result() {
 #[test]
 #[ignore]
 fn test_count_empty() {
-    assert_eq!(dna::count('A', "").unwrap(), 0);
+    assert_eq!(dna::count('A', ""), Ok(0));
 }
 
 #[test]
@@ -41,13 +41,13 @@ fn count_invalid_dna() {
 #[test]
 #[ignore]
 fn test_count_repetitive_cytosine() {
-    assert_eq!(dna::count('C', "CCCCC").unwrap(), 5);
+    assert_eq!(dna::count('C', "CCCCC"), Ok(5));
 }
 
 #[test]
 #[ignore]
 fn test_count_only_thymine() {
-    assert_eq!(dna::count('T', "GGGGGTAACCCGG").unwrap(), 1);
+    assert_eq!(dna::count('T', "GGGGGTAACCCGG"), Ok(1));
 }
 
 #[test]

--- a/exercises/ocr-numbers/tests/ocr-numbers.rs
+++ b/exercises/ocr-numbers/tests/ocr-numbers.rs
@@ -32,7 +32,7 @@ fn unrecognized_chararcters_return_question_mark() {
                 "  |\n" +
                 "   ";
 
-    assert_eq!("?", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("?".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn recognizes_0() {
                 "|_|\n" +
                 "   ";
 
-    assert_eq!("0", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("0".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -56,7 +56,7 @@ fn recognizes_1() {
                 "  |\n" +
                 "   ";
 
-    assert_eq!("1", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("1".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn recognizes_2() {
                 "|_ \n" +
                 "   ";
 
-    assert_eq!("2", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("2".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn recognizes_3() {
                 " _|\n" +
                 "   ";
 
-    assert_eq!("3", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("3".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn recognizes_4() {
                 "  |\n" +
                 "   ";
 
-    assert_eq!("4", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("4".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -104,7 +104,7 @@ fn recognizes_5() {
                 " _|\n" +
                 "   ";
 
-    assert_eq!("5", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("5".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn recognizes_6() {
                 "|_|\n" +
                 "   ";
 
-    assert_eq!("6", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("6".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn recognizes_7() {
                 "  |\n" +
                 "   ";
 
-    assert_eq!("7", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("7".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -140,7 +140,7 @@ fn recognizes_8() {
                 "|_|\n" +
                 "   ";
 
-    assert_eq!("8", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("8".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -152,7 +152,7 @@ fn recognizes_9() {
                 " _|\n" +
                 "   ";
 
-    assert_eq!("9", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("9".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -164,7 +164,7 @@ fn recognizes_110101100() {
                 "  |  ||_|  ||_|  |  ||_||_|\n" +
                 "                           ";
 
-    assert_eq!("110101100", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("110101100".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -176,7 +176,7 @@ fn replaces_only_garbled_numbers_with_question_mark() {
                 "  |  | _|  ||_|  |  ||_||_|\n" +
                 "                           ";
 
-    assert_eq!("11?10?1?0", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("11?10?1?0".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -188,7 +188,7 @@ fn recognizes_string_of_decimal_numbers() {
                 "  ||_  _|  | _||_|  ||_| _||_|\n" +
                 "                              ";
 
-    assert_eq!("1234567890", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("1234567890".to_string()), ocr::convert(&input));
 }
 
 #[test]
@@ -207,5 +207,5 @@ fn numbers_across_multiple_lines_are_joined_by_commas() {
                 "  ||_||_|\n" +
                 "  ||_| _|\n" +
                 "         ";
-    assert_eq!("123,456,789", ocr::convert(&input).unwrap());
+    assert_eq!(Ok("123,456,789".to_string()), ocr::convert(&input));
 }

--- a/exercises/pascals-triangle/tests/pascals-triangle.rs
+++ b/exercises/pascals-triangle/tests/pascals-triangle.rs
@@ -38,5 +38,5 @@ fn three_rows() {
 fn last_of_four_rows() {
     let pt = PascalsTriangle::new(4);
     let expected: Vec<u32> = vec![1, 3, 3, 1];
-    assert_eq!(expected, pt.rows().pop().unwrap());
+    assert_eq!(Some(expected), pt.rows().pop());
 }

--- a/exercises/protein-translation/tests/proteins.rs
+++ b/exercises/protein-translation/tests/proteins.rs
@@ -75,24 +75,24 @@ fn too_long_is_invalid() {
 #[ignore]
 fn test_translates_rna_strand_into_correct_protein() {
     let info = proteins::parse(make_pairs());
-    assert_eq!(info.of_rna("AUGUUUUGG").unwrap(),
-               vec!["methionine", "phenylalanine", "tryptophan"]);
+    assert_eq!(info.of_rna("AUGUUUUGG"),
+               Ok(vec!["methionine", "phenylalanine", "tryptophan"]));
 }
 
 #[test]
 #[ignore]
 fn test_stops_translation_if_stop_codon_present() {
     let info = proteins::parse(make_pairs());
-    assert_eq!(info.of_rna("AUGUUUUAA").unwrap(),
-               vec!["methionine", "phenylalanine"]);
+    assert_eq!(info.of_rna("AUGUUUUAA"),
+               Ok(vec!["methionine", "phenylalanine"]));
 }
 
 #[test]
 #[ignore]
 fn test_stops_translation_of_longer_strand() {
     let info = proteins::parse(make_pairs());
-    assert_eq!(info.of_rna("UGGUGUUAUUAAUGGUUU").unwrap(),
-               vec!["tryptophan", "cysteine", "tyrosine"]);
+    assert_eq!(info.of_rna("UGGUGUUAUUAAUGGUUU"),
+               Ok(vec!["tryptophan", "cysteine", "tyrosine"]));
 }
 
 #[test]

--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -6,7 +6,7 @@ use react::*;
 fn input_cells_have_a_value() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(10);
-    assert_eq!(reactor.value(input).unwrap(), 10);
+    assert_eq!(reactor.value(input), Some(10));
 }
 
 #[test]
@@ -15,7 +15,7 @@ fn an_input_cells_value_can_be_set() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(4);
     assert!(reactor.set_value(input, 20).is_ok());
-    assert_eq!(reactor.value(input).unwrap(), 20);
+    assert_eq!(reactor.value(input), Some(20));
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn compute_cells_calculate_initial_value() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let output = reactor.create_compute(&vec![input], |v| v[0] + 1).unwrap();
-    assert_eq!(reactor.value(output).unwrap(), 2);
+    assert_eq!(reactor.value(output), Some(2));
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn compute_cells_take_inputs_in_the_right_order() {
     let one = reactor.create_input(1);
     let two = reactor.create_input(2);
     let output = reactor.create_compute(&vec![one, two], |v| v[0] + v[1] * 10).unwrap();
-    assert_eq!(reactor.value(output).unwrap(), 21);
+    assert_eq!(reactor.value(output), Some(21));
 }
 
 #[test]
@@ -63,7 +63,7 @@ fn do_not_break_cell_if_creating_compute_cell_with_valid_and_invalid_input() {
     let input = reactor.create_input(1);
     assert!(reactor.create_compute(&vec![input, dummy_cell], |_| 0).is_err());
     assert!(reactor.set_value(input, 5).is_ok());
-    assert_eq!(reactor.value(input).unwrap(), 5);
+    assert_eq!(reactor.value(input), Some(5));
 }
 
 #[test]
@@ -72,9 +72,9 @@ fn compute_cells_update_value_when_dependencies_are_changed() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let output = reactor.create_compute(&vec![input], |v| v[0] + 1).unwrap();
-    assert_eq!(reactor.value(output).unwrap(), 2);
+    assert_eq!(reactor.value(output), Some(2));
     assert!(reactor.set_value(input, 3).is_ok());
-    assert_eq!(reactor.value(output).unwrap(), 4);
+    assert_eq!(reactor.value(output), Some(4));
 }
 
 #[test]
@@ -85,9 +85,9 @@ fn compute_cells_can_depend_on_other_compute_cells() {
     let times_two = reactor.create_compute(&vec![input], |v| v[0] * 2).unwrap();
     let times_thirty = reactor.create_compute(&vec![input], |v| v[0] * 30).unwrap();
     let output = reactor.create_compute(&vec![times_two, times_thirty], |v| v[0] + v[1]).unwrap();
-    assert_eq!(reactor.value(output).unwrap(), 32);
+    assert_eq!(reactor.value(output), Some(32));
     assert!(reactor.set_value(input, 3).is_ok());
-    assert_eq!(reactor.value(output).unwrap(), 96);
+    assert_eq!(reactor.value(output), Some(96));
 }
 
 #[test]
@@ -251,7 +251,7 @@ fn test_adder_with_boolean_values() {
         assert!(reactor.set_value(b, bval).is_ok());
         assert!(reactor.set_value(carry_in, cinval).is_ok());
 
-        assert_eq!(reactor.value(sum).unwrap(), expected_sum);
-        assert_eq!(reactor.value(carry_out).unwrap(), expected_cout);
+        assert_eq!(reactor.value(sum), Some(expected_sum));
+        assert_eq!(reactor.value(carry_out), Some(expected_cout));
     }
 }

--- a/exercises/variable-length-quantity/tests/variable-length-quantity.rs
+++ b/exercises/variable-length-quantity/tests/variable-length-quantity.rs
@@ -48,15 +48,15 @@ fn to_quintuple_byte() {
 #[test]
 #[ignore]
 fn from_bytes() {
-    assert_eq!(&[0x7f], vlq::from_bytes(&[0x7f]).unwrap().as_slice());
-    assert_eq!(&[0x2000],
-               vlq::from_bytes(&[0xc0, 0x00]).unwrap().as_slice());
-    assert_eq!(&[0x1f_ffff],
-               vlq::from_bytes(&[0xff, 0xff, 0x7f]).unwrap().as_slice());
-    assert_eq!(&[0x20_0000],
-               vlq::from_bytes(&[0x81, 0x80, 0x80, 0x00]).unwrap().as_slice());
-    assert_eq!(&[0xffff_ffff],
-               vlq::from_bytes(&[0x8f, 0xff, 0xff, 0xff, 0x7f]).unwrap().as_slice());
+    assert_eq!(Ok(vec![0x7f]), vlq::from_bytes(&[0x7f]));
+    assert_eq!(Ok(vec![0x2000]),
+               vlq::from_bytes(&[0xc0, 0x00]));
+    assert_eq!(Ok(vec![0x1f_ffff]),
+               vlq::from_bytes(&[0xff, 0xff, 0x7f]));
+    assert_eq!(Ok(vec![0x20_0000]),
+               vlq::from_bytes(&[0x81, 0x80, 0x80, 0x00]));
+    assert_eq!(Ok(vec![0xffff_ffff]),
+               vlq::from_bytes(&[0x8f, 0xff, 0xff, 0xff, 0x7f]));
 }
 
 
@@ -74,11 +74,9 @@ fn to_bytes_multiple_values() {
 #[test]
 #[ignore]
 fn from_bytes_multiple_values() {
-    assert_eq!(&[0x2000, 0x12_3456, 0x0fff_ffff, 0x00, 0x3fff, 0x4000],
+    assert_eq!(Ok(vec![0x2000, 0x12_3456, 0x0fff_ffff, 0x00, 0x3fff, 0x4000]),
                vlq::from_bytes(&[0xc0, 0x00, 0xc8, 0xe8, 0x56, 0xff, 0xff, 0xff, 0x7f, 0x00,
-                                 0xff, 0x7f, 0x81, 0x80, 0x00])
-                   .unwrap()
-                   .as_slice());
+                                 0xff, 0x7f, 0x81, 0x80, 0x00]));
 }
 
 #[test]
@@ -103,6 +101,6 @@ fn overflow_u32() {
 #[ignore]
 fn chained_execution_is_identity() {
     let test = &[0xf2, 0xf6, 0x96, 0x9c, 0x3b, 0x39, 0x2e, 0x30, 0xb3, 0x24];
-    assert_eq!(test,
-               vlq::from_bytes(&vlq::to_bytes(test)).unwrap().as_slice());
+    assert_eq!(Ok(Vec::from(&test[..])),
+               vlq::from_bytes(&vlq::to_bytes(test)));
 }

--- a/exercises/wordy/tests/wordy.rs
+++ b/exercises/wordy/tests/wordy.rs
@@ -5,98 +5,98 @@ use wordy::*;
 #[test]
 fn addition() {
     let command = "What is 1 plus 1?";
-    assert_eq!(2, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(2), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn more_addition() {
     let command = "What is 53 plus 2?";
-    assert_eq!(55, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(55), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn addition_with_negative_numbers() {
     let command = "What is -1 plus -10?";
-    assert_eq!(-11, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(-11), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn large_addition() {
     let command = "What is 123 plus 45678?";
-    assert_eq!(45801, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(45801), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn subtraction() {
     let command = "What is 4 minus -12?";
-    assert_eq!(16, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(16), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn multiplication() {
     let command = "What is -3 multiplied by 25?";
-    assert_eq!(-75, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(-75), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn division() {
     let command = "What is 33 divided by -3?";
-    assert_eq!(-11, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(-11), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn multiple_additions() {
     let command = "What is 1 plus 1 plus 1?";
-    assert_eq!(3, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(3), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn addition_and_subtraction() {
     let command = "What is 1 plus 5 minus -2?";
-    assert_eq!(8, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(8), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn multiple_subtraction() {
     let command = "What is 20 minus 4 minus 13?";
-    assert_eq!(3, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(3), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn subtraction_then_addition() {
     let command = "What is 17 minus 6 plus 3?";
-    assert_eq!(14, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(14), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn multiple_multiplications() {
     let command = "What is 2 multiplied by -2 multiplied by 3?";
-    assert_eq!(-12, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(-12), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn addition_and_multiplication() {
     let command = "What is -3 plus 7 multiplied by -2?";
-    assert_eq!(-8, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(-8), WordProblem::new(command).answer());
 }
 
 #[test]
 #[ignore]
 fn multiple_divisions() {
     let command = "What is -12 divided by 2 divided by -3?";
-    assert_eq!(2, WordProblem::new(command).answer().unwrap());
+    assert_eq!(Ok(2), WordProblem::new(command).answer());
 }
 
 #[test]


### PR DESCRIPTION
Resolves #338 

Test assertions should compare `Option` or `Result` values directly instead of unwrapping them.