### PR TITLE
check-exercises: Move `echo` before `test-exercise`

### DIFF
--- a/_test/check-exercises.sh
+++ b/_test/check-exercises.sh
@@ -39,15 +39,15 @@ for exercise in $files; do
    fi
 
    if [ -n "$DENYWARNINGS" ]; then
+      # Output a progress dot; otherwise Travis may assume we're hung,
+      # if we don't produce output in > 10 mins.
+      echo -n '.'
       # No-run mode so we see no test output.
       # Quiet mode so we see no compile output
       # (such as "Compiling"/"Downloading").
       # Compiler errors will still be shown though.
       # Both flags are necessary to keep things quiet.
       ./bin/test-exercise $directory --quiet --no-run
-      # Output a progress dot; otherwise Travis may assume we're hung,
-      # if we don't produce output in > 10 mins.
-      echo -n '.'
       return_code=$(($return_code | $?))
    else
       # Run the test and get the status


### PR DESCRIPTION
Notice that below `test-exercise` there is a check of `$?`. This means
nothing should come after `text-exercise`.

If we fail to do this, warnings will never cause the build to fail (as
we would like them to), because the `$?` is examining the exit code of
`echo`.

We need to move the `echo` (progress dot) that we added in
https://github.com/exercism/rust/pull/446
https://github.com/exercism/rust/pull/446/commits/a3a7b16c0715d03be93e942ef55ec136917ff3b5