### PR TITLE
reverse-string: Update function template to use a variable name instead of an underscore

### DIFF
--- a/exercises/reverse-string/src/lib.rs
+++ b/exercises/reverse-string/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn reverse(_: &str) -> String {
+pub fn reverse(input: &str) -> String {
     unimplemented!()
 }

--- a/exercises/reverse-string/src/lib.rs
+++ b/exercises/reverse-string/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn reverse(input: &str) -> String {
-    unimplemented!()
+    unimplemented!("Write a function to reverse {}", input);
 }


### PR DESCRIPTION
Basically as-titled. It took me an embarrassing amount of time to figure out how to reference the `_` in the current function template (i.e. change it to something else). I've really enjoyed the Rust track so far, just trying to help clarify what I found confusing. 😄 

I tried to make the minimum number of changes here and ensured that `_test/check-exercises.sh` was able to validate the reverse-string exercise before submitting.