### PR TITLE
Standardize proverb tests

### DIFF
--- a/exercises/proverb/example.rs
+++ b/exercises/proverb/example.rs
@@ -1,17 +1,16 @@
-pub fn build_proverb(list: Vec<&str>) -> String {
-    if list.len() == 0 {
-        return String::new();
+
+pub fn build_proverb(items: Vec<&str>) -> String {
+    let mut stanzas = Vec::with_capacity(items.len());
+    for index in 0..items.len() {
+        if index == items.len() - 1 {
+            stanzas.push(format!("And all for the want of a {}.", items[0]));
+        } else {
+            stanzas.push(format!(
+                "For want of a {} the {} was lost.",
+                items[index],
+                items[index + 1]
+            ));
+        }
     }
-    let mut out: Vec<String> = vec![];
-    for i in 1..list.len() {
-        out.push(format!("For want of a {} the {} was lost.", list[i-1], list[i]));
-    }
-    let end: String;
-    if list.len() > 2 {
-        end = format!("{}{} {}", list[2], list[1], list[0]);
-    } else {
-        end = format!("{}", list[0]);
-    }
-    out.push(format!("And all for the want of a {}.", end));
-    out.join("\n")
+    stanzas.join("\n")
 }

--- a/exercises/proverb/tests/proverb.rs
+++ b/exercises/proverb/tests/proverb.rs
@@ -5,8 +5,10 @@ use proverb::build_proverb;
 #[test]
 fn test_two_pieces() {
     let input = vec!["nail", "shoe"];
-    let expected = vec!["For want of a nail the shoe was lost.",
-                        "And all for the want of a nail."].join("\n");
+    let expected = vec![
+        "For want of a nail the shoe was lost.",
+        "And all for the want of a nail.",
+    ].join("\n");
     assert_eq!(build_proverb(input), expected);
 }
 
@@ -15,9 +17,11 @@ fn test_two_pieces() {
 #[ignore]
 fn test_three_pieces() {
     let input = vec!["nail", "shoe", "horse"];
-    let expected = vec!["For want of a nail the shoe was lost.",
-                        "For want of a shoe the horse was lost.",
-                        "And all for the want of a horseshoe nail."].join("\n");
+    let expected = vec![
+        "For want of a nail the shoe was lost.",
+        "For want of a shoe the horse was lost.",
+        "And all for the want of a nail.",
+    ].join("\n");
     assert_eq!(build_proverb(input), expected);
 }
 
@@ -40,13 +44,36 @@ fn test_zero_pieces() {
 #[test]
 #[ignore]
 fn test_full() {
-    let input = vec!["nail", "shoe", "horse", "rider", "message", "battle", "kingdom"];
-    let expected = vec!["For want of a nail the shoe was lost.",
-                        "For want of a shoe the horse was lost.",
-                        "For want of a horse the rider was lost.",
-                        "For want of a rider the message was lost.",
-                        "For want of a message the battle was lost.",
-                        "For want of a battle the kingdom was lost.",
-                        "And all for the want of a horseshoe nail."].join("\n");
+    let input = vec![
+        "nail",
+        "shoe",
+        "horse",
+        "rider",
+        "message",
+        "battle",
+        "kingdom",
+    ];
+    let expected = vec![
+        "For want of a nail the shoe was lost.",
+        "For want of a shoe the horse was lost.",
+        "For want of a horse the rider was lost.",
+        "For want of a rider the message was lost.",
+        "For want of a message the battle was lost.",
+        "For want of a battle the kingdom was lost.",
+        "And all for the want of a nail.",
+    ].join("\n");
+    assert_eq!(build_proverb(input), expected);
+}
+
+#[test]
+#[ignore]
+fn test_three_pieces_modernized() {
+    let input = vec!["pin", "gun", "soldier", "battle"];
+    let expected = vec![
+        "For want of a pin the gun was lost.",
+        "For want of a gun the soldier was lost.",
+        "For want of a soldier the battle was lost.",
+        "And all for the want of a pin.",
+    ].join("\n");
     assert_eq!(build_proverb(input), expected);
 }


### PR DESCRIPTION
Closes #379.

- Eliminate the inconsistencies pointed out in #379.
- Add a new test with different vocab to reduce the viability of hard-coded solutions
- Update example implementation to correctly handle the new tests

This should not break existing solutions, because users who have already
completed the exercise won't be prompted to re-try it. It simply makes
the exercise more rational for future users.