### PR TITLE
react: return domain-specific errors (DO NOT MERGE, reference for #434 #464 merge ONLY)

### DIFF
--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -91,14 +91,11 @@ impl <'a, T: Copy + PartialEq> Reactor<'a, T> {
     }
 
     pub fn add_callback<F: FnMut(T) -> () + 'a>(&mut self, id: CellID, callback: F) -> Option<CallbackID> {
-        match self.cells.get_mut(id) {
-            Some(c) => {
-                c.callbacks_issued += 1;
-                c.callbacks.insert(c.callbacks_issued, Box::new(callback));
-                Some(c.callbacks_issued)
-            },
-            None => None,
-        }
+        self.cells.get_mut(id).map(|c| {
+            c.callbacks_issued += 1;
+            c.callbacks.insert(c.callbacks_issued, Box::new(callback));
+            c.callbacks_issued
+        })
     }
 
     pub fn remove_callback(&mut self, cell: CellID, callback: CallbackID) -> Result<(), &'static str> {

--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -90,14 +90,14 @@ impl <'a, T: Copy + PartialEq> Reactor<'a, T> {
         })
     }
 
-    pub fn add_callback<F: FnMut(T) -> () + 'a>(&mut self, id: CellID, callback: F) -> Result<CallbackID, &'static str> {
+    pub fn add_callback<F: FnMut(T) -> () + 'a>(&mut self, id: CellID, callback: F) -> Option<CallbackID> {
         match self.cells.get_mut(id) {
             Some(c) => {
                 c.callbacks_issued += 1;
                 c.callbacks.insert(c.callbacks_issued, Box::new(callback));
-                Ok(c.callbacks_issued)
+                Some(c.callbacks_issued)
             },
-            None => Err("Can't add callback to nonexistent cell"),
+            None => None,
         }
     }
 

--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -9,6 +9,12 @@ pub enum SetValueError {
     ComputeCell,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum RemoveCallbackError {
+    NonexistentCell,
+    NonexistentCallback,
+}
+
 struct Cell<'a, T: Copy> {
     value: T,
     last_value: T,
@@ -104,13 +110,13 @@ impl <'a, T: Copy + PartialEq> Reactor<'a, T> {
         })
     }
 
-    pub fn remove_callback(&mut self, cell: CellID, callback: CallbackID) -> Result<(), &'static str> {
+    pub fn remove_callback(&mut self, cell: CellID, callback: CallbackID) -> Result<(), RemoveCallbackError> {
         match self.cells.get_mut(cell) {
             Some(c) => match c.callbacks.remove(&callback) {
                 Some(_) => Ok(()),
-                None => Err("Can't remove nonexistent callback"),
+                None => Err(RemoveCallbackError::NonexistentCallback),
             },
-            None => Err("Can't remove callback from nonexistent cell"),
+            None => Err(RemoveCallbackError::NonexistentCell),
         }
     }
 

--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -46,11 +46,13 @@ impl <'a, T: Copy + PartialEq> Reactor<'a, T> {
         self.cells.len() - 1
     }
 
-    pub fn create_compute<F: Fn(&[T]) -> T + 'a>(&mut self, dependencies: &[CellID], compute_func: F) -> Result<CellID, &'static str> {
+    pub fn create_compute<F: Fn(&[T]) -> T + 'a>(&mut self, dependencies: &[CellID], compute_func: F) -> Result<CellID, CellID> {
         // Check all dependencies' validity before modifying any of them,
         // so that we don't perform an incorrect partial write.
-        if !dependencies.iter().all(|&id| id < self.cells.len()) {
-            return Err("Nonexistent input");
+        for &dep in dependencies {
+            if dep >= self.cells.len() {
+                return Err(dep);
+            }
         }
         let new_id = self.cells.len();
         for &id in dependencies {

--- a/exercises/react/src/lib.rs
+++ b/exercises/react/src/lib.rs
@@ -28,12 +28,14 @@ impl <T: Copy + PartialEq> Reactor<T> {
     // You do not need to reject compute functions that expect more arguments than there are
     // dependencies (how would you check for this, anyway?).
     //
-    // Return an Err (and you can change the error type) if any dependency doesn't exist.
+    // If any dependency doesn't exist, returns an Err with that nonexistent dependency.
+    // (If multiple dependencies do not exist, exactly which one is returned is not defined and
+    // will not be tested)
     //
     // Notice that there is no way to *remove* a cell.
     // This means that you may assume, without checking, that if the dependencies exist at creation
     // time they will continue to exist as long as the Reactor exists.
-    pub fn create_compute<F: Fn(&[T]) -> T>(&mut self, dependencies: &[CellID], compute_func: F) -> Result<CellID, ()> {
+    pub fn create_compute<F: Fn(&[T]) -> T>(&mut self, dependencies: &[CellID], compute_func: F) -> Result<CellID, CellID> {
         unimplemented!()
     }
 

--- a/exercises/react/src/lib.rs
+++ b/exercises/react/src/lib.rs
@@ -11,6 +11,12 @@ pub enum SetValueError {
     ComputeCell,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum RemoveCallbackError {
+    NonexistentCell,
+    NonexistentCallback,
+}
+
 pub struct Reactor<T> {
     // Just so that the compiler doesn't complain about an unused type parameter.
     // You probably want to delete this field.
@@ -89,11 +95,10 @@ impl <T: Copy + PartialEq> Reactor<T> {
 
     // Removes the specified callback, using an ID returned from add_callback.
     //
-    // Return an Err (and you can change the error type) if either the cell or callback
-    // does not exist.
+    // Returns an Err if either the cell or callback does not exist.
     //
     // A removed callback should no longer be called.
-    pub fn remove_callback(&mut self, cell: CellID, callback: CallbackID) -> Result<(), ()> {
+    pub fn remove_callback(&mut self, cell: CellID, callback: CallbackID) -> Result<(), RemoveCallbackError> {
         unimplemented!()
     }
 }

--- a/exercises/react/src/lib.rs
+++ b/exercises/react/src/lib.rs
@@ -5,6 +5,12 @@
 pub type CellID = ();
 pub type CallbackID = ();
 
+#[derive(Debug, PartialEq)]
+pub enum SetValueError {
+    NonexistentCell,
+    ComputeCell,
+}
+
 pub struct Reactor<T> {
     // Just so that the compiler doesn't complain about an unused type parameter.
     // You probably want to delete this field.
@@ -52,14 +58,16 @@ impl <T: Copy + PartialEq> Reactor<T> {
 
     // Sets the value of the specified input cell.
     //
-    // Return an Err (and you can change the error type) if the cell does not exist, or the
-    // specified cell is a compute cell, since compute cells cannot have their values directly set.
+    // Returns an Err if either:
+    // * the cell does not exist
+    // * the specified cell is a compute cell, since compute cells cannot have their values
+    //   directly set.
     //
     // Similarly, you may wonder about `get_mut(&mut self, id: CellID) -> Option<&mut Cell>`, with
     // a `set_value(&mut self, new_value: T)` method on `Cell`.
     //
     // As before, that turned out to add too much extra complexity.
-    pub fn set_value(&mut self, id: CellID, new_value: T) -> Result<(), ()> {
+    pub fn set_value(&mut self, id: CellID, new_value: T) -> Result<(), SetValueError> {
         unimplemented!()
     }
 

--- a/exercises/react/src/lib.rs
+++ b/exercises/react/src/lib.rs
@@ -65,7 +65,7 @@ impl <T: Copy + PartialEq> Reactor<T> {
 
     // Adds a callback to the specified compute cell.
     //
-    // Return an Err (and you can change the error type) if the cell does not exist.
+    // Returns the ID of the just-added callback, or None if the cell doesn't exist.
     //
     // Callbacks on input cells will not be tested.
     //
@@ -75,7 +75,7 @@ impl <T: Copy + PartialEq> Reactor<T> {
     // * Exactly once if the compute cell's value changed as a result of the set_value call.
     //   The value passed to the callback should be the final value of the compute cell after the
     //   set_value call.
-    pub fn add_callback<F: FnMut(T) -> ()>(&mut self, id: CellID, callback: F) -> Result<CallbackID, ()> {
+    pub fn add_callback<F: FnMut(T) -> ()>(&mut self, id: CellID, callback: F) -> Option<CallbackID> {
         unimplemented!()
     }
 

--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -56,7 +56,7 @@ fn an_input_cells_value_can_be_set() {
 fn error_setting_a_nonexistent_input_cell() {
     let mut dummy_reactor = Reactor::new();
     let input = dummy_reactor.create_input(1);
-    assert!(Reactor::new().set_value(input, 0).is_err());
+    assert_eq!(Reactor::new().set_value(input, 0), Err(SetValueError::NonexistentCell));
 }
 
 #[test]
@@ -129,7 +129,7 @@ fn error_setting_a_compute_cell() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let output = reactor.create_compute(&[input], |_| 0).unwrap();
-    assert!(reactor.set_value(output, 3).is_err());
+    assert_eq!(reactor.set_value(output, 3), Err(SetValueError::ComputeCell));
 }
 
 #[test]

--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -83,7 +83,7 @@ fn compute_cells_take_inputs_in_the_right_order() {
 fn error_creating_compute_cell_if_input_doesnt_exist() {
     let mut dummy_reactor = Reactor::new();
     let input = dummy_reactor.create_input(1);
-    assert!(Reactor::new().create_compute(&[input], |_| 0).is_err());
+    assert_eq!(Reactor::new().create_compute(&[input], |_| 0), Err(input));
 }
 
 #[test]
@@ -94,7 +94,7 @@ fn do_not_break_cell_if_creating_compute_cell_with_valid_and_invalid_input() {
     let dummy_cell = dummy_reactor.create_input(2);
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
-    assert!(reactor.create_compute(&[input, dummy_cell], |_| 0).is_err());
+    assert_eq!(reactor.create_compute(&[input, dummy_cell], |_| 0), Err(dummy_cell));
     assert!(reactor.set_value(input, 5).is_ok());
     assert_eq!(reactor.value(input), Some(5));
 }

--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -206,10 +206,10 @@ fn removing_a_callback_multiple_times_doesnt_interfere_with_other_callbacks() {
     let output = reactor.create_compute(&[input], |v| v[0] + 1).unwrap();
     let callback = reactor.add_callback(output, |v| cb1.callback_called(v)).unwrap();
     assert!(reactor.add_callback(output, |v| cb2.callback_called(v)).is_some());
-    // We want the first remove to be Ok, but we don't care about the others.
+    // We want the first remove to be Ok, but the others should be errors.
     assert!(reactor.remove_callback(output, callback).is_ok());
     for _ in 1..5 {
-        assert!(reactor.remove_callback(output, callback).is_err());
+        assert_eq!(reactor.remove_callback(output, callback), Err(RemoveCallbackError::NonexistentCallback));
     }
 
     assert!(reactor.set_value(input, 2).is_ok());


### PR DESCRIPTION
Closes https://github.com/exercism/rust/issues/462.
Closes #464 by mutual exclusion.

Note to reviewers: Since this will inevitably conflict with https://github.com/exercism/rust/pull/434, I chose to make all commits on top of https://github.com/exercism/rust/pull/434. This assumes that https://github.com/exercism/rust/pull/434 is getting merged before this one.

You should ignore the commit from #434 in your review of this PR.

If you would instead prefer the changes described in this PR be merged before #434 (perhaps you can review this one very quickly but require more time to review #434), you must instead review #464. Then #434 will rebased on #464.

I have no particular preference on whether the five commits comprising this PR should be squashed (but please do not squash them together with #434).