### PR TITLE
robot-name: Move rand dependency to Cargo-example.toml

### DIFF
--- a/exercises/robot-name/Cargo-example.toml
+++ b/exercises/robot-name/Cargo-example.toml
@@ -3,3 +3,4 @@ name = "robot-name"
 version = "0.0.0"
 
 [dependencies]
+rand = "0.3.12"


### PR DESCRIPTION
Closes #431

Exercise has no library stubs which require the rand crate, so
dependency is removed. Students should learn to use crates.io
to search for dependencies such as this on their own.