### PR TITLE
Remove unused variable from Alphametics stub

### DIFF
--- a/exercises/alphametics/src/lib.rs
+++ b/exercises/alphametics/src/lib.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
 
-pub fn solve(puzzle: &str) -> Option<HashMap<char, u8>> {
+pub fn solve(_: &str) -> Option<HashMap<char, u8>> {
     unimplemented!()
 }


### PR DESCRIPTION
Travis fails in general right now, because we have an unused variable in the Alphametics stub. This is causing #381 to fail right now, and possibly others.

This simply removes the unused name from the Alphametics stub. This changes no interfaces or tests; students may rename the variable to anything they prefer. It simply ensures that the `_test/ensure-stubs-compile.sh` test actually passes.