### PR TITLE
collatz-conjecture: Use Option<T> instead of Result<T, str>

### DIFF
--- a/config.json
+++ b/config.json
@@ -172,7 +172,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "error handling with Result<T, E>"
+        "Option"
       ]
     },
     {

--- a/exercises/collatz-conjecture/example.rs
+++ b/exercises/collatz-conjecture/example.rs
@@ -10,10 +10,10 @@ pub fn collatz_positive(n: u64) -> u64 {
 }
 
 // return Ok(x) where x is the number of steps required to reach 1
-pub fn collatz(n: u64) -> Result<u64, &'static str> {
+pub fn collatz(n: u64) -> Option<u64> {
     if n < 1 {
-        Err("Only positive numbers are allowed")
+        None
     } else {
-        Ok(collatz_positive(n))
+        Some(collatz_positive(n))
     }
 }

--- a/exercises/collatz-conjecture/src/lib.rs
+++ b/exercises/collatz-conjecture/src/lib.rs
@@ -1,4 +1,4 @@
-// return Ok(x) where x is the number of steps required to reach 1
-pub fn collatz(n: u64) -> Result<u64, &'static str> {
+// return Some(x) where x is the number of steps required to reach 1
+pub fn collatz(n: u64) -> Option<u64> {
     unimplemented!()
 }

--- a/exercises/collatz-conjecture/tests/collatz-conjecture.rs
+++ b/exercises/collatz-conjecture/tests/collatz-conjecture.rs
@@ -4,29 +4,29 @@ use collatz_conjecture::*;
 
 #[test]
 fn test_1() {
-    assert_eq!(Ok(0), collatz(1));
+    assert_eq!(Some(0), collatz(1));
 }
 
 #[test]
 #[ignore]
 fn test_16() {
-    assert_eq!(Ok(4), collatz(16));
+    assert_eq!(Some(4), collatz(16));
 }
 
 #[test]
 #[ignore]
 fn test_12() {
-    assert_eq!(Ok(9), collatz(12));
+    assert_eq!(Some(9), collatz(12));
 }
 
 #[test]
 #[ignore]
 fn test_1000000() {
-    assert_eq!(Ok(152), collatz(1000000));
+    assert_eq!(Some(152), collatz(1000000));
 }
 
 #[test]
 #[ignore]
 fn test_0() {
-    assert!(collatz(0).is_err());
+    assert_eq!(None, collatz(0));
 }


### PR DESCRIPTION
**Preface**: I'd like to open this PR as a discussion of when we should use Option vs Result. The result of this discussion might also be applicable to perfect-numbers.

---

Since there is only one kind of error that can occur (a non-positive
number), no extra information is given by the `str`, and I do not like
to encourage using `str` as an error type.

I examined a user poll of when to use Result vs Option:
https://www.reddit.com/r/rust/comments/2j0k21/rust_option_vs_result/

One user says to use Option when there is only one failure mode, which
supports the approach taken in this commit.

However, in contrast, there are others who say Result is for any case
when you need to explain the failure. It is possible that we may want to
explain the failure even if there is only one way for a function to
fail.

So the question is whether this error warrants an explanation. Perhaps
any necessary explanation can be produced in the documentation... and
the documentation here does say take any **positive** integer.