### PR TITLE
Add CI test to ensure that README.md files are present and correct

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script:
 - "sh ./_test/ensure-stubs-compile.sh"
 - "sh ./_test/count-ignores.sh"
 - "./bin/fetch-configlet"
+- "sh ./_test/ensure-readmes-are-updated.sh"
 - "./bin/configlet lint ."
 sudo: false
 rust:

--- a/_test/ensure-readmes-are-updated.sh
+++ b/_test/ensure-readmes-are-updated.sh
@@ -4,13 +4,10 @@ if [ ! -x bin/configlet ]; then
    exit 1
 fi
 
-<<<<<<< HEAD
 if [ ! -d "problem-specifications" ]; then
    git clone git@github.com:exercism/problem-specifications.git problem-specifications
 fi
 
-=======
->>>>>>> 28d4a17e7c424b47d9c6649c05cdd127c1a2ef59
 newline=$'\n  '
 
 missing_readmes=""
@@ -23,11 +20,7 @@ for exercise in $(git diff --name-only master..$(git rev-parse --abbrev-ref HEAD
    else
       existing_readme_checksum=$(md5sum $readme_path | cut -d' ' -f1)
       # generate the new README
-<<<<<<< HEAD
       bin/configlet generate . --only "$exercise" --spec-path "problem-specifications"
-=======
-      bin/configlet generate . --only "$exercise"
->>>>>>> 28d4a17e7c424b47d9c6649c05cdd127c1a2ef59
       generated_readme_checksum=$(md5sum $readme_path | cut -d' ' -f1)
 
       if [ $existing_readme_checksum != $generated_readme_checksum ]; then

--- a/_test/ensure-readmes-are-updated.sh
+++ b/_test/ensure-readmes-are-updated.sh
@@ -5,7 +5,7 @@ if [ ! -x bin/configlet ]; then
 fi
 
 if [ ! -d "problem-specifications" ]; then
-   git clone git@github.com:exercism/problem-specifications.git problem-specifications
+   git clone https://github.com/exercism/problem-specifications.git problem-specifications
 fi
 
 newline=$'\n  '

--- a/_test/ensure-readmes-are-updated.sh
+++ b/_test/ensure-readmes-are-updated.sh
@@ -4,6 +4,10 @@ if [ ! -x bin/configlet ]; then
    exit 1
 fi
 
+if [ ! -d "problem-specifications" ]; then
+   git clone git@github.com:exercism/problem-specifications.git problem-specifications
+fi
+
 newline=$'\n  '
 
 missing_readmes=""
@@ -16,7 +20,7 @@ for exercise in $(git diff --name-only master..$(git rev-parse --abbrev-ref HEAD
    else
       existing_readme_checksum=$(md5sum $readme_path | cut -d' ' -f1)
       # generate the new README
-      bin/configlet generate . --only "$exercise"
+      bin/configlet generate . --only "$exercise" --spec-path "problem-specifications"
       generated_readme_checksum=$(md5sum $readme_path | cut -d' ' -f1)
 
       if [ $existing_readme_checksum != $generated_readme_checksum ]; then

--- a/_test/ensure-readmes-are-updated.sh
+++ b/_test/ensure-readmes-are-updated.sh
@@ -1,0 +1,36 @@
+if [ ! -x bin/configlet ]; then
+   echo "Improper configuration; configlet should exist in bin/ when this script is run"
+   echo "Ping a Rust track maintainer to fix this"
+   exit 1
+fi
+
+newline=$'\n  '
+
+missing_readmes=""
+wrong_readmes=""
+for exercise in $(git diff --name-only master..$(git rev-parse --abbrev-ref HEAD) | grep exercises/ | cut -d'/' -f2 -s | sort -fu); do
+   echo "Checking readme for $exercise"
+   readme_path="exercises/${exercise}/README.md"
+   if [ ! -f $readme_path ]; then
+      missing_readmes="$missing_readmes$newline$exercise"
+   else
+      existing_readme_checksum=$(md5sum $readme_path | cut -d' ' -f1)
+      # generate the new README
+      bin/configlet generate . --only "$exercise"
+      generated_readme_checksum=$(md5sum $readme_path | cut -d' ' -f1)
+
+      if [ $existing_readme_checksum != $generated_readme_checksum ]; then
+         wrong_readmes="$wrong_readmes$newline$exercise"
+      fi
+   fi
+done
+
+if [ -n "$missing_readmes" ]; then
+  echo "Exercises missing README.md:$missing_readmes"
+fi
+if [ -n "$wrong_readmes" ]; then
+  echo "Exercises with out-of-date README.md:$wrong_readmes"
+fi
+if [ -n "$missing_readmes" -o -n "$wrong_readmes" ]; then
+   exit 1
+fi


### PR DESCRIPTION
Checking readmes takes up non-trivial maintainer time, and is
prone to error. This script adds a check to the CI which ensures
that PRs are only accepted if their README.md files are
present and correct.

The intent and method come from the discussion which begins [here](https://github.com/exercism/rust/pull/354#issuecomment-341902986). 

It begins by isolating the exercises already impacted by the PR,
so that upstream changes to unrelated exercises don't cause undue
difficulty. It then simply ensures that the README.md within
the PR is identical to the one generated by `configlet generate`.

Outputs lists of exercises with missing or incorrect READMEs,
so people for whom CI fails due to this test not passing should
have an easy time understanding what went wrong and how to fix it.