### PR TITLE
remove `use std::ascii::AsciiExt` for Rust 1.23

### DIFF
--- a/exercises/atbash-cipher/example.rs
+++ b/exercises/atbash-cipher/example.rs
@@ -1,5 +1,3 @@
-use std::ascii::AsciiExt;
-
 fn ascii(ch: char) -> u8 {
     ch as u8
 }

--- a/exercises/crypto-square/example.rs
+++ b/exercises/crypto-square/example.rs
@@ -1,5 +1,3 @@
-use std::ascii::AsciiExt;
-
 extern crate itertools;
 use itertools::Itertools;
 

--- a/exercises/etl/example.rs
+++ b/exercises/etl/example.rs
@@ -1,4 +1,3 @@
-use std::ascii::AsciiExt;
 use std::collections::BTreeMap;
 
 pub fn transform(input: &BTreeMap<i32, Vec<char>>) -> BTreeMap<char, i32> {

--- a/exercises/forth/example.rs
+++ b/exercises/forth/example.rs
@@ -1,4 +1,3 @@
-use std::ascii::AsciiExt;
 use std::collections::HashMap;
 use std::collections::LinkedList;
 use std::str::FromStr;

--- a/exercises/pangram/example.rs
+++ b/exercises/pangram/example.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeSet;
-use std::ascii::AsciiExt;
 use std::iter::FromIterator;
 
 pub fn is_pangram(sentence: &str) -> bool {


### PR DESCRIPTION
remove `use std::ascii::AsciiExt` for rust 1.23

In rust 1.23, the `AsciiExt` methods are implemented directly on the
concerned types, so attempting to import `AsciiExt` results in an
unused import.

Rust language PR:
https://github.com/rust-lang/rust/pull/44042

PSA:
https://users.rust-lang.org/t/psa-dealing-with-warning-unused-import-std-ascii-asciiext-in-today-s-nightly/13726

This started warning as an unused import on nightly sometime between
2017-11-02 and 2017-11-09:

https://travis-ci.org/exercism/rust/builds/296391447
https://travis-ci.org/exercism/rust/builds/299770403

This started warning on beta exactly when 1.23.0 became Beta (it was
accepted on 1.22.0):

https://travis-ci.org/exercism/rust/builds/303139434
https://travis-ci.org/exercism/rust/builds/306431846

As 1.23 is now stable and our repo disallows warnings on stable, we will
need this.