### PR TITLE
bob 1.1.0: Add yelling question rule

### DIFF
--- a/exercises/bob/Cargo.toml
+++ b/exercises/bob/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "bob"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -6,6 +6,8 @@ Bob answers 'Sure.' if you ask him a question.
 
 He answers 'Whoa, chill out!' if you yell at him.
 
+He answers 'Calm down, I know what I'm doing!' if you yell a question at him.
+
 He says 'Fine. Be that way!' if you address him without actually saying
 anything.
 

--- a/exercises/bob/example.rs
+++ b/exercises/bob/example.rs
@@ -1,5 +1,6 @@
 pub fn reply(message: &str) -> &str {
     if is_silence(message) { "Fine. Be that way!" }
+    else if is_yelling(message) && is_question(message) { "Calm down, I know what I'm doing!" }
     else if is_yelling(message) { "Whoa, chill out!" }
     else if is_question(message) { "Sure." }
     else { "Whatever." }

--- a/exercises/bob/tests/bob.rs
+++ b/exercises/bob/tests/bob.rs
@@ -52,7 +52,7 @@ fn test_using_acronyms_in_regular_speech() {
 #[test]
 #[ignore]
 fn test_forceful_question() {
-    assert_eq!("Whoa, chill out!",
+    assert_eq!("Calm down, I know what I'm doing!",
                bob::reply("WHAT THE HELL WERE YOU THINKING?"));
 }
 


### PR DESCRIPTION
Closes https://github.com/exercism/problem-specifications/issues/943.

It was possible for a message directed to Bob to be both a question and
yelling, which meant it was unclear which rule should take effect.
Resolve ambiguity by simply adding a rule for that case.

https://github.com/exercism/problem-specifications/pull/1025