### PR TITLE
nth-prime: Provide a function template

### DIFF
--- a/exercises/nth-prime/example.rs
+++ b/exercises/nth-prime/example.rs
@@ -9,10 +9,10 @@ fn is_prime(n: u32) -> bool {
    return true;
 }
 
-pub fn nth(n: u32) -> Result<u32, ()> {
+pub fn nth(n: u32) -> Option<u32> {
     match n {
-        0 => Err(()),
-        1 => Ok(2),
+        0 => None,
+        1 => Some(2),
         _ => {
             let mut count: u32 = 1;
             let mut candidate: u32 = 1;
@@ -22,7 +22,7 @@ pub fn nth(n: u32) -> Result<u32, ()> {
                     count += 1;
                 }
             }
-            Ok(candidate)
+            Some(candidate)
         }
     }
 }

--- a/exercises/nth-prime/src/lib.rs
+++ b/exercises/nth-prime/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn nth(n: u32) -> Option<u32> {
+    unimplemented!("What is the {}th prime number?", n)
+}

--- a/exercises/nth-prime/tests/nth-prime.rs
+++ b/exercises/nth-prime/tests/nth-prime.rs
@@ -2,29 +2,29 @@ extern crate nth_prime as np;
 
 #[test]
 fn test_first_prime() {
-    assert_eq!(np::nth(1), Ok(2));
+    assert_eq!(np::nth(1), Some(2));
 }
 
 #[test]
 #[ignore]
 fn test_second_prime() {
-    assert_eq!(np::nth(2), Ok(3));
+    assert_eq!(np::nth(2), Some(3));
 }
 
 #[test]
 #[ignore]
 fn test_sixth_prime() {
-    assert_eq!(np::nth(6), Ok(13));
+    assert_eq!(np::nth(6), Some(13));
 }
 
 #[test]
 #[ignore]
 fn test_big_prime() {
-    assert_eq!(np::nth(10001), Ok(104743));
+    assert_eq!(np::nth(10001), Some(104743));
 }
 
 #[test]
 #[ignore]
 fn test_zeroth_prime() {
-    assert!(np::nth(0).is_err());
+    assert_eq!(np::nth(0), None);
 }


### PR DESCRIPTION
I found it a bit confusing when I pulled down this exercise and didn't have a template for the function. Ended up pulling the function name and type out of the `tests/nth-prime.rs` file but I think having this in place would help myself and others.

One alternate approach would be to use a return type of `Result<usize, &'a str>` to allow `Err("Some message")` values.

The full function definition would then be:
```
pub fn nth<'a>(n: usize) -> Result<usize, &'a str> {
    unimplemented!()
}
```

I wasn't sure if this was better, worse or of no consequence since it introduces the `'a` lifetime annotations as well.

I tried to make the minimum number of changes here and ensured that `_test/check-exercises.sh` was able to validate the nth-prime exercise before submitting.