### PR TITLE
travis: Enforce that stubs compile, supporting commit (add unimplemented)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: rust
 script:
 - "./_test/check-exercises.sh"
 - "sh ./_test/ensure-lib-src-rs-exist.sh"
+- "sh ./_test/ensure-stubs-compile.sh"
 - "sh ./_test/count-ignores.sh"
 - "./bin/fetch-configlet"
 - "./bin/configlet lint ."

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Note that:
 
 - The stub file and test suite should use only the Rust core libraries. `Cargo.toml` should not list any external dependencies as we don't want to make the student assume required crates. If an `example.rs` uses external crates, include `Cargo-example.toml` so that `_tests/check-exercises.sh` can compile with these when testing.
 
+- Except in extraordinary circumstances, the stub file should compile under `cargo test --no-run`.
+  This allows us to check that the signatures in the stub file match the signatures expected by the tests.
+  Use `unimplemented!()` as the body of each function to achieve this.
+  If there is a justified reason why this is not possible, instead include a `.meta/ALLOWED_TO_NOT_COMPILE` containing the reason.
+
 - If porting an existing exercise from problem-specifications that has a `canonical-data.json` file, use the version in `canonical-data.json` for that exercise as your `Cargo.toml` version.  Otherwise, use "0.0.0".
 
 - An exercise may contain `.meta/hints.md`.  This is optional and will appear after the normal exercise

--- a/_test/ensure-stubs-compile.sh
+++ b/_test/ensure-stubs-compile.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+repo=$(cd "$(dirname "$0")/.." && pwd)
+
+broken=""
+
+for dir in $repo/exercises/*/; do
+  exercise=$(basename "$dir")
+
+  # If src/lib.rs contains any non-comment line that contains any non-spaces,
+  # it probably contains function signatures, and these should compile.
+  if grep -v '^//' $dir/src/lib.rs | grep '\S' > /dev/null; then
+    allowed_file=$dir/.meta/ALLOWED_TO_NOT_COMPILE
+    if [ -f $allowed_file ]; then
+      echo "$exercise's stub is allowed to not compile"
+    elif ! (cd $dir && cargo test --quiet --no-run); then
+      echo "$exercise's stub does not compile; please make it compile or remove all non-commented lines"
+      broken="$broken\n$exercise"
+    fi
+  fi
+done
+
+if [ -n "$broken" ]; then
+  echo "Exercises that don't compile:$broken"
+  exit 1
+fi

--- a/exercises/beer-song/src/lib.rs
+++ b/exercises/beer-song/src/lib.rs
@@ -1,7 +1,7 @@
 pub fn verse(n: i32) -> String {
-
+    unimplemented!()
 }
 
 pub fn sing(start: i32, end: i32) -> String {
-
+    unimplemented!()
 }

--- a/exercises/bob/src/lib.rs
+++ b/exercises/bob/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn reply(message: &str) -> &str {
-
+    unimplemented!()
 }

--- a/exercises/collatz-conjecture/src/lib.rs
+++ b/exercises/collatz-conjecture/src/lib.rs
@@ -1,4 +1,4 @@
 // return Ok(x) where x is the number of steps required to reach 1
 pub fn collatz(n: u64) -> Result<u64, &'static str> {
-
+    unimplemented!()
 }

--- a/exercises/decimal/.meta/ALLOWED_TO_NOT_COMPILE
+++ b/exercises/decimal/.meta/ALLOWED_TO_NOT_COMPILE
@@ -1,0 +1,2 @@
+Stub doesn't compile because operations like +, - are not found.
+However, giving stubs to the traits would reduce the student's learning.

--- a/exercises/difference-of-squares/src/lib.rs
+++ b/exercises/difference-of-squares/src/lib.rs
@@ -1,11 +1,11 @@
 pub fn square_of_sum(n: usize) -> usize {
-
+    unimplemented!()
 }
 
 pub fn sum_of_squares(n: usize) -> usize {
-
+    unimplemented!()
 }
 
 pub fn difference(n: usize) -> usize {
-
+    unimplemented!()
 }

--- a/exercises/forth/src/lib.rs
+++ b/exercises/forth/src/lib.rs
@@ -13,11 +13,14 @@ pub enum Error {
 
 impl Forth {
     pub fn new() -> Forth {
+        unimplemented!()
     }
 
     pub fn stack(&self) -> Vec<Value> {
+        unimplemented!()
     }
 
     pub fn eval(&mut self, input: &str) -> ForthResult {
+        unimplemented!()
     }
 }

--- a/exercises/leap/src/lib.rs
+++ b/exercises/leap/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn is_leap_year(year: i32) -> bool {
-
+    unimplemented!()
 }

--- a/exercises/proverb/src/lib.rs
+++ b/exercises/proverb/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn build_proverb(list: Vec<&str>) -> String {
-
+    unimplemented!()
 }

--- a/exercises/raindrops/src/lib.rs
+++ b/exercises/raindrops/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn raindrops(n: usize) -> String {
-
+    unimplemented!()
 }

--- a/exercises/sum-of-multiples/src/lib.rs
+++ b/exercises/sum-of-multiples/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn sum_of_multiples(limit: u32, factors: &[u32]) -> u32 {
-
+    unimplemented!()
 }


### PR DESCRIPTION
travis: Enforce that stubs compile

Adding a stub with an incorrect signature would be confusing to
students. We will prevent that with CI.

Was desired in https://github.com/exercism/rust/pull/339#issuecomment-319645344

Closes https://github.com/exercism/rust/issues/371.