### PR TITLE
no-op declare compliance with problem-specifications for any input object change

### DIFF
--- a/exercises/allergies/Cargo.toml
+++ b/exercises/allergies/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "allergies"
-version = "1.0.0"
+version = "1.1.0"
 

--- a/exercises/atbash-cipher/Cargo.toml
+++ b/exercises/atbash-cipher/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "atbash-cipher"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/binary-search/Cargo.toml
+++ b/exercises/binary-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary-search"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["<marco.stahl@mailbox.org>"]
 
 [dependencies]

--- a/exercises/bob/Cargo.toml
+++ b/exercises/bob/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "bob"
-version = "1.1.0"
+version = "1.2.0"

--- a/exercises/bracket-push/Cargo.toml
+++ b/exercises/bracket-push/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "bracket-push"
-version = "1.1.0"
+version = "1.2.0"

--- a/exercises/collatz-conjecture/Cargo.toml
+++ b/exercises/collatz-conjecture/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "collatz_conjecture"
-version = "1.1.1"
+version = "1.2.0"

--- a/exercises/difference-of-squares/Cargo.toml
+++ b/exercises/difference-of-squares/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "difference-of-squares"
-version = "1.1.0"
+version = "1.2.0"

--- a/exercises/dominoes/Cargo.toml
+++ b/exercises/dominoes/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "dominoes"
-version = "2.0.0"
+version = "2.1.0"

--- a/exercises/gigasecond/Cargo.toml
+++ b/exercises/gigasecond/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gigasecond"
-version = "1.0.0"
+version = "1.1.0"
 
 [dependencies]
 chrono = "0.4"

--- a/exercises/grains/Cargo.toml
+++ b/exercises/grains/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "grains"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/hello-world/Cargo.toml
+++ b/exercises/hello-world/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "hello-world"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/isogram/Cargo.toml
+++ b/exercises/isogram/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "isogram"
-version = "1.2.0"
+version = "1.3.0"

--- a/exercises/largest-series-product/Cargo.toml
+++ b/exercises/largest-series-product/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "largest-series-product"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/minesweeper/Cargo.toml
+++ b/exercises/minesweeper/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "minesweeper"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/pascals-triangle/Cargo.toml
+++ b/exercises/pascals-triangle/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "pascals-triangle"
-version = "1.2.0"
+version = "1.3.0"

--- a/exercises/perfect-numbers/Cargo.toml
+++ b/exercises/perfect-numbers/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "perfect_numbers"
-version = "1.0.1"
+version = "1.1.0"
 
 [dependencies]

--- a/exercises/poker/Cargo.toml
+++ b/exercises/poker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poker"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Peter Goodspeed-Niklaus <peter.r.goodspeedniklaus@gmail.com>"]
 
 [dependencies]

--- a/exercises/prime-factors/Cargo.toml
+++ b/exercises/prime-factors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prime_factors"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["sacherjj <sacherjj@gmail.com>"]
 
 [dependencies]

--- a/exercises/queen-attack/Cargo.toml
+++ b/exercises/queen-attack/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "queen-attack"
-version = "1.0.0"
+version = "2.1.0"

--- a/exercises/raindrops/Cargo.toml
+++ b/exercises/raindrops/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "raindrops"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/react/Cargo.toml
+++ b/exercises/react/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "react"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/rectangles/Cargo.toml
+++ b/exercises/rectangles/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "rectangles"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/robot-simulator/Cargo.toml
+++ b/exercises/robot-simulator/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "robot-simulator"
-version = "1.0.0"
+version = "2.2.0"

--- a/exercises/run-length-encoding/Cargo.toml
+++ b/exercises/run-length-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "run-length-encoding"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["zombiefungus <divmermarlav@gmail.com>"]
 
 [dependencies]

--- a/exercises/saddle-points/Cargo.toml
+++ b/exercises/saddle-points/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "saddle-points"
-version = "1.0.0"
+version = "1.1.0"
 
 [dependencies]

--- a/exercises/say/Cargo.toml
+++ b/exercises/say/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "say"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["sacherjj <sacherjj@gmail.com>"]

--- a/exercises/scrabble-score/Cargo.toml
+++ b/exercises/scrabble-score/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "scrabble-score"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/sieve/Cargo.toml
+++ b/exercises/sieve/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "sieve"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/space-age/Cargo.toml
+++ b/exercises/space-age/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "space-age"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/tournament/Cargo.toml
+++ b/exercises/tournament/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "tournament"
-version = "1.3.0"
+version = "1.4.0"

--- a/exercises/variable-length-quantity/Cargo.toml
+++ b/exercises/variable-length-quantity/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "variable-length-quantity"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/wordy/Cargo.toml
+++ b/exercises/wordy/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "wordy"
-version = "1.0.0"
+version = "1.1.0"


### PR DESCRIPTION
In https://github.com/exercism/problem-specifications/issues/996 it was proposed that inputs will be moved to the input object.

It was enacted across all the exercises.

For those exercises for which the input type is the only reason the Rust track is no longer up to date, those exercises are now declared to be up to date.

**No attempt** was made to update any exercise that was out of date for **any other reason**. The author has no interest in writing the test generators at this time, nor making any changes by hand.

The up-to-date determination was done in the usual manner (https://github.com/petertseng/exercism-problem-specifications/blob/up-to-date/up-to-date/rust.rb).

All commit contents were generated by the following script.
With the exception of queen-attack and robot-simulator (written by hand), all commits messages were also generated by the following script

```ruby
require 'json'

pr = ARGV.last

repo_root = `git rev-parse --show-toplevel`.chomp
exercise = ARGV.size > 1 ? ARGV.first.delete(?/) : `pwd`.chomp.split(?/).last
ver = JSON.parse(File.read("#{repo_root}/../problem-specifications/exercises/#{exercise}/canonical-data.json"))['version']

version_file = "#{repo_root}/exercises/#{exercise}/Cargo.toml"

lines = File.readlines(version_file)
File.open(version_file, ?w) { |f|
  lines.each { |l|
    f.write(l.include?('version') ? "version = \"#{ver}\"\n" : l)
  }
}

m = "#{exercise} #{ver}: no-op declare compliance with problem-specifications

input object

https://github.com/exercism/problem-specifications/pull/#{pr}"

`git commit --all -m '#{m}'`

puts m
```

--- 

Question:

https://github.com/exercism/discussions/issues/133#issuecomment-367964538

> If test version lived in a separate file in `.meta`, I'd find it pretty easy to accidentally forget to update it when updating an exercise.

So, does this also apply to the version being in Cargo.toml?