### PR TITLE
react: Express callback expectations precisely after each `set_value`

### DIFF
--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -2,39 +2,6 @@ extern crate react;
 
 use react::*;
 
-struct CallbackRecorder {
-    // Note that this `Cell` is https://doc.rust-lang.org/std/cell/
-    // a mechanism to allow internal mutability,
-    // distinct from the cells (input cells, compute cells) in the reactor
-    value: std::cell::Cell<Option<isize>>,
-}
-
-/// A CallbackRecorder helps tests whether callbacks get called correctly.
-/// You'll see it used in tests that deal with callbacks.
-/// The names should be descriptive enough so that the tests make sense,
-/// so it's not necessary to fully understand the implementation,
-/// though you are welcome to.
-impl CallbackRecorder {
-    fn new() -> Self {
-        CallbackRecorder {
-            value: std::cell::Cell::new(None),
-        }
-    }
-
-    fn expect_to_have_been_called_with(&self, v: isize) {
-        assert_ne!(self.value.get(), None, "Callback was not called, but should have been");
-        assert_eq!(self.value.replace(None), Some(v), "Callback was called with incorrect value");
-    }
-
-    fn expect_not_to_have_been_called(&self) {
-        assert_eq!(self.value.get(), None, "Callback was called, but should not have been");
-    }
-
-    fn callback_called(&self, v: isize) {
-        assert_eq!(self.value.replace(Some(v)), None, "Callback was called too many times; can't be called with {}", v);
-    }
-}
-
 #[test]
 fn input_cells_have_a_value() {
     let mut reactor = Reactor::new();
@@ -130,6 +97,39 @@ fn error_setting_a_compute_cell() {
     let input = reactor.create_input(1);
     let output = reactor.create_compute(&[input], |_| 0).unwrap();
     assert!(reactor.set_value(output, 3).is_err());
+}
+
+struct CallbackRecorder {
+    // Note that this `Cell` is https://doc.rust-lang.org/std/cell/
+    // a mechanism to allow internal mutability,
+    // distinct from the cells (input cells, compute cells) in the reactor
+    value: std::cell::Cell<Option<isize>>,
+}
+
+/// A CallbackRecorder helps tests whether callbacks get called correctly.
+/// You'll see it used in tests that deal with callbacks.
+/// The names should be descriptive enough so that the tests make sense,
+/// so it's not necessary to fully understand the implementation,
+/// though you are welcome to.
+impl CallbackRecorder {
+    fn new() -> Self {
+        CallbackRecorder {
+            value: std::cell::Cell::new(None),
+        }
+    }
+
+    fn expect_to_have_been_called_with(&self, v: isize) {
+        assert_ne!(self.value.get(), None, "Callback was not called, but should have been");
+        assert_eq!(self.value.replace(None), Some(v), "Callback was called with incorrect value");
+    }
+
+    fn expect_not_to_have_been_called(&self) {
+        assert_eq!(self.value.get(), None, "Callback was called, but should not have been");
+    }
+
+    fn callback_called(&self, v: isize) {
+        assert_eq!(self.value.replace(Some(v)), None, "Callback was called too many times; can't be called with {}", v);
+    }
 }
 
 #[test]

--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -99,6 +99,11 @@ fn error_setting_a_compute_cell() {
     assert!(reactor.set_value(output, 3).is_err());
 }
 
+/// A CallbackRecorder helps tests whether callbacks get called correctly.
+/// You'll see it used in tests that deal with callbacks.
+/// The names should be descriptive enough so that the tests make sense,
+/// so it's not necessary to fully understand the implementation,
+/// though you are welcome to.
 struct CallbackRecorder {
     // Note that this `Cell` is https://doc.rust-lang.org/std/cell/
     // a mechanism to allow internal mutability,
@@ -106,11 +111,6 @@ struct CallbackRecorder {
     value: std::cell::Cell<Option<isize>>,
 }
 
-/// A CallbackRecorder helps tests whether callbacks get called correctly.
-/// You'll see it used in tests that deal with callbacks.
-/// The names should be descriptive enough so that the tests make sense,
-/// so it's not necessary to fully understand the implementation,
-/// though you are welcome to.
 impl CallbackRecorder {
     fn new() -> Self {
         CallbackRecorder {


### PR DESCRIPTION
react: Express callback expectations precisely after each `set_value`

**Problem statement**:

Consider a test with two `set_value` calls and which expects that a
callback has, ultimately, been called with the two values, one for each
`set_value`.

The tests currently do not check that one value was added during each
`set_value` call. For all we know, maybe an implementation:

* magically manages to predict the future and calls the callback twice
  on the first `set_value` call, with the correct value.
* calls the callback zero times on the first `set_value` call, but twice
  on the second `set_value` call.

To more precisely define the `set_value` expectations, this commit uses
a `Cell`-based implementation to test callbacks.

---

**Discussion**:

Is this clearer to students than the old vector-based approach? It is
certainly true that the expectations are closer to the line of code that
could cause the expectations to fail; each `set_value` now shows exactly
what callback calls are expected as a result of it. I would argue this
is does increase test clarity.

Some questions I will have:

* Is there any potential for student confusion if they were to read the
  implementation of the `Expector` class? Any way to alleviate that
  confusion?
* A better name for `Expector`. It was chosen arbitrarily simply because
  it is something that expects.
* Whether this can in fact be done without Cell. I tried my best but
  could not find a way.

It behooves me to explain why I could not. If the reason is already obvious to you because of your knowledge of Rust, you can probably skip this part, then.

If the callback mutably borrows something (say, to record what value it was called with), the rest of the test code cannot borrow that same thing to check that the values are correct. Same if we try to go vice-versa: If the test code mutably borrows something to signal to the callback "I am going to call set_value now so it is safe for you to let one more value through", the callback cannot have immutably borrowed it to check that signal. So it seems the only sharing the two can do is through both of them immutably borrowing something.

If they must both immutably borrow something, it seems that at least one of them will nevertheless need to mutate something. ~~Thus, it seems to be the case that we must achieve dynamic (runtime-checked, instead of compile-time-checked) borrowing, by using a RefCell.~~
After experimentation, we can use a Cell, preferable because now there is no dynamic borrowing.