### PR TITLE
travis: Move lib/src.rs check to separate script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: rust
 script:
 - "./_test/check-exercises.sh"
+- "sh ./_test/ensure-lib-src-rs-exist.sh"
 - "sh ./_test/count-ignores.sh"
 - "./bin/fetch-configlet"
 - "./bin/configlet lint ."

--- a/_test/check-exercises.sh
+++ b/_test/check-exercises.sh
@@ -32,12 +32,6 @@ for exercise in $files; do
     (
         cd $workdir
 
-        if [ ! -f src/lib.rs ]; then
-            # https://github.com/exercism/rust/pull/270
-            echo "$exercise is missing a src/lib.rs; please create one (an empty file is acceptable)"
-            exitcode=1
-        fi
-
         cp example.rs src/lib.rs
 
         # Overwrite empty Cargo.toml if an example specific file exists

--- a/_test/ensure-lib-src-rs-exist.sh
+++ b/_test/ensure-lib-src-rs-exist.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+repo=$(cd "$(dirname "$0")/.." && pwd)
+
+missing=""
+
+for dir in $repo/exercises/*/; do
+  exercise=$(basename "$dir")
+  if [ ! -f $dir/src/lib.rs ]; then
+    # https://github.com/exercism/rust/pull/270
+    echo "$exercise is missing a src/lib.rs; please create one (an empty file is acceptable)"
+    missing="$missing\n$exercise"
+  fi
+done
+
+if [ -n "$missing" ]; then
+  echo "Exercises missing src/lib.rs:$missing"
+  exit 1
+fi


### PR DESCRIPTION
The reasons to do this:

1. Easier to run (and thus test) it separately
2. Previous scheme wasn't propagating the exit codes correctly. the
   `exitcode` is a new variable local to the subshell (as I understand),
   so a missing stub file would not actually cause an exit code of 1.