### PR TITLE
check-exercises: Output progress dot when DENYWARNINGS

### DIFF
--- a/_test/check-exercises.sh
+++ b/_test/check-exercises.sh
@@ -45,6 +45,9 @@ for exercise in $files; do
       # Compiler errors will still be shown though.
       # Both flags are necessary to keep things quiet.
       ./bin/test-exercise $directory --quiet --no-run
+      # Output a progress dot; otherwise Travis may assume we're hung,
+      # if we don't produce output in > 10 mins.
+      echo -n '.'
       return_code=$(($return_code | $?))
    else
       # Run the test and get the status


### PR DESCRIPTION
Otherwise, Travis may assume we're hung if we don't produce output in
10+ minutes. Normally we don't think checking all exercises takes this
long, but this prepares for the future and prevents spurious failures in
instances when outside circumstances cause slowness.

This approach was suggested in response to such a failure in
https://github.com/exercism/rust/pull/435#issuecomment-368254549