### PR TITLE
scrabble-score: improve non-english letter tests

### DIFF
--- a/exercises/scrabble-score/tests/scrabble-score.rs
+++ b/exercises/scrabble-score/tests/scrabble-score.rs
@@ -71,6 +71,6 @@ fn all_letters_work() {
 #[test]
 #[ignore]
 fn german_letters_do_not_score() {
-    assert_eq!(score("STRASSE"), 7, "\"SS\" should score 2.");
+    assert_eq!(score("STRASSE"), 7, "\"SS\" should score 2");
     assert_eq!(score("STRAßE"), 5, "'ß' should score 0");
 }

--- a/exercises/scrabble-score/tests/scrabble-score.rs
+++ b/exercises/scrabble-score/tests/scrabble-score.rs
@@ -52,8 +52,8 @@ fn long_mixed_case_word() {
 #[test]
 #[ignore]
 fn non_english_scrabble_letters_do_not_score() {
-    assert_eq!(score("pinata"), 8);
-    assert_eq!(score("piñata"), 7);
+    assert_eq!(score("pinata"), 8, "'n' should score 1");
+    assert_eq!(score("piñata"), 7, "'ñ' should score 0");
 }
 
 #[test]
@@ -66,4 +66,11 @@ fn empty_words_are_worth_zero() {
 #[ignore]
 fn all_letters_work() {
     assert_eq!(score("abcdefghijklmnopqrstuvwxyz"), 87);
+}
+
+#[test]
+#[ignore]
+fn german_letters_do_not_score() {
+    assert_eq!(score("STRASSE"), 7, "\"SS\" should score 2.");
+    assert_eq!(score("STRAßE"), 5, "'ß' should score 0");
 }


### PR DESCRIPTION
Resolves #264.

Implements both of @dexterlemmer's proposals from that issue.