### PR TITLE
perfect-numbers: Use Option<T> instead of Result<T, str>

### DIFF
--- a/exercises/perfect-numbers/example.rs
+++ b/exercises/perfect-numbers/example.rs
@@ -1,14 +1,14 @@
-pub fn classify(num: u64) -> Result<Classification, & 'static str> {
+pub fn classify(num: u64) -> Option<Classification> {
     if num == 0 {
-        return Err("Number must be positive");
+        return None;
     }
     let sum: u64 = (1..num).filter(|i| num%i == 0).sum();
     if sum == num {
-        Ok(Classification::Perfect)
+        Some(Classification::Perfect)
     } else if sum < num {
-        Ok(Classification::Deficient)
+        Some(Classification::Deficient)
     } else {
-        Ok(Classification::Abundant)
+        Some(Classification::Abundant)
     }
 }
 

--- a/exercises/perfect-numbers/src/lib.rs
+++ b/exercises/perfect-numbers/src/lib.rs
@@ -5,6 +5,6 @@ pub enum Classification {
     Deficient
 }
 
-pub fn classify(num: u64) -> Result<Classification, & 'static str> {
+pub fn classify(num: u64) -> Option<Classification> {
     unimplemented!();
 }

--- a/exercises/perfect-numbers/tests/perfect-numbers.rs
+++ b/exercises/perfect-numbers/tests/perfect-numbers.rs
@@ -17,12 +17,12 @@ macro_rules! tests {
 }
 
 fn test_classification(num: u64, result: Classification) {
-    assert_eq!(classify(num), Ok(result));
+    assert_eq!(classify(num), Some(result));
 }
 
 #[test]
 fn basic() {
-    assert_eq!(classify(0), Err("Number must be positive"));
+    assert_eq!(classify(0), None);
 }
 
 


### PR DESCRIPTION
Since there is only one kind of error that can occur (a non-positive
number), no extra information is given by the `str`, and I do not like
to encourage using `str` as an error type.

I examined a user poll of when to use Result vs Option:
https://www.reddit.com/r/rust/comments/2j0k21/rust_option_vs_result/

One user says to use Option when there is only one failure mode, which
supports the approach taken in this commit.

Same operation as that performed for collatz-conjecture in
https://github.com/exercism/rust/pull/441