### PR TITLE
Use &[T] instead of &Vec<T> where possible

### DIFF
--- a/exercises/allergies/tests/allergies.rs
+++ b/exercises/allergies/tests/allergies.rs
@@ -44,97 +44,97 @@ fn is_allergic_to_egg_shellfish_and_strawberries() {
 #[test]
 #[ignore]
 fn no_allergies_at_all() {
-    let expected: Vec<Allergen> = Vec::new();
+    let expected = &[];
     let allergies = Allergies::new(0).allergies();
 
-    compare_allergy_vectors(&expected, &allergies);
+    compare_allergy_vectors(expected, &allergies);
 }
 
 #[test]
 #[ignore]
 fn allergic_to_just_eggs() {
-    let expected = vec![Allergen::Eggs];
+    let expected = &[Allergen::Eggs];
     let allergies = Allergies::new(1).allergies();
 
-    compare_allergy_vectors(&expected, &allergies);
+    compare_allergy_vectors(expected, &allergies);
 }
 
 #[test]
 #[ignore]
 fn allergic_to_just_peanuts() {
-    let expected = vec![Allergen::Peanuts];
+    let expected = &[Allergen::Peanuts];
     let allergies = Allergies::new(2).allergies();
 
-    compare_allergy_vectors(&expected, &allergies);
+    compare_allergy_vectors(expected, &allergies);
 }
 
 #[test]
 #[ignore]
 fn allergic_to_just_strawberries() {
-    let expected = vec![Allergen::Strawberries];
+    let expected = &[Allergen::Strawberries];
     let allergies = Allergies::new(8).allergies();
 
-    compare_allergy_vectors(&expected, &allergies);
+    compare_allergy_vectors(expected, &allergies);
 }
 
 #[test]
 #[ignore]
 fn allergic_to_eggs_and_peanuts() {
-    let expected = vec![Allergen::Eggs, Allergen::Peanuts];
+    let expected = &[Allergen::Eggs, Allergen::Peanuts];
     let allergies = Allergies::new(3).allergies();
 
-    compare_allergy_vectors(&expected, &allergies);
+    compare_allergy_vectors(expected, &allergies);
 }
 
 #[test]
 #[ignore]
 fn allergic_to_eggs_and_shellfish() {
-    let expected = vec![Allergen::Eggs, Allergen::Shellfish];
+    let expected = &[Allergen::Eggs, Allergen::Shellfish];
     let allergies = Allergies::new(5).allergies();
 
-    compare_allergy_vectors(&expected, &allergies);
+    compare_allergy_vectors(expected, &allergies);
 }
 
 #[test]
 #[ignore]
 fn allergic_to_many_things() {
-    let expected = vec![Allergen::Strawberries,
-                        Allergen::Tomatoes,
-                        Allergen::Chocolate,
-                        Allergen::Pollen,
-                        Allergen::Cats];
+    let expected = &[Allergen::Strawberries,
+                     Allergen::Tomatoes,
+                     Allergen::Chocolate,
+                     Allergen::Pollen,
+                     Allergen::Cats];
     let allergies = Allergies::new(248).allergies();
 
-    compare_allergy_vectors(&expected, &allergies);
+    compare_allergy_vectors(expected, &allergies);
 }
 
 #[test]
 #[ignore]
 fn allergic_to_everything() {
-    let expected = vec![Allergen::Eggs,
-                        Allergen::Peanuts,
-                        Allergen::Shellfish,
-                        Allergen::Strawberries,
-                        Allergen::Tomatoes,
-                        Allergen::Chocolate,
-                        Allergen::Pollen,
-                        Allergen::Cats];
+    let expected = &[Allergen::Eggs,
+                     Allergen::Peanuts,
+                     Allergen::Shellfish,
+                     Allergen::Strawberries,
+                     Allergen::Tomatoes,
+                     Allergen::Chocolate,
+                     Allergen::Pollen,
+                     Allergen::Cats];
     let allergies = Allergies::new(255).allergies();
 
-    compare_allergy_vectors(&expected, &allergies);
+    compare_allergy_vectors(expected, &allergies);
 }
 
 #[test]
 #[ignore]
 fn scores_over_255_do_not_trigger_false_positives() {
-    let expected = vec![Allergen::Eggs,
-                        Allergen::Shellfish,
-                        Allergen::Strawberries,
-                        Allergen::Tomatoes,
-                        Allergen::Chocolate,
-                        Allergen::Pollen,
-                        Allergen::Cats];
+    let expected = &[Allergen::Eggs,
+                     Allergen::Shellfish,
+                     Allergen::Strawberries,
+                     Allergen::Tomatoes,
+                     Allergen::Chocolate,
+                     Allergen::Pollen,
+                     Allergen::Cats];
     let allergies = Allergies::new(509).allergies();
 
-    compare_allergy_vectors(&expected, &allergies);
+    compare_allergy_vectors(expected, &allergies);
 }

--- a/exercises/allergies/tests/allergies.rs
+++ b/exercises/allergies/tests/allergies.rs
@@ -2,7 +2,7 @@ extern crate allergies;
 
 use allergies::*;
 
-fn compare_allergy_vectors(expected: &Vec<Allergen>, actual: &Vec<Allergen>) {
+fn compare_allergy_vectors(expected: &[Allergen], actual: &[Allergen]) {
     for element in expected {
         if !actual.contains(element) {
             panic!("Allergen missing\n  {:?} should be in {:?}",

--- a/exercises/dominoes/example.rs
+++ b/exercises/dominoes/example.rs
@@ -68,7 +68,7 @@ impl AvailabilityTable {
     }
 }
 
-pub fn chain(dominoes: &Vec<Domino>) -> Option<Vec<Domino>> {
+pub fn chain(dominoes: &[Domino]) -> Option<Vec<Domino>> {
     match dominoes.len() {
         0 => Some(vec!()),
         1 => if dominoes[0].0 == dominoes[0].1 { Some(vec![dominoes[0]]) } else { None },
@@ -100,8 +100,8 @@ pub fn chain(dominoes: &Vec<Domino>) -> Option<Vec<Domino>> {
     }
 }
 
-fn chain_worker(dominoes: &Vec<Domino>) -> Vec<Domino> {
-    let mut doms = dominoes.clone();
+fn chain_worker(dominoes: &[Domino]) -> Vec<Domino> {
+    let mut doms = dominoes.to_vec();
     let first = doms.pop().unwrap();
     let mut t = AvailabilityTable::new();
     for dom in doms.iter() {

--- a/exercises/dominoes/tests/dominoes.rs
+++ b/exercises/dominoes/tests/dominoes.rs
@@ -76,83 +76,83 @@ fn assert_correct(input: &[Domino]) {
 
 #[test]
 fn empty_input_empty_output() {
-    let input = vec!();
-    assert_eq!(dominoes::chain(&input), Some(vec!()));
+    let input = &[];
+    assert_eq!(dominoes::chain(input), Some(vec!()));
 }
 
 #[test]
 #[ignore]
 fn singleton_input_singleton_output() {
-    let input = vec!((1, 1));
-    assert_correct(&input);
+    let input = &[(1, 1)];
+    assert_correct(input);
 }
 
 #[test]
 #[ignore]
 fn singleton_that_cant_be_chained() {
-    let input = vec![(1, 2)];
-    assert_eq!(dominoes::chain(&input), None);
+    let input = &[(1, 2)];
+    assert_eq!(dominoes::chain(input), None);
 }
 
 #[test]
 #[ignore]
 fn no_repeat_numbers() {
-    let input = vec!((1, 2), (3, 1), (2, 3));
-    assert_correct(&input);
+    let input = &[(1, 2), (3, 1), (2, 3)];
+    assert_correct(input);
 }
 
 #[test]
 #[ignore]
 fn can_reverse_dominoes() {
-    let input = vec![(1, 2), (1, 3), (2, 3)];
-    assert_correct(&input);
+    let input = &[(1, 2), (1, 3), (2, 3)];
+    assert_correct(input);
 }
 
 #[test]
 #[ignore]
 fn no_chains() {
-    let input = vec!((1, 2), (4, 1), (2, 3));
-    assert_eq!(dominoes::chain(&input), None);
+    let input = &[(1, 2), (4, 1), (2, 3)];
+    assert_eq!(dominoes::chain(input), None);
 }
 
 #[test]
 #[ignore]
 fn disconnected_simple() {
-    let input = vec![(1, 1), (2, 2)];
-    assert_eq!(dominoes::chain(&input), None);
+    let input = &[(1, 1), (2, 2)];
+    assert_eq!(dominoes::chain(input), None);
 }
 
 #[test]
 #[ignore]
 fn disconnected_double_loop() {
-    let input = vec![(1, 2), (2, 1), (3, 4), (4, 3)];
-    assert_eq!(dominoes::chain(&input), None);
+    let input = &[(1, 2), (2, 1), (3, 4), (4, 3)];
+    assert_eq!(dominoes::chain(input), None);
 }
 
 #[test]
 #[ignore]
 fn disconnected_single_isolated() {
-    let input = vec![(1, 2), (2, 3), (3, 1), (4, 4)];
-    assert_eq!(dominoes::chain(&input), None);
+    let input = &[(1, 2), (2, 3), (3, 1), (4, 4)];
+    assert_eq!(dominoes::chain(input), None);
 }
 
 #[test]
 #[ignore]
 fn need_backtrack() {
-    let input = vec![(1, 2), (2, 3), (3, 1), (2, 4), (2, 4)];
-    assert_correct(&input);
+    let input = &[(1, 2), (2, 3), (3, 1), (2, 4), (2, 4)];
+    assert_correct(input);
 }
 
 #[test]
 #[ignore]
 fn separate_loops() {
-    let input = vec![(1, 2), (2, 3), (3, 1), (1, 1), (2, 2), (3, 3)];
-    assert_correct(&input);
+    let input = &[(1, 2), (2, 3), (3, 1), (1, 1), (2, 2), (3, 3)];
+    assert_correct(input);
 }
 
 #[test]
 #[ignore]
 fn nine_elements() {
-    let input = vec!((1, 2), (5, 3), (3, 1), (1, 2), (2, 4), (1, 6), (2, 3), (3, 4), (5, 6));
-    assert_correct(&input);
+    let input = &[(1, 2), (5, 3), (3, 1), (1, 2), (2, 4), (1, 6), (2, 3), (3, 4), (5, 6)];
+    assert_correct(input);
 }

--- a/exercises/dominoes/tests/dominoes.rs
+++ b/exercises/dominoes/tests/dominoes.rs
@@ -21,7 +21,7 @@ fn normalize(d: &Domino) -> Domino {
     }
 }
 
-fn check(input: &Vec<Domino>) -> CheckResult {
+fn check(input: &[Domino]) -> CheckResult {
     let output = match dominoes::chain(input) {
         None => return GotInvalid,
         Some(o) => o
@@ -64,7 +64,7 @@ fn check(input: &Vec<Domino>) -> CheckResult {
     }
 }
 
-fn assert_correct(input: &Vec<Domino>) {
+fn assert_correct(input: &[Domino]) {
     match check(&input) {
         Correct => (),
         GotInvalid => panic!("Unexpectedly got invalid on input {:?}", input),

--- a/exercises/grade-school/tests/grade-school.rs
+++ b/exercises/grade-school/tests/grade-school.rs
@@ -1,6 +1,6 @@
 extern crate grade_school as school;
 
-fn some_strings(v: Vec<&str>) -> Option<Vec<String>> {
+fn some_strings(v: &[&str]) -> Option<Vec<String>> {
     Some(v.iter().map(|s| s.to_string()).collect())
 }
 
@@ -59,7 +59,7 @@ fn test_grade_for_one_student() {
     let mut s = school::School::new();
     s.add(2, "Aimee");
     assert_eq!(s.grade(2),
-                some_strings(vec!["Aimee"]));
+                some_strings(&["Aimee"]));
 }
 
 #[test]
@@ -70,7 +70,7 @@ fn test_grade_returns_students_sorted_by_name() {
     s.add(2, "Blair");
     s.add(2, "Paul");
     assert_eq!(s.grade(2),
-               some_strings(vec!["Blair", "James", "Paul"]));
+               some_strings(&["Blair", "James", "Paul"]));
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn test_add_students_to_different_grades() {
     s.add(7, "Logan");
     assert_eq!(s.grades(), vec!(3, 7));
     assert_eq!(s.grade(3),
-               some_strings(vec!["Chelsea"]));
+               some_strings(&["Chelsea"]));
     assert_eq!(s.grade(7),
-               some_strings(vec!["Logan"]));
+               some_strings(&["Logan"]));
 }

--- a/exercises/poker/tests/poker.rs
+++ b/exercises/poker/tests/poker.rs
@@ -26,15 +26,15 @@ fn test<'a, 'b>(input: &[&'a str], expected: &[&'b str]) {
 
 #[test]
 fn test_single_hand_always_wins() {
-    test(&vec!["4S 5S 7H 8D JC"], &vec!["4S 5S 7H 8D JC"])
+    test(&["4S 5S 7H 8D JC"], &["4S 5S 7H 8D JC"])
 }
 
 #[test]
 #[ignore]
 fn test_highest_card_of_all_hands_wins() {
     test(
-        &vec!["4D 5S 6S 8D 3C", "2S 4C 7S 9H 10H", "3S 4S 5D 6H JH"],
-        &vec!["3S 4S 5D 6H JH"],
+        &["4D 5S 6S 8D 3C", "2S 4C 7S 9H 10H", "3S 4S 5D 6H JH"],
+        &["3S 4S 5D 6H JH"],
     )
 }
 
@@ -42,13 +42,13 @@ fn test_highest_card_of_all_hands_wins() {
 #[ignore]
 fn test_a_tie_has_multiple_winners() {
     test(
-        &vec![
+        &[
             "4D 5S 6S 8D 3C",
             "2S 4C 7S 9H 10H",
             "3S 4S 5D 6H JH",
             "3H 4H 5C 6C JD",
         ],
-        &vec!["3S 4S 5D 6H JH", "3H 4H 5C 6C JD"],
+        &["3S 4S 5D 6H JH", "3H 4H 5C 6C JD"],
     )
 }
 
@@ -58,8 +58,8 @@ fn test_high_card_can_be_low_card_in_an_otherwise_tie() {
     // multiple hands with the same high cards, tie compares next highest ranked,
     // down to last card
     test(
-        &vec!["3S 5H 6S 8D 7H", "2S 5D 6D 8C 7S"],
-        &vec!["3S 5H 6S 8D 7H"],
+        &["3S 5H 6S 8D 7H", "2S 5D 6D 8C 7S"],
+        &["3S 5H 6S 8D 7H"],
     )
 }
 
@@ -67,8 +67,8 @@ fn test_high_card_can_be_low_card_in_an_otherwise_tie() {
 #[ignore]
 fn test_one_pair_beats_high_card() {
     test(
-        &vec!["4S 5H 6C 8D KH", "2S 4H 6S 4D JH"],
-        &vec!["2S 4H 6S 4D JH"],
+        &["4S 5H 6C 8D KH", "2S 4H 6S 4D JH"],
+        &["2S 4H 6S 4D JH"],
     )
 }
 
@@ -76,8 +76,8 @@ fn test_one_pair_beats_high_card() {
 #[ignore]
 fn test_highest_pair_wins() {
     test(
-        &vec!["4S 2H 6S 2D JH", "2S 4H 6C 4D JD"],
-        &vec!["2S 4H 6C 4D JD"],
+        &["4S 2H 6S 2D JH", "2S 4H 6C 4D JD"],
+        &["2S 4H 6C 4D JD"],
     )
 }
 
@@ -85,8 +85,8 @@ fn test_highest_pair_wins() {
 #[ignore]
 fn test_two_pairs_beats_one_pair() {
     test(
-        &vec!["2S 8H 6S 8D JH", "4S 5H 4C 8C 5C"],
-        &vec!["4S 5H 4C 8C 5C"],
+        &["2S 8H 6S 8D JH", "4S 5H 4C 8C 5C"],
+        &["4S 5H 4C 8C 5C"],
     )
 }
 
@@ -95,8 +95,8 @@ fn test_two_pairs_beats_one_pair() {
 fn test_two_pair_ranks() {
     // both hands have two pairs, highest ranked pair wins
     test(
-        &vec!["2S 8H 2D 8D 3H", "4S 5H 4C 8S 5D"],
-        &vec!["2S 8H 2D 8D 3H"],
+        &["2S 8H 2D 8D 3H", "4S 5H 4C 8S 5D"],
+        &["2S 8H 2D 8D 3H"],
     )
 }
 
@@ -106,8 +106,8 @@ fn test_two_pairs_second_pair_cascade() {
     // both hands have two pairs, with the same highest ranked pair,
     // tie goes to low pair
     test(
-        &vec!["2S QS 2C QD JH", "JD QH JS 8D QC"],
-        &vec!["JD QH JS 8D QC"],
+        &["2S QS 2C QD JH", "JD QH JS 8D QC"],
+        &["JD QH JS 8D QC"],
     )
 }
 
@@ -117,8 +117,8 @@ fn test_two_pairs_last_card_cascade() {
     // both hands have two identically ranked pairs,
     // tie goes to remaining card (kicker)
     test(
-        &vec!["JD QH JS 8D QC", "JS QS JC 2D QD"],
-        &vec!["JD QH JS 8D QC"],
+        &["JD QH JS 8D QC", "JS QS JC 2D QD"],
+        &["JD QH JS 8D QC"],
     )
 }
 
@@ -126,8 +126,8 @@ fn test_two_pairs_last_card_cascade() {
 #[ignore]
 fn test_three_of_a_kind_beats_two_pair() {
     test(
-        &vec!["2S 8H 2H 8D JH", "4S 5H 4C 8S 4H"],
-        &vec!["4S 5H 4C 8S 4H"],
+        &["2S 8H 2H 8D JH", "4S 5H 4C 8S 4H"],
+        &["4S 5H 4C 8S 4H"],
     )
 }
 
@@ -136,8 +136,8 @@ fn test_three_of_a_kind_beats_two_pair() {
 fn test_three_of_a_kind_ranks() {
     //both hands have three of a kind, tie goes to highest ranked triplet
     test(
-        &vec!["2S 2H 2C 8D JH", "4S AH AS 8C AD"],
-        &vec!["4S AH AS 8C AD"],
+        &["2S 2H 2C 8D JH", "4S AH AS 8C AD"],
+        &["4S AH AS 8C AD"],
     )
 }
 
@@ -147,8 +147,8 @@ fn test_three_of_a_kind_cascade_ranks() {
     // with multiple decks, two players can have same three of a kind,
     // ties go to highest remaining cards
     test(
-        &vec!["4S AH AS 7C AD", "4S AH AS 8C AD"],
-        &vec!["4S AH AS 8C AD"],
+        &["4S AH AS 7C AD", "4S AH AS 8C AD"],
+        &["4S AH AS 8C AD"],
     )
 }
 
@@ -156,8 +156,8 @@ fn test_three_of_a_kind_cascade_ranks() {
 #[ignore]
 fn test_straight_beats_three_of_a_kind() {
     test(
-        &vec!["4S 5H 4C 8D 4H", "3S 4D 2S 6D 5C"],
-        &vec!["3S 4D 2S 6D 5C"],
+        &["4S 5H 4C 8D 4H", "3S 4D 2S 6D 5C"],
+        &["3S 4D 2S 6D 5C"],
     )
 }
 
@@ -166,8 +166,8 @@ fn test_straight_beats_three_of_a_kind() {
 fn test_aces_can_end_a_straight_high() {
     // aces can end a straight (10 J Q K A)
     test(
-        &vec!["4S 5H 4C 8D 4H", "10D JH QS KD AC"],
-        &vec!["10D JH QS KD AC"],
+        &["4S 5H 4C 8D 4H", "10D JH QS KD AC"],
+        &["10D JH QS KD AC"],
     )
 }
 
@@ -176,8 +176,8 @@ fn test_aces_can_end_a_straight_high() {
 fn test_aces_can_end_a_straight_low() {
     // aces can start a straight (A 2 3 4 5)
     test(
-        &vec!["4S 5H 4C 8D 4H", "4D AH 3S 2D 5C"],
-        &vec!["4D AH 3S 2D 5C"],
+        &["4S 5H 4C 8D 4H", "4D AH 3S 2D 5C"],
+        &["4D AH 3S 2D 5C"],
     )
 }
 
@@ -186,8 +186,8 @@ fn test_aces_can_end_a_straight_low() {
 fn test_straight_cascade() {
     // both hands with a straight, tie goes to highest ranked card
     test(
-        &vec!["4S 6C 7S 8D 5H", "5S 7H 8S 9D 6H"],
-        &vec!["5S 7H 8S 9D 6H"],
+        &["4S 6C 7S 8D 5H", "5S 7H 8S 9D 6H"],
+        &["5S 7H 8S 9D 6H"],
     )
 }
 
@@ -196,8 +196,8 @@ fn test_straight_cascade() {
 fn test_straight_scoring() {
     // even though an ace is usually high, a 5-high straight is the lowest-scoring straight
     test(
-        &vec!["2H 3C 4D 5D 6H", "4S AH 3S 2D 5H"],
-        &vec!["2H 3C 4D 5D 6H"],
+        &["2H 3C 4D 5D 6H", "4S AH 3S 2D 5H"],
+        &["2H 3C 4D 5D 6H"],
     )
 }
 
@@ -205,8 +205,8 @@ fn test_straight_scoring() {
 #[ignore]
 fn test_flush_beats_a_straight() {
     test(
-        &vec!["4C 6H 7D 8D 5H", "2S 4S 5S 6S 7S"],
-        &vec!["2S 4S 5S 6S 7S"],
+        &["4C 6H 7D 8D 5H", "2S 4S 5S 6S 7S"],
+        &["2S 4S 5S 6S 7S"],
     )
 }
 
@@ -215,8 +215,8 @@ fn test_flush_beats_a_straight() {
 fn test_flush_cascade() {
     // both hands have a flush, tie goes to high card, down to the last one if necessary
     test(
-        &vec!["4H 7H 8H 9H 6H", "2S 4S 5S 6S 7S"],
-        &vec!["4H 7H 8H 9H 6H"],
+        &["4H 7H 8H 9H 6H", "2S 4S 5S 6S 7S"],
+        &["4H 7H 8H 9H 6H"],
     )
 }
 
@@ -224,8 +224,8 @@ fn test_flush_cascade() {
 #[ignore]
 fn test_full_house_beats_a_flush() {
     test(
-        &vec!["3H 6H 7H 8H 5H", "4S 5C 4C 5D 4H"],
-        &vec!["4S 5C 4C 5D 4H"],
+        &["3H 6H 7H 8H 5H", "4S 5C 4C 5D 4H"],
+        &["4S 5C 4C 5D 4H"],
     )
 }
 
@@ -234,8 +234,8 @@ fn test_full_house_beats_a_flush() {
 fn test_full_house_ranks() {
     // both hands have a full house, tie goes to highest-ranked triplet
     test(
-        &vec!["4H 4S 4D 9S 9D", "5H 5S 5D 8S 8D"],
-        &vec!["5H 5S 5D 8S 8D"],
+        &["4H 4S 4D 9S 9D", "5H 5S 5D 8S 8D"],
+        &["5H 5S 5D 8S 8D"],
     )
 }
 
@@ -244,8 +244,8 @@ fn test_full_house_ranks() {
 fn test_full_house_cascade() {
     // with multiple decks, both hands have a full house with the same triplet, tie goes to the pair
     test(
-        &vec!["5H 5S 5D 9S 9D", "5H 5S 5D 8S 8D"],
-        &vec!["5H 5S 5D 9S 9D"],
+        &["5H 5S 5D 9S 9D", "5H 5S 5D 8S 8D"],
+        &["5H 5S 5D 9S 9D"],
     )
 }
 
@@ -253,8 +253,8 @@ fn test_full_house_cascade() {
 #[ignore]
 fn test_four_of_a_kind_beats_full_house() {
     test(
-        &vec!["4S 5H 4D 5D 4H", "3S 3H 2S 3D 3C"],
-        &vec!["3S 3H 2S 3D 3C"],
+        &["4S 5H 4D 5D 4H", "3S 3H 2S 3D 3C"],
+        &["3S 3H 2S 3D 3C"],
     )
 }
 
@@ -263,8 +263,8 @@ fn test_four_of_a_kind_beats_full_house() {
 fn test_four_of_a_kind_ranks() {
     // both hands have four of a kind, tie goes to high quad
     test(
-        &vec!["2S 2H 2C 8D 2D", "4S 5H 5S 5D 5C"],
-        &vec!["4S 5H 5S 5D 5C"],
+        &["2S 2H 2C 8D 2D", "4S 5H 5S 5D 5C"],
+        &["4S 5H 5S 5D 5C"],
     )
 }
 
@@ -273,8 +273,8 @@ fn test_four_of_a_kind_ranks() {
 fn test_four_of_a_kind_cascade() {
     // with multiple decks, both hands with identical four of a kind, tie determined by kicker
     test(
-        &vec!["3S 3H 2S 3D 3C", "3S 3H 4S 3D 3C"],
-        &vec!["3S 3H 4S 3D 3C"],
+        &["3S 3H 2S 3D 3C", "3S 3H 4S 3D 3C"],
+        &["3S 3H 4S 3D 3C"],
     )
 }
 
@@ -282,8 +282,8 @@ fn test_four_of_a_kind_cascade() {
 #[ignore]
 fn test_straight_flush_beats_four_of_a_kind() {
     test(
-        &vec!["4S 5H 5S 5D 5C", "7S 8S 9S 6S 10S"],
-        &vec!["7S 8S 9S 6S 10S"],
+        &["4S 5H 5S 5D 5C", "7S 8S 9S 6S 10S"],
+        &["7S 8S 9S 6S 10S"],
     )
 }
 
@@ -292,7 +292,7 @@ fn test_straight_flush_beats_four_of_a_kind() {
 fn test_straight_flush_ranks() {
     // both hands have straight flush, tie goes to highest-ranked card
     test(
-        &vec!["4H 6H 7H 8H 5H", "5S 7S 8S 9S 6S"],
-        &vec!["5S 7S 8S 9S 6S"],
+        &["4H 6H 7H 8H 5H", "5S 7S 8S 9S 6S"],
+        &["5S 7S 8S 9S 6S"],
     )
 }

--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -235,7 +235,7 @@ fn test_adder_with_boolean_values() {
     let a_and_b = reactor.create_compute(&[a, b], |v| v[0] && v[1]).unwrap();
     let carry_out = reactor.create_compute(&[a_xor_b_and_cin, a_and_b], |v| v[0] || v[1]).unwrap();
 
-    let tests = vec![
+    let tests = &[
         (false, false, false, false, false),
         (false, false, true, false, true),
         (false, true, false, false, true),
@@ -246,7 +246,7 @@ fn test_adder_with_boolean_values() {
         (true, true, true, true, true),
     ];
 
-    for (aval, bval, cinval, expected_cout, expected_sum) in tests {
+    for &(aval, bval, cinval, expected_cout, expected_sum) in tests {
         assert!(reactor.set_value(a, aval).is_ok());
         assert!(reactor.set_value(b, bval).is_ok());
         assert!(reactor.set_value(carry_in, cinval).is_ok());

--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -31,7 +31,7 @@ fn error_setting_a_nonexistent_input_cell() {
 fn compute_cells_calculate_initial_value() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
-    let output = reactor.create_compute(&vec![input], |v| v[0] + 1).unwrap();
+    let output = reactor.create_compute(&[input], |v| v[0] + 1).unwrap();
     assert_eq!(reactor.value(output), Some(2));
 }
 
@@ -41,7 +41,7 @@ fn compute_cells_take_inputs_in_the_right_order() {
     let mut reactor = Reactor::new();
     let one = reactor.create_input(1);
     let two = reactor.create_input(2);
-    let output = reactor.create_compute(&vec![one, two], |v| v[0] + v[1] * 10).unwrap();
+    let output = reactor.create_compute(&[one, two], |v| v[0] + v[1] * 10).unwrap();
     assert_eq!(reactor.value(output), Some(21));
 }
 
@@ -50,7 +50,7 @@ fn compute_cells_take_inputs_in_the_right_order() {
 fn error_creating_compute_cell_if_input_doesnt_exist() {
     let mut dummy_reactor = Reactor::new();
     let input = dummy_reactor.create_input(1);
-    assert!(Reactor::new().create_compute(&vec![input], |_| 0).is_err());
+    assert!(Reactor::new().create_compute(&[input], |_| 0).is_err());
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn do_not_break_cell_if_creating_compute_cell_with_valid_and_invalid_input() {
     let dummy_cell = dummy_reactor.create_input(2);
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
-    assert!(reactor.create_compute(&vec![input, dummy_cell], |_| 0).is_err());
+    assert!(reactor.create_compute(&[input, dummy_cell], |_| 0).is_err());
     assert!(reactor.set_value(input, 5).is_ok());
     assert_eq!(reactor.value(input), Some(5));
 }
@@ -71,7 +71,7 @@ fn do_not_break_cell_if_creating_compute_cell_with_valid_and_invalid_input() {
 fn compute_cells_update_value_when_dependencies_are_changed() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
-    let output = reactor.create_compute(&vec![input], |v| v[0] + 1).unwrap();
+    let output = reactor.create_compute(&[input], |v| v[0] + 1).unwrap();
     assert_eq!(reactor.value(output), Some(2));
     assert!(reactor.set_value(input, 3).is_ok());
     assert_eq!(reactor.value(output), Some(4));
@@ -82,9 +82,9 @@ fn compute_cells_update_value_when_dependencies_are_changed() {
 fn compute_cells_can_depend_on_other_compute_cells() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
-    let times_two = reactor.create_compute(&vec![input], |v| v[0] * 2).unwrap();
-    let times_thirty = reactor.create_compute(&vec![input], |v| v[0] * 30).unwrap();
-    let output = reactor.create_compute(&vec![times_two, times_thirty], |v| v[0] + v[1]).unwrap();
+    let times_two = reactor.create_compute(&[input], |v| v[0] * 2).unwrap();
+    let times_thirty = reactor.create_compute(&[input], |v| v[0] * 30).unwrap();
+    let output = reactor.create_compute(&[times_two, times_thirty], |v| v[0] + v[1]).unwrap();
     assert_eq!(reactor.value(output), Some(32));
     assert!(reactor.set_value(input, 3).is_ok());
     assert_eq!(reactor.value(output), Some(96));
@@ -95,7 +95,7 @@ fn compute_cells_can_depend_on_other_compute_cells() {
 fn error_setting_a_compute_cell() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
-    let output = reactor.create_compute(&vec![input], |_| 0).unwrap();
+    let output = reactor.create_compute(&[input], |_| 0).unwrap();
     assert!(reactor.set_value(output, 3).is_err());
 }
 
@@ -108,7 +108,7 @@ fn compute_cells_fire_callbacks() {
     {
         let mut reactor = Reactor::new();
         let input = reactor.create_input(1);
-        let output = reactor.create_compute(&vec![input], |v| v[0] + 1).unwrap();
+        let output = reactor.create_compute(&[input], |v| v[0] + 1).unwrap();
         assert!(reactor.add_callback(output, |v| values.push(v)).is_ok());
         assert!(reactor.set_value(input, 3).is_ok());
     }
@@ -120,7 +120,7 @@ fn compute_cells_fire_callbacks() {
 fn error_adding_callback_to_nonexistent_cell() {
     let mut dummy_reactor = Reactor::new();
     let input = dummy_reactor.create_input(1);
-    let output = dummy_reactor.create_compute(&vec![input], |_| 0).unwrap();
+    let output = dummy_reactor.create_compute(&[input], |_| 0).unwrap();
     assert!(Reactor::new().add_callback(output, |_: usize| println!("hi")).is_err());
 }
 
@@ -131,7 +131,7 @@ fn callbacks_only_fire_on_change() {
     {
         let mut reactor = Reactor::new();
         let input = reactor.create_input(1);
-        let output = reactor.create_compute(&vec![input], |v| if v[0] < 3 { 111 } else { 222 }).unwrap();
+        let output = reactor.create_compute(&[input], |v| if v[0] < 3 { 111 } else { 222 }).unwrap();
         assert!(reactor.add_callback(output, |v| values.push(v)).is_ok());
         assert!(reactor.set_value(input, 2).is_ok());
         assert!(reactor.set_value(input, 4).is_ok());
@@ -148,7 +148,7 @@ fn callbacks_can_be_added_and_removed() {
     {
         let mut reactor = Reactor::new();
         let input = reactor.create_input(11);
-        let output = reactor.create_compute(&vec![input], |v| v[0] + 1).unwrap();
+        let output = reactor.create_compute(&[input], |v| v[0] + 1).unwrap();
         let callback = reactor.add_callback(output, |v| values1.push(v)).unwrap();
         assert!(reactor.add_callback(output, |v| values2.push(v)).is_ok());
         assert!(reactor.set_value(input, 31).is_ok());
@@ -169,7 +169,7 @@ fn removing_a_callback_multiple_times_doesnt_interfere_with_other_callbacks() {
     {
         let mut reactor = Reactor::new();
         let input = reactor.create_input(1);
-        let output = reactor.create_compute(&vec![input], |v| v[0] + 1).unwrap();
+        let output = reactor.create_compute(&[input], |v| v[0] + 1).unwrap();
         let callback = reactor.add_callback(output, |v| values1.push(v)).unwrap();
         assert!(reactor.add_callback(output, |v| values2.push(v)).is_ok());
         // We want the first remove to be Ok, but we don't care about the others.
@@ -190,10 +190,10 @@ fn callbacks_should_only_be_called_once_even_if_multiple_dependencies_change() {
     {
         let mut reactor = Reactor::new();
         let input = reactor.create_input(1);
-        let plus_one = reactor.create_compute(&vec![input], |v| v[0] + 1).unwrap();
-        let minus_one1 = reactor.create_compute(&vec![input], |v| v[0] - 1).unwrap();
-        let minus_one2 = reactor.create_compute(&vec![minus_one1], |v| v[0] - 1).unwrap();
-        let output = reactor.create_compute(&vec![plus_one, minus_one2], |v| v[0] * v[1]).unwrap();
+        let plus_one = reactor.create_compute(&[input], |v| v[0] + 1).unwrap();
+        let minus_one1 = reactor.create_compute(&[input], |v| v[0] - 1).unwrap();
+        let minus_one2 = reactor.create_compute(&[minus_one1], |v| v[0] - 1).unwrap();
+        let output = reactor.create_compute(&[plus_one, minus_one2], |v| v[0] * v[1]).unwrap();
         assert!(reactor.add_callback(output, |v| values.push(v)).is_ok());
         assert!(reactor.set_value(input, 4).is_ok());
     }
@@ -207,9 +207,9 @@ fn callbacks_should_not_be_called_if_dependencies_change_but_output_value_doesnt
     {
         let mut reactor = Reactor::new();
         let input = reactor.create_input(1);
-        let plus_one = reactor.create_compute(&vec![input], |v| v[0] + 1).unwrap();
-        let minus_one = reactor.create_compute(&vec![input], |v| v[0] - 1).unwrap();
-        let always_two = reactor.create_compute(&vec![plus_one, minus_one], |v| v[0] - v[1]).unwrap();
+        let plus_one = reactor.create_compute(&[input], |v| v[0] + 1).unwrap();
+        let minus_one = reactor.create_compute(&[input], |v| v[0] - 1).unwrap();
+        let always_two = reactor.create_compute(&[plus_one, minus_one], |v| v[0] - v[1]).unwrap();
         assert!(reactor.add_callback(always_two, |v| values.push(v)).is_ok());
         for i in 2..5 {
             assert!(reactor.set_value(input, i).is_ok());
@@ -228,12 +228,12 @@ fn test_adder_with_boolean_values() {
     let b = reactor.create_input(false);
     let carry_in = reactor.create_input(false);
 
-    let a_xor_b = reactor.create_compute(&vec![a, b], |v| v[0] ^ v[1]).unwrap();
-    let sum = reactor.create_compute(&vec![a_xor_b, carry_in], |v| v[0] ^ v[1]).unwrap();
+    let a_xor_b = reactor.create_compute(&[a, b], |v| v[0] ^ v[1]).unwrap();
+    let sum = reactor.create_compute(&[a_xor_b, carry_in], |v| v[0] ^ v[1]).unwrap();
 
-    let a_xor_b_and_cin = reactor.create_compute(&vec![a_xor_b, carry_in], |v| v[0] && v[1]).unwrap();
-    let a_and_b = reactor.create_compute(&vec![a, b], |v| v[0] && v[1]).unwrap();
-    let carry_out = reactor.create_compute(&vec![a_xor_b_and_cin, a_and_b], |v| v[0] || v[1]).unwrap();
+    let a_xor_b_and_cin = reactor.create_compute(&[a_xor_b, carry_in], |v| v[0] && v[1]).unwrap();
+    let a_and_b = reactor.create_compute(&[a, b], |v| v[0] && v[1]).unwrap();
+    let carry_out = reactor.create_compute(&[a_xor_b_and_cin, a_and_b], |v| v[0] || v[1]).unwrap();
 
     let tests = vec![
         (false, false, false, false, false),

--- a/exercises/rectangles/example.rs
+++ b/exercises/rectangles/example.rs
@@ -84,7 +84,7 @@ struct Connections {
     points: HashMap<Point, u8>
 }
 
-pub fn count(lines: &Vec<&str>) -> usize {
+pub fn count(lines: &[&str]) -> usize {
     if lines.len() == 0 {
         return 0
     } else if lines[0].len() == 0 {

--- a/exercises/rectangles/tests/rectangles.rs
+++ b/exercises/rectangles/tests/rectangles.rs
@@ -4,135 +4,135 @@ use rectangles::count;
 
 #[test]
 fn test_zero_area_1() {
-    let lines = vec![];
-    assert_eq!(0, count(&lines))
+    let lines = &[];
+    assert_eq!(0, count(lines))
 }
 
 #[test]
 #[ignore]
 fn test_zero_area_2() {
-    let lines = vec![""];
-    assert_eq!(0, count(&lines))
+    let lines = &[""];
+    assert_eq!(0, count(lines))
 }
 
 #[test]
 #[ignore]
 fn test_empty_area() {
-    let lines = vec![" "];
-    assert_eq!(0, count(&lines))
+    let lines = &[" "];
+    assert_eq!(0, count(lines))
 }
 
 #[test]
 #[ignore]
 fn test_one_rectangle() {
-    let lines = vec![
+    let lines = &[
         "+-+",
         "| |",
         "+-+",
         ];
-    assert_eq!(1, count(&lines))
+    assert_eq!(1, count(lines))
 }
 
 #[test]
 #[ignore]
 fn test_two_rectangles_no_shared_parts() {
-    let lines = vec![
+    let lines = &[
         "  +-+",
         "  | |",
         "+-+-+",
         "| |  ",
         "+-+  "
         ];
-    assert_eq!(2, count(&lines))
+    assert_eq!(2, count(lines))
 }
 
 #[test]
 #[ignore]
 fn test_five_rectangles_three_regions() {
-    let lines = vec![
+    let lines = &[
         "  +-+",
         "  | |",
         "+-+-+",
         "| | |",
         "+-+-+"
         ];
-    assert_eq!(5, count(&lines))
+    assert_eq!(5, count(lines))
 }
 
 #[test]
 #[ignore]
 fn rectangle_of_height_1() {
-    let lines = vec![
+    let lines = &[
         "+--+",
         "+--+"
         ];
-    assert_eq!(1, count(&lines))
+    assert_eq!(1, count(lines))
 }
 
 #[test]
 #[ignore]
 fn rectangle_of_width_1() {
-    let lines = vec![
+    let lines = &[
         "++",
         "||",
         "++"
         ];
-    assert_eq!(1, count(&lines))
+    assert_eq!(1, count(lines))
 }
 
 #[test]
 #[ignore]
 fn unit_equare() {
-    let lines = vec![
+    let lines = &[
         "++",
         "++"
         ];
-    assert_eq!(1, count(&lines))
+    assert_eq!(1, count(lines))
 }
 
 #[test]
 #[ignore]
 fn test_incomplete_rectangles() {
-    let lines = vec![
+    let lines = &[
         "  +-+",
         "    |",
         "+-+-+",
         "| | -",
         "+-+-+"
         ];
-    assert_eq!(1, count(&lines))
+    assert_eq!(1, count(lines))
 }
 
 #[test]
 #[ignore]
 fn test_complicated() {
-    let lines = vec![
+    let lines = &[
         "+------+----+",
         "|      |    |",
         "+---+--+    |",
         "|   |       |",
         "+---+-------+"
         ];
-    assert_eq!(3, count(&lines))
+    assert_eq!(3, count(lines))
 }
 
 #[test]
 #[ignore]
 fn test_not_so_complicated() {
-    let lines = vec![
+    let lines = &[
         "+------+----+",
         "|      |    |",
         "+------+    |",
         "|   |       |",
         "+---+-------+"
         ];
-    assert_eq!(2, count(&lines))
+    assert_eq!(2, count(lines))
 }
 
 #[test]
 #[ignore]
 fn test_large_input_with_many_rectangles() {
-    let lines = vec![
+    let lines = &[
         "+---+--+----+",
         "|   +--+----+",
         "+---+--+    |",
@@ -142,5 +142,5 @@ fn test_large_input_with_many_rectangles() {
         "+------+  | |",
         "          +-+"
         ];
-    assert_eq!(60, count(&lines))
+    assert_eq!(60, count(lines))
 }

--- a/exercises/simple-linked-list/tests/simple-linked-list.rs
+++ b/exercises/simple-linked-list/tests/simple-linked-list.rs
@@ -82,7 +82,7 @@ fn test_reverse() {
 fn test_into_vector() {
     let mut v = Vec::new();
     let mut s = SimpleLinkedList::new();
-    for i in vec![1, 2, 3] {
+    for i in 1..4 {
         v.push(i);
         s.push(i);
     }

--- a/exercises/sum-of-multiples/tests/sum-of-multiples.rs
+++ b/exercises/sum-of-multiples/tests/sum-of-multiples.rs
@@ -4,71 +4,71 @@ use sum_of_multiples::*;
 
 #[test]
 fn multiples_one() {
-    assert_eq!(0, sum_of_multiples(1, &vec![3, 5]))
+    assert_eq!(0, sum_of_multiples(1, &[3, 5]))
 }
 
 #[test]
 #[ignore]
 fn multiples_two() {
-    assert_eq!(3, sum_of_multiples(4, &vec![3, 5]))
+    assert_eq!(3, sum_of_multiples(4, &[3, 5]))
 }
 
 #[test]
 #[ignore]
 fn multiples_three() {
-    assert_eq!(23, sum_of_multiples(10, &vec![3, 5]))
+    assert_eq!(23, sum_of_multiples(10, &[3, 5]))
 }
 
 #[test]
 #[ignore]
 fn multiples_four() {
-    assert_eq!(2318, sum_of_multiples(100, &vec![3, 5]))
+    assert_eq!(2318, sum_of_multiples(100, &[3, 5]))
 }
 
 #[test]
 #[ignore]
 fn multiples_five() {
-    assert_eq!(233168, sum_of_multiples(1000, &vec![3, 5]))
+    assert_eq!(233168, sum_of_multiples(1000, &[3, 5]))
 }
 
 #[test]
 #[ignore]
 fn multiples_six() {
-    assert_eq!(51, sum_of_multiples(20, &vec![7, 13, 17]))
+    assert_eq!(51, sum_of_multiples(20, &[7, 13, 17]))
 }
 
 #[test]
 #[ignore]
 fn multiples_seven() {
-    assert_eq!(30, sum_of_multiples(15, &vec![4, 6]))
+    assert_eq!(30, sum_of_multiples(15, &[4, 6]))
 }
 
 #[test]
 #[ignore]
 fn multiples_eight() {
-    assert_eq!(4419, sum_of_multiples(150, &vec![5, 6, 8]))
+    assert_eq!(4419, sum_of_multiples(150, &[5, 6, 8]))
 }
 
 #[test]
 #[ignore]
 fn multiples_nine() {
-    assert_eq!(275, sum_of_multiples(51, &vec![5, 25]))
+    assert_eq!(275, sum_of_multiples(51, &[5, 25]))
 }
 
 #[test]
 #[ignore]
 fn multiples_ten() {
-    assert_eq!(2203160, sum_of_multiples(10000, &vec![43, 47]))
+    assert_eq!(2203160, sum_of_multiples(10000, &[43, 47]))
 }
 
 #[test]
 #[ignore]
 fn multiples_eleven() {
-    assert_eq!(4950, sum_of_multiples(100, &vec![1]))
+    assert_eq!(4950, sum_of_multiples(100, &[1]))
 }
 
 #[test]
 #[ignore]
 fn multiples_twelve() {
-    assert_eq!(0, sum_of_multiples(10000, &vec![]))
+    assert_eq!(0, sum_of_multiples(10000, &[]))
 }

--- a/exercises/word-count/tests/word-count.rs
+++ b/exercises/word-count/tests/word-count.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 extern crate word_count;
 
-fn check_word_count(s: &str, pairs: Vec<(&str, u32)>) {
+fn check_word_count(s: &str, pairs: &[(&str, u32)]) {
     // The reason for the awkward code in here is to ensure that the failure
     // message for assert_eq! is as informative as possible. A simpler
     // solution would simply check the length of the map, and then
@@ -17,7 +17,7 @@ fn check_word_count(s: &str, pairs: Vec<(&str, u32)>) {
 
 #[test]
 fn test_count_one_word() {
-    check_word_count("word", vec![("word", 1)]);
+    check_word_count("word", &[("word", 1)]);
 }
 
 #[test]
@@ -25,9 +25,9 @@ fn test_count_one_word() {
 fn test_count_one_of_each() {
     check_word_count(
         "one of each",
-        vec![("one", 1),
-             ("of", 1),
-             ("each", 1)]);
+        &[("one", 1),
+          ("of", 1),
+          ("each", 1)]);
 }
 
 #[test]
@@ -35,11 +35,11 @@ fn test_count_one_of_each() {
 fn test_count_multiple_occurrences() {
     check_word_count(
         "one fish two fish red fish blue fish",
-        vec![("one", 1),
-             ("fish", 4),
-             ("two", 1),
-             ("red", 1),
-             ("blue", 1)]);
+        &[("one", 1),
+          ("fish", 4),
+          ("two", 1),
+          ("red", 1),
+          ("blue", 1)]);
 }
 
 #[test]
@@ -47,11 +47,11 @@ fn test_count_multiple_occurrences() {
 fn test_ignore_punctuation() {
     check_word_count(
         "car : carpet as java : javascript!!&@$%^&",
-        vec![("car", 1),
-             ("carpet", 1),
-             ("as", 1),
-             ("java", 1),
-             ("javascript", 1)]);
+        &[("car", 1),
+          ("carpet", 1),
+          ("as", 1),
+          ("java", 1),
+          ("javascript", 1)]);
 }
 
 #[test]
@@ -59,9 +59,9 @@ fn test_ignore_punctuation() {
 fn test_include_numbers() {
     check_word_count(
         "testing, 1, 2 testing",
-        vec![("testing", 2),
-             ("1", 1),
-             ("2", 1)]);
+        &[("testing", 2),
+          ("1", 1),
+          ("2", 1)]);
 }
 
 #[test]
@@ -69,6 +69,6 @@ fn test_include_numbers() {
 fn test_normalize_case() {
     check_word_count(
         "go Go GO Stop stop",
-        vec![("go", 3),
-             ("stop", 2)]);
+        &[("go", 3),
+          ("stop", 2)]);
 }


### PR DESCRIPTION
I believe this covers the following Clippy lints:

1. writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices.
  * Where this was encountered, the signatures were changed from `Vec<T>` to `&[T]` in one commit; the resulting code compiles. Then a second commit was additionally made to change uses of `vec!` into slices, which is not necessitated by the first commit by the commit but is enabled by it.
2. this argument is passed by value, but not consumed in the function body
  * Where this was encountered, the signatures were changed from `Vec<T>` to `&[T]` and the usages were changed from `vec!` to slices in one commit, since both changes need to happen together for the tests to compile.
3. useless use of `vec!`
  * Where this was encountered, uses of `vec!` were changed to slices.