### PR TITLE
dominoes: no-op declare compliance with 2.0.0

### DIFF
--- a/exercises/dominoes/Cargo.lock
+++ b/exercises/dominoes/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "dominoes"
-version = "1.0.1"
+version = "2.0.0"
 

--- a/exercises/dominoes/Cargo.toml
+++ b/exercises/dominoes/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "dominoes"
-version = "1.0.1"
+version = "2.0.0"


### PR DESCRIPTION
2.0.0 only changes `can_chain` to `expected`; no tests changed. Thus,
the corresponding operation is a no-op.

https://github.com/exercism/problem-specifications/pull/823