### PR TITLE
test-exercise: sed now more precisely excises #[ignore]

### DIFF
--- a/bin/test-exercise
+++ b/bin/test-exercise
@@ -73,7 +73,7 @@ fi
 # eliminate #[ignore] lines from tests
 for test in "$exercise/tests/*.rs"; do
    sed -i -e '/#\[ignore\]/{
-      s/#\[ignore\]\s*\(.*\)$/\1/
+      s/#\[ignore\]\s*//
       /^\s*$/d
    }' $test
 done

--- a/bin/test-exercise
+++ b/bin/test-exercise
@@ -72,7 +72,10 @@ fi
 
 # eliminate #[ignore] lines from tests
 for test in "$exercise/tests/*.rs"; do
-    sed -i '/\[ignore\]/d' $test
+   sed -i -e '/#\[ignore\]/{
+      s/#\[ignore\]\s*\(.*\)$/\1/
+      /^\s*$/d
+   }' $test
 done
 
 # run tests from within exercise directory


### PR DESCRIPTION
Closes #395.

Previous implementation simply deleted all lines containing the string
`[ignore]`. This was not desired behavior, because it also deleted
lines which used the attribute inline.

The updated version now removes the string `#[ignore]` and any
trailing whitespace. If the line is blank in consequence, it deletes
the entire line; otherwise it leaves it.

Given test input:

```rust
tests! {
    test_classification {
        #[ignore] test_1(1, Classification::Deficient);
        #[ignore] test_2(2, Classification::Deficient);
        #[ignore] test_4(4, Classification::Deficient);
    }
}

#[test]
#[ignore]
fn test_me() {
   unimplemented!();
}

{
   #[test]
   #[ignore]
   fn test_indented() {
      unimplemented!();
   }
}

#[test] #[ignore] fn test_full_inline() { unimplemented!() }

{
   #[test] #[ignore] fn test_full_inline_indented() { unimplemented!() }
}

// don't [ignore] me
// this might get #[ignore]d
```

the new sed line produces output:

```rust
tests! {
    test_classification {
        test_1(1, Classification::Deficient);
        test_2(2, Classification::Deficient);
        test_4(4, Classification::Deficient);
    }
}

#[test]
fn test_me() {
   unimplemented!();
}

{
   #[test]
   fn test_indented() {
      unimplemented!();
   }
}

#[test] fn test_full_inline() { unimplemented!() }

{
   #[test] fn test_full_inline_indented() { unimplemented!() }
}

// don't [ignore] me
// this might get d
```

If this is approved, it should be merged before #394 so that one can use the attribute inline.