### PR TITLE
isbn-verifier: Add test for long numeric ISBN

### DIFF
--- a/exercises/isbn-verifier/tests/isbn-verifier.rs
+++ b/exercises/isbn-verifier/tests/isbn-verifier.rs
@@ -81,3 +81,8 @@ fn test_invalid_isbn_too_long() {
 fn test_invalid_isbn_with_check_digit_X_instead_of_0() {
     assert!(!is_valid_isbn("3-598-21515-X"));
 }
+
+#[test]
+fn test_invalid_isbn_too_long_with_number() {
+    assert!(!is_valid_isbn("35982150881"));
+}


### PR DESCRIPTION
My initial [solution](http://exercism.io/submissions/fbfae36628fc4deb907fced6808362c2) would've failed this test case (a valid extended 11-test, adding an extra number, which would've been multiplied by a factor of 0, instead of X), so I added this case and a test for the length of the number.