### PR TITLE
gigasecond: Update dependency to conform to usage guidelines

### DIFF
--- a/exercises/gigasecond/.meta/hints.md
+++ b/exercises/gigasecond/.meta/hints.md
@@ -1,0 +1,1 @@
+If you're unsure what operations you can perform on `DateTime<Utc>` take a look at the [chrono crate](https://docs.rs/chrono/0.4.0/chrono/) which is listed as a dependency in the `Cargo.toml` file for this exercise.

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -4,6 +4,9 @@ Calculate the moment when someone has lived for 10^9 seconds.
 
 A gigasecond is 10^9 (1,000,000,000) seconds.
 
+If you're unsure what operations you can perform on `DateTime<Utc>` take a look at the [chrono crate](https://docs.rs/chrono/0.4.0/chrono/) which is listed as a dependency in the `Cargo.toml` file for this exercise.
+
+
 ## Rust Installation
 
 Refer to the [exercism help page][help-page] for Rust installation and learning

--- a/exercises/gigasecond/example.rs
+++ b/exercises/gigasecond/example.rs
@@ -1,5 +1,5 @@
 extern crate chrono;
-use chrono::*;
+use chrono::{DateTime, Duration, Utc};
 
 pub fn after(start: DateTime<Utc>) -> DateTime<Utc> {
     start + Duration::seconds(1_000_000_000)

--- a/exercises/gigasecond/src/lib.rs
+++ b/exercises/gigasecond/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate chrono;
-use chrono::*;
+use chrono::{DateTime, Utc};
 
 // Returns a Utc DateTime one billion seconds after start.
 pub fn after(start: DateTime<Utc>) -> DateTime<Utc> {
-    unimplemented!()
+    unimplemented!("What time is a gigasecond later than {}", start);
 }

--- a/exercises/gigasecond/tests/gigasecond.rs
+++ b/exercises/gigasecond/tests/gigasecond.rs
@@ -13,7 +13,7 @@ extern crate gigasecond;
  * In order to use the crate, your solution will need to start with the two following lines
 */
 extern crate chrono;
-use chrono::*;
+use chrono::{TimeZone, Utc};
 
 #[test]
 fn test_date() {


### PR DESCRIPTION
This updates the dependencies for the gigasecond exercise to conform to the [usage guidelines](https://docs.rs/chrono/0.4.0/chrono/#usage) for the [chrono](https://docs.rs/chrono/0.4.0/chrono) cargo package:
> Avoid using use chrono::*; as Chrono exports several modules other than types. If you prefer the glob imports, use the following instead:

I realize using `chrono::*` might have been an intentional decision to avoid having to expose beginners to importing `time::Duration` as well, but I think it probably makes more sense to mirror a real environment closely when exposing people to these exercises.

I tried to make the minimum number of changes here and ensured that `_test/check-exercises.sh` was able to validate the gigasecond exercise before submitting.
