### PR TITLE
variable-length-quantity: Use domain-specific error

### DIFF
--- a/exercises/variable-length-quantity/example.rs
+++ b/exercises/variable-length-quantity/example.rs
@@ -1,3 +1,9 @@
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    IncompleteNumber,
+    Overflow,
+}
+
 /// Convert a list of numbers to a stream of bytes encoded with variable length encoding.
 pub fn to_bytes(values: &[u32]) -> Vec<u8> {
     let mut res = vec![];
@@ -68,13 +74,13 @@ fn to_bytes_single(mut value: u32) -> Vec<u8> {
 // }
 
 /// Given a stream of bytes, extract all numbers which are encoded in there.
-pub fn from_bytes(bytes: &[u8]) -> Result<Vec<u32>, &'static str> {
+pub fn from_bytes(bytes: &[u8]) -> Result<Vec<u32>, Error> {
     let mut res = vec![];
     let mut tmp = 0;
     for (i,b) in bytes.iter().enumerate() {
         // test if first 7 bit are set, to check for overflow
         if (tmp & 0xfe_00_00_00) > 0 {
-            return Err("Would overflow");
+            return Err(Error::Overflow);
         }
 
         // append bytes of b to tmp
@@ -89,7 +95,7 @@ pub fn from_bytes(bytes: &[u8]) -> Result<Vec<u32>, &'static str> {
             if i+1 == bytes.len() {
                 // the next index would be past the end,
                 // i.e. there are no more bytes.
-                return Err("Incomplete byte sequence");
+                return Err(Error::IncompleteNumber);
             }
         }
     }

--- a/exercises/variable-length-quantity/src/lib.rs
+++ b/exercises/variable-length-quantity/src/lib.rs
@@ -1,9 +1,15 @@
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    IncompleteNumber,
+    Overflow,
+}
+
 /// Convert a list of numbers to a stream of bytes encoded with variable length encoding.
 pub fn to_bytes(values: &[u32]) -> Vec<u8> {
     unimplemented!()
 }
 
 /// Given a stream of bytes, extract all numbers which are encoded in there.
-pub fn from_bytes(bytes: &[u8]) -> Result<Vec<u32>, &'static str> {
+pub fn from_bytes(bytes: &[u8]) -> Result<Vec<u32>, Error> {
     unimplemented!()
 }

--- a/exercises/variable-length-quantity/tests/variable-length-quantity.rs
+++ b/exercises/variable-length-quantity/tests/variable-length-quantity.rs
@@ -82,19 +82,19 @@ fn from_bytes_multiple_values() {
 #[test]
 #[ignore]
 fn incomplete_byte_sequence() {
-    assert!(vlq::from_bytes(&[0xff]).is_err());
+    assert_eq!(Err(vlq::Error::IncompleteNumber), vlq::from_bytes(&[0xff]));
 }
 
 #[test]
 #[ignore]
 fn zero_incomplete_byte_sequence() {
-    assert!(vlq::from_bytes(&[0x80]).is_err());
+    assert_eq!(Err(vlq::Error::IncompleteNumber), vlq::from_bytes(&[0x80]));
 }
 
 #[test]
 #[ignore]
 fn overflow_u32() {
-    assert!(vlq::from_bytes(&[0xff, 0xff, 0xff, 0xff, 0x7f]).is_err());
+    assert_eq!(Err(vlq::Error::Overflow), vlq::from_bytes(&[0xff, 0xff, 0xff, 0xff, 0x7f]));
 }
 
 #[test]


### PR DESCRIPTION
We prefer domain-specific errors to strings because they are
programmatically inspectable. We would prefer to encourage students to
use domain-specific errors rather than strings.

As discussed in #444:
https://github.com/exercism/rust/issues/444