### PR TITLE
Added armstrong-numbers exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -166,6 +166,16 @@
       ]
     },
     {
+      "uuid": "e652139e-ff3f-4e03-9810-d21f8b0c9e60",
+      "slug": "armstrong-numbers",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "mathematics"
+      ]
+    },
+    {
       "uuid": "f9afd650-8103-4373-a284-fa4ecfee7207",
       "slug": "collatz-conjecture",
       "core": false,

--- a/exercises/armstrong-numbers/.gitignore
+++ b/exercises/armstrong-numbers/.gitignore
@@ -1,0 +1,3 @@
+# Ignore Cargo.lock if creating a library
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/exercises/armstrong-numbers/Cargo.toml
+++ b/exercises/armstrong-numbers/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "armstrong_numbers"
+version = "1.0.0"
+authors = ["Shing Tak Lam <shingtaklam1324@gmail.com>"]
+
+[dependencies]

--- a/exercises/armstrong-numbers/Cargo.toml
+++ b/exercises/armstrong-numbers/Cargo.toml
@@ -1,6 +1,3 @@
 [package]
 name = "armstrong_numbers"
-version = "1.0.0"
-authors = ["Shing Tak Lam <shingtaklam1324@gmail.com>"]
-
-[dependencies]
+version = "0.0.0"

--- a/exercises/armstrong-numbers/Cargo.toml
+++ b/exercises/armstrong-numbers/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "armstrong_numbers"
-version = "0.0.0"
+version = "1.0.0"

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -1,0 +1,51 @@
+# Armstrong Numbers
+
+An [Armstrong number](https://en.wikipedia.org/wiki/Narcissistic_number) is a number that is the sum of its own digits each raised to the power of the number of digits.
+
+For example:
+
+- 9 is an Armstrong number, because `9 = 9^1 = 9`
+- 10 is *not* an Armstrong number, because `10 != 1^2 + 0^2 = 2`
+- 153 is an Armstrong number, because: `153 = 1^3 + 5^3 + 3^3 = 1 + 125 + 27 = 153`
+- 154 is *not* an Armstrong number, because: `154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190`
+
+Write some code to determine whether a number is an Armstrong number.
+
+## Rust Installation
+
+Refer to the [exercism help page][help-page] for Rust installation and learning
+resources.
+
+## Writing the Code
+
+Execute the tests with:
+
+```bash
+$ cargo test
+```
+
+All but the first test have been ignored.  After you get the first test to
+pass, remove the ignore flag (`#[ignore]`) from the next test and get the tests
+to pass again.  The test file is located in the `tests` directory.   You can
+also remove the ignore flag from all the tests to get them to run all at once
+if you wish.
+
+Make sure to read the [Modules](https://doc.rust-lang.org/book/second-edition/ch07-00-modules.html) chapter if you
+haven't already, it will help you with organizing your files.
+
+## Feedback, Issues, Pull Requests
+
+The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the [rust track team](https://github.com/orgs/exercism/teams/rust) are happy to help!
+
+If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
+
+[help-page]: http://exercism.io/languages/rust
+[modules]: https://doc.rust-lang.org/book/second-edition/ch07-00-modules.html
+[cargo]: https://doc.rust-lang.org/book/second-edition/ch14-00-more-about-cargo.html
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Narcissistic_number](https://en.wikipedia.org/wiki/Narcissistic_number)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/armstrong-numbers/example.rs
+++ b/exercises/armstrong-numbers/example.rs
@@ -1,0 +1,18 @@
+//! Example implementation for armstrong-numbers
+//!
+//! - Implement the solution to your exercise here.
+//! - Put the stubs for any tested functions in `src/lib.rs`,
+//!   whose variable names are `_` and
+//!   whose contents are `unimplemented!()`.
+//! - If your example implementation has dependencies, copy
+//!   `Cargo.toml` into `Cargo-example.toml` and then make
+//!   any modifications necessary to the latter so your example will run.
+//! - Test your example by running `../../bin/test-exercise`
+
+pub fn is_armstrong_number(num: u32) -> bool {
+    let s = format!("{}", num);
+    let l = s.len();
+    s.chars()
+        .map(|c| c.to_digit(10).unwrap().pow(l as u32))
+        .sum::<u32>() == num
+}

--- a/exercises/armstrong-numbers/example.rs
+++ b/exercises/armstrong-numbers/example.rs
@@ -1,14 +1,3 @@
-//! Example implementation for armstrong-numbers
-//!
-//! - Implement the solution to your exercise here.
-//! - Put the stubs for any tested functions in `src/lib.rs`,
-//!   whose variable names are `_` and
-//!   whose contents are `unimplemented!()`.
-//! - If your example implementation has dependencies, copy
-//!   `Cargo.toml` into `Cargo-example.toml` and then make
-//!   any modifications necessary to the latter so your example will run.
-//! - Test your example by running `../../bin/test-exercise`
-
 pub fn is_armstrong_number(num: u32) -> bool {
     let s = format!("{}", num);
     let l = s.len();

--- a/exercises/armstrong-numbers/src/lib.rs
+++ b/exercises/armstrong-numbers/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn is_armstrong_number(_num: u32) -> bool {
+    unimplemented!()
+}

--- a/exercises/armstrong-numbers/tests/armstrong-numbers.rs
+++ b/exercises/armstrong-numbers/tests/armstrong-numbers.rs
@@ -1,0 +1,49 @@
+extern crate armstrong_numbers;
+use armstrong_numbers::*;
+
+#[test]
+fn test_single_digit_numbers_are_armstrong_numbers() {
+    assert!(is_armstrong_number(5))
+}
+
+#[test]
+#[ignore]
+fn test_there_are_no_2_digit_armstring_numbers() {
+    assert!(!is_armstrong_number(10))
+}
+
+#[test]
+#[ignore]
+fn test_three_digit_armstrong_number() {
+    assert!(is_armstrong_number(153))
+}
+
+#[test]
+#[ignore]
+fn test_three_digit_non_armstrong_number() {
+    assert!(!is_armstrong_number(100))
+}
+
+#[test]
+#[ignore]
+fn test_four_digit_armstrong_number() {
+    assert!(is_armstrong_number(9474))
+}
+
+#[test]
+#[ignore]
+fn test_four_digit_non_armstrong_number() {
+    assert!(!is_armstrong_number(9475))
+}
+
+#[test]
+#[ignore]
+fn test_seven_digit_armstrong_number() {
+    assert!(is_armstrong_number(9926315))
+}
+
+#[test]
+#[ignore]
+fn test_seven_digit_non_armstrong_number() {
+    assert!(!is_armstrong_number(9926316))
+}


### PR DESCRIPTION
Currently, it is after `series` and before `collatz-conjecture`. I'm not 100% sure on the positioning but the exercise is complete

Problem Specification
---
https://github.com/exercism/problem-specifications/tree/master/exercises/armstrong-numbers