### PR TITLE
ocr-numbers: Return domain-specific error

### DIFF
--- a/exercises/ocr-numbers/example.rs
+++ b/exercises/ocr-numbers/example.rs
@@ -2,16 +2,20 @@ use std::collections::BTreeMap;
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
-    InvalidRowCount,
-    InvalidColumnCount,
+    InvalidRowCount(usize),
+    InvalidColumnCount(usize),
 }
 
 pub fn convert(input: &str) -> Result<String, Error> {
-    if input.lines().count() % 4 != 0 {
-        return Err(Error::InvalidRowCount);
+    let line_count = input.lines().count();
+    if line_count % 4 != 0 {
+        return Err(Error::InvalidRowCount(line_count));
     }
-    if input.lines().any(|line| line.chars().count() % 3 != 0) {
-        return Err(Error::InvalidColumnCount);
+    for line in input.lines() {
+        let char_count = line.chars().count();
+        if char_count % 3 != 0 {
+            return Err(Error::InvalidColumnCount(char_count));
+        }
     }
 
     let y = input.lines().collect::<Vec<_>>();

--- a/exercises/ocr-numbers/example.rs
+++ b/exercises/ocr-numbers/example.rs
@@ -1,13 +1,17 @@
 use std::collections::BTreeMap;
-use std::str::Lines;
 
-fn lines_valid(lines: &Lines) -> bool {
-    lines.clone().count() % 4 == 0 && lines.clone().all(|line| line.chars().count() % 3 == 0)
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    InvalidRowCount,
+    InvalidColumnCount,
 }
 
-pub fn convert(input: &str) -> Result<String, ()> {
-    if !lines_valid(&input.lines()) {
-        return Err(());
+pub fn convert(input: &str) -> Result<String, Error> {
+    if input.lines().count() % 4 != 0 {
+        return Err(Error::InvalidRowCount);
+    }
+    if input.lines().any(|line| line.chars().count() % 3 != 0) {
+        return Err(Error::InvalidColumnCount);
     }
 
     let y = input.lines().collect::<Vec<_>>();

--- a/exercises/ocr-numbers/src/lib.rs
+++ b/exercises/ocr-numbers/src/lib.rs
@@ -3,8 +3,8 @@
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
-    InvalidRowCount,
-    InvalidColumnCount,
+    InvalidRowCount(usize),
+    InvalidColumnCount(usize),
 }
 
 #[allow(unused_variables)]

--- a/exercises/ocr-numbers/src/lib.rs
+++ b/exercises/ocr-numbers/src/lib.rs
@@ -1,7 +1,13 @@
 // The code below is a stub. Just enough to satisfy the compiler.
 // In order to pass the tests you can add-to or change any of this code.
 
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    InvalidRowCount,
+    InvalidColumnCount,
+}
+
 #[allow(unused_variables)]
-pub fn convert(input: &str) -> Result<String, ()> {
+pub fn convert(input: &str) -> Result<String, Error> {
     unimplemented!();
 }

--- a/exercises/ocr-numbers/tests/ocr-numbers.rs
+++ b/exercises/ocr-numbers/tests/ocr-numbers.rs
@@ -7,7 +7,7 @@ fn input_with_lines_not_multiple_of_four_is_error() {
                 "| |\n" +
                 "   ";
 
-    assert_eq!(Err(ocr::Error::InvalidRowCount), ocr::convert(&input));
+    assert_eq!(Err(ocr::Error::InvalidRowCount(3)), ocr::convert(&input));
 }
 
 #[test]
@@ -19,7 +19,7 @@ fn input_with_columns_not_multiple_of_three_is_error() {
                 "   |\n" +
                 "    ";
 
-    assert_eq!(Err(ocr::Error::InvalidColumnCount), ocr::convert(&input));
+    assert_eq!(Err(ocr::Error::InvalidColumnCount(4)), ocr::convert(&input));
 }
 
 

--- a/exercises/ocr-numbers/tests/ocr-numbers.rs
+++ b/exercises/ocr-numbers/tests/ocr-numbers.rs
@@ -7,7 +7,7 @@ fn input_with_lines_not_multiple_of_four_is_error() {
                 "| |\n" +
                 "   ";
 
-    assert!(ocr::convert(&input).is_err());
+    assert_eq!(Err(ocr::Error::InvalidRowCount), ocr::convert(&input));
 }
 
 #[test]
@@ -19,7 +19,7 @@ fn input_with_columns_not_multiple_of_three_is_error() {
                 "   |\n" +
                 "    ";
 
-    assert!(ocr::convert(&input).is_err());
+    assert_eq!(Err(ocr::Error::InvalidColumnCount), ocr::convert(&input));
 }
 
 


### PR DESCRIPTION
We prefer domain-specific errors to empty tuple because the former are
programmatically inspectable. We would prefer to encourage students to
use domain-specific errors rather than empty tuple.

As discussed in #444.

---

One slight disadvantage is now it appears we have to be opinionated about what information is contained by the errors. The `InvalidRowCount` seems relatively uncontroversial, but one might imagine that the `InvalidColumnCount` could also include which line had an invalid column count. But, careful, that's hard to test because there are multiple lines with invalid column count, so should we accept all of them?

If we wanted to let students change what data the error variants will carry (perhaps they like to provide more information than what the test asks for), I guess we can have the tests just do a  `match { Error::InvalidRowCount(_) => ... }` and that would probably work (I haven't tested it). I'm not sure how much of a demand there is for this.