### PR TITLE
count-ignores: Use `..` not `dirname` to get repo directory

### DIFF
--- a/_test/count-ignores.sh
+++ b/_test/count-ignores.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-dir=$(dirname $(dirname $0))
+repo=$(cd "$(dirname "$0")/.." && pwd)
 exitcode=0
 
-for t in $dir/exercises/*/tests/*.rs; do
+for t in $repo/exercises/*/tests/*.rs; do
   tests=$(grep "^\s*\#\[test\]" $t | wc -l | tr -d '[:space:]')
   ignores=$(grep "^\s*\#\[ignore\]" $t | wc -l | tr -d '[:space:]')
   want_ignores=$(expr $tests - 1)


### PR DESCRIPTION
Otherwise, if I run from `_test`, the `dirname` of `.` is `.`, which
means we don't successfully get the repo directory; we just get `_test`
again.