### PR TITLE
simple-linked-list: fix hints.md

### DIFF
--- a/exercises/simple-linked-list/.meta/hints.md
+++ b/exercises/simple-linked-list/.meta/hints.md
@@ -17,7 +17,7 @@ struct Node<T> {
 ```
 `data` contains the stored data, and `next` points to the following node (if available) or None.  
 
-### Why Option<__Box__<Node<T>>> and not just Option<Node<T>>?
+### Why `Option<Box<Node<T>>>` and not just `Option<Node<T>>`?
 Try it on your own. You will get the following error.
 
 ```
@@ -27,8 +27,7 @@ Try it on your own. You will get the following error.
 |     next: Option<Node<T>>,
 |     --------------------- recursive without indirection
  ```
- 
+
  The problem is that at compile time the size of next must be known.
  Since `next` is recursive ("a node has a node has a node..."), the compiler does not know how much memory is to be allocated.
  In contrast, [Box](https://doc.rust-lang.org/std/boxed/) is a heap pointer with a defined size.
- 

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -40,7 +40,7 @@ struct Node<T> {
 ```
 `data` contains the stored data, and `next` points to the following node (if available) or None.  
 
-### Why Option<__Box__<Node<T>>> and not just Option<Node<T>>?
+### Why `Option<Box<Node<T>>>` and not just `Option<Node<T>>`?
 Try it on your own. You will get the following error.
 
 ```
@@ -50,11 +50,11 @@ Try it on your own. You will get the following error.
 |     next: Option<Node<T>>,
 |     --------------------- recursive without indirection
  ```
- 
+
  The problem is that at compile time the size of next must be known.
  Since `next` is recursive ("a node has a node has a node..."), the compiler does not know how much memory is to be allocated.
  In contrast, [Box](https://doc.rust-lang.org/std/boxed/) is a heap pointer with a defined size.
- 
+
 
 ## Rust Installation
 


### PR DESCRIPTION
Closes #413.

I still don't know what the underlying root cause of this error is;
a variety of Markdown renderers have all struggled on the same line,
and each has produced a different output. The one thing all the output
has in common is that it's wrong.

Luckily, we don't need to know what's precisely wrong with this in
order to be able to fix it. This version should be much easier to
render consistently and correctly.