### PR TITLE
Switch travis config away from container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 - "./bin/fetch-configlet"
 - "sh ./_test/ensure-readmes-are-updated.sh"
 - "./bin/configlet lint ."
-sudo: false
+sudo: true
 rust:
   - stable
   - beta


### PR DESCRIPTION
The sudo: false option runs on older infrastructure; experimenting with sudo: true to see how it affects
the build time.