### PR TITLE
rna-transcription: Make DNA and RNA validate input on creation.

### DIFF
--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -1,4 +1,4 @@
-# Isbn Verifier
+# ISBN Verifier
 
 The [ISBN-10 verification process](https://en.wikipedia.org/wiki/International_Standard_Book_Number) is used to validate book identification
 numbers. These normally contain dashes and look like: `3-598-21508-8`

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -20,11 +20,11 @@ All subsequent codons after are ignored, like this:
 
 RNA: `"AUGUUUUCUUAAAUG"` =>
 
-Codons: `"AUG", "UUU", "UCU", "UAG", "AUG"` =>
+Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
 
 Protein: `"Methionine", "Phenylalanine", "Serine"`
 
-Note the stop codon terminates the translation and the final methionine is not translated into the protein sequence.
+Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
 
 Below are the codons and resulting Amino Acids needed for the exercise.
 

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -1,4 +1,4 @@
-# reverse-string
+# Reverse String
 
 Reverse a string
 

--- a/exercises/rna-transcription/.meta/hints.md
+++ b/exercises/rna-transcription/.meta/hints.md
@@ -1,0 +1,9 @@
+## Notes on Rust implementation
+
+By using private fields in structs with public `new` functions returning
+`Option` or `Result` (as here with `DNA::new` & `RNA::new`), we can guarantee
+that the internal representation of `DNA` is correct. Because every valid DNA
+string has a valid RNA string, we don't need to return a `Result`/`Option` from
+`to_rna`.
+
+This explains the type signatures you will see in the tests.

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -18,6 +18,17 @@ each nucleotide with its complement:
 * `T` -> `A`
 * `A` -> `U`
 
+## Notes on Rust implementation
+
+By using private fields in structs with public `new` functions returning
+`Option` or `Result` (as here with `DNA::new` & `RNA::new`), we can guarantee
+that the internal representation of `DNA` is correct. Because every valid DNA
+string has a valid RNA string, we don't need to return a `Result`/`Option` from
+`to_rna`.
+
+This explains the type signatures you will see in the tests.
+
+
 ## Rust Installation
 
 Refer to the [exercism help page][help-page] for Rust installation and learning

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -52,7 +52,7 @@ If you want to know more about Exercism, take a look at the [contribution guide]
 
 ## Source
 
-Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+Hyperphysics [http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html](http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rna-transcription/example.rs
+++ b/exercises/rna-transcription/example.rs
@@ -1,40 +1,79 @@
-#[derive(PartialEq, Eq, Debug)]
-pub struct RNA {
-    nucleotides: String
+
+
+/// The possible nucleotides in DNA and RNA
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum Nucleotide {
+    Adenine,
+    Cytosine,
+    Guanine,
+    Thymine,
+    Uracil
 }
 
-impl RNA {
-    pub fn new(nucleotides: &str) -> RNA {
-        RNA { nucleotides: nucleotides.to_string() }
+impl Nucleotide {
+    /// Parses a nucleotode from its character value, if valid.
+    fn from_char(ch: char) -> Option<Nucleotide> {
+        Some(match ch {
+            'A' => Nucleotide::Adenine,
+            'C' => Nucleotide::Cytosine,
+            'G' => Nucleotide::Guanine,
+            'T' => Nucleotide::Thymine,
+            'U' => Nucleotide::Uracil,
+            _ => { return None; }
+        })
     }
 }
 
-#[derive(PartialEq, Eq, Debug)]
-pub struct DNA {
-    nucleotides: String
-}
-
-fn transcribe_dna_rna(c: char) -> Option<char> {
-    match c {
-        'C' => Some('G'),
-        'G' => Some('C'),
-        'A' => Some('U'),
-        'T' => Some('A'),
-        _   => None
-    }
-}
+/// A vector of nucleotides
+///
+/// Guaranteed that Uracil is not present thanks to `new`.
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct DNA(Vec<Nucleotide>);
 
 impl DNA {
-    pub fn new(nucleotides: &str) -> DNA {
-        DNA { nucleotides: nucleotides.to_string() }
+    /// Parse a DNA string, checking it is valid.
+    ///
+    /// The error value is the first invalid character index (char index, not utf8).
+    pub fn new(input: &str) -> Result<DNA, usize> {
+        let mut out = Vec::new();
+        for (idx, ch) in input.chars().enumerate() {
+            match Nucleotide::from_char(ch) {
+                Some(Nucleotide::Uracil) | None => { return Err(idx); },
+                Some(n) => { out.push(n);  },
+            }
+        }
+        Ok(DNA(out))
     }
 
-    pub fn to_rna(&self) -> Result<RNA, ()> {
-        let rna_nucleotides: String = self.nucleotides.chars().filter_map(transcribe_dna_rna).collect();
-        if rna_nucleotides.len() == self.nucleotides.len() {
-            Ok(RNA { nucleotides: rna_nucleotides })
-        } else {
-            Err(())
+    pub fn to_rna(mut self) -> RNA {
+        for nuc in self.0.iter_mut() {
+            *nuc = match *nuc {
+                Nucleotide::Adenine => Nucleotide::Uracil,
+                Nucleotide::Cytosine => Nucleotide::Guanine,
+                Nucleotide::Guanine => Nucleotide::Cytosine,
+                Nucleotide::Thymine => Nucleotide::Adenine,
+                Nucleotide::Uracil => unreachable!()
+            }
         }
+        RNA(self.0)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct RNA(Vec<Nucleotide>);
+
+impl RNA {
+    /// Parse a RNA string, checking it is valid.
+    ///
+    /// The error value is the first invalid character index (char index, not utf8).
+    pub fn new(input: &str) -> Result<RNA, usize> {
+        let mut out = Vec::new();
+        for (idx, ch) in input.chars().enumerate() {
+            match Nucleotide::from_char(ch) {
+                Some(Nucleotide::Thymine) | None => { return Err(idx); },
+                Some(n) => { out.push(n);  },
+            }
+        }
+        Ok(RNA(out))
     }
 }

--- a/exercises/rna-transcription/tests/rna-transcription.rs
+++ b/exercises/rna-transcription/tests/rna-transcription.rs
@@ -1,55 +1,88 @@
 extern crate rna_transcription as dna;
 
 #[test]
+fn test_valid_dna_input() {
+    assert!(dna::DNA::new("GCTA").is_ok());
+}
+
+#[test]
+#[ignore]
+fn test_valid_rna_input() {
+    assert!(dna::RNA::new("CGAU").is_ok());
+}
+
+#[test]
+#[ignore]
+fn test_invalid_dna_input() {
+    // Invalid character
+    assert!(dna::DNA::new("X").is_err());
+    // Valid nucleotide, but invalid in context
+    assert!(dna::DNA::new("U").is_err());
+    // Longer string with contained errors
+    assert!(dna::DNA::new("ACGTUXXCTTAA").is_err());
+}
+
+#[test]
+#[ignore]
+fn test_invalid_rna_input() {
+    // Invalid character
+    assert!(dna::RNA::new("X").is_err());
+    // Valid nucleotide, but invalid in context
+    assert!(dna::RNA::new("T").is_err());
+    // Longer string with contained errors
+    assert!(dna::RNA::new("ACGUTTXCUUAA").is_err());
+}
+
+#[test]
+#[ignore]
 fn test_acid_equals_acid() {
-    assert_eq!(dna::RNA::new("CGA"), dna::RNA::new("CGA"));
-    assert_ne!(dna::RNA::new("CGA"), dna::RNA::new("AGC"));
+    assert_eq!(dna::DNA::new("CGA").unwrap(), dna::DNA::new("CGA").unwrap());
+    assert_ne!(dna::DNA::new("CGA").unwrap(), dna::DNA::new("AGC").unwrap());
+    assert_eq!(dna::RNA::new("CGA").unwrap(), dna::RNA::new("CGA").unwrap());
+    assert_ne!(dna::RNA::new("CGA").unwrap(), dna::RNA::new("AGC").unwrap());
 }
 
 #[test]
 #[ignore]
 fn test_transcribes_cytosine_guanine() {
-    assert_eq!(Ok(dna::RNA::new("G")), dna::DNA::new("C").to_rna());
+    assert_eq!(
+        dna::RNA::new("G").unwrap(),
+        dna::DNA::new("C").unwrap().to_rna()
+    );
 }
 
 #[test]
 #[ignore]
 fn test_transcribes_guanine_cytosine() {
-    assert_eq!(Ok(dna::RNA::new("C")), dna::DNA::new("G").to_rna());
+    assert_eq!(
+        dna::RNA::new("C").unwrap(),
+        dna::DNA::new("G").unwrap().to_rna()
+    );
 }
 
 #[test]
 #[ignore]
 fn test_transcribes_adenine_uracil() {
-    assert_eq!(Ok(dna::RNA::new("U")), dna::DNA::new("A").to_rna());
+    assert_eq!(
+        dna::RNA::new("U").unwrap(),
+        dna::DNA::new("A").unwrap().to_rna()
+    );
 }
 
 #[test]
 #[ignore]
 fn test_transcribes_thymine_to_adenine() {
-    assert_eq!(Ok(dna::RNA::new("A")), dna::DNA::new("T").to_rna());
+    assert_eq!(
+        dna::RNA::new("A").unwrap(),
+        dna::DNA::new("T").unwrap().to_rna()
+    );
 }
 
 #[test]
 #[ignore]
 fn test_transcribes_all_dna_to_rna() {
-    assert_eq!(Ok(dna::RNA::new("UGCACCAGAAUU")), dna::DNA::new("ACGTGGTCTTAA").to_rna())
-}
-
-#[test]
-#[ignore]
-fn handles_invalid_input() {
-    assert!(dna::DNA::new("U").to_rna().is_err());
-}
-
-#[test]
-#[ignore]
-fn handles_completely_invalid_input() {
-    assert!(dna::DNA::new("XXX").to_rna().is_err());
-}
-
-#[test]
-#[ignore]
-fn handles_partially_invalid_input() {
-    assert!(dna::DNA::new("ACGTXXXCTTAA").to_rna().is_err());
+    assert_eq!(
+        dna::RNA::new("UGCACCAGAAUU").unwrap(),
+        dna::DNA::new("ACGTGGTCTTAA").unwrap().to_rna()
+    )
 }


### PR DESCRIPTION
PR to address issue #423.

The tests are re-ordered because it is natural to test validation before `to_rna` using the changed data structures.