### PR TITLE
all-your-base: Return domain-specific error

### DIFF
--- a/exercises/all-your-base/example.rs
+++ b/exercises/all-your-base/example.rs
@@ -1,5 +1,12 @@
 pub type Digit = u32;
 
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    InvalidInputBase,
+    InvalidOutputBase,
+    InvalidDigit(Digit),
+}
+
 ///
 /// Convert a number between two bases.
 ///
@@ -31,15 +38,18 @@ pub type Digit = u32;
 ///  * Never output leading 0 digits. However, your function must be able to
 ///     process input with leading 0 digits.
 ///
-pub fn convert<P: AsRef<[Digit]>>(digits: P, from_base: Digit, to_base: Digit) -> Result<Vec<Digit>, &'static str> {
+pub fn convert<P: AsRef<[Digit]>>(digits: P, from_base: Digit, to_base: Digit) -> Result<Vec<Digit>, Error> {
     // check that both bases are in the correct range
-    if from_base < 2 || to_base < 2 {
-        return Err("Invalid base");
+    if from_base < 2 {
+        return Err(Error::InvalidInputBase);
+    }
+    if to_base < 2 {
+        return Err(Error::InvalidOutputBase);
     }
 
     // check that all digits are in the correct range specified by the base
-    if digits.as_ref().iter().any(|&num| num >= from_base) {
-        return Err("Digits invalid for input base");
+    if let Some(&invalid) = digits.as_ref().iter().find(|&num| *num >= from_base) {
+        return Err(Error::InvalidDigit(invalid));
     }
 
     // convert all digits into a single large number

--- a/exercises/all-your-base/src/lib.rs
+++ b/exercises/all-your-base/src/lib.rs
@@ -1,3 +1,10 @@
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    InvalidInputBase,
+    InvalidOutputBase,
+    InvalidDigit(u32),
+}
+
 ///
 /// Convert a number between two bases.
 ///

--- a/exercises/all-your-base/src/lib.rs
+++ b/exercises/all-your-base/src/lib.rs
@@ -37,6 +37,6 @@ pub enum Error {
 ///     process input with leading 0 digits.
 ///
 #[allow(unused_variables)]
-pub fn convert(number: &[u32], from_base: u32, to_base: u32) -> Result<Vec<u32>, ()> {
+pub fn convert(number: &[u32], from_base: u32, to_base: u32) -> Result<Vec<u32>, Error> {
     unimplemented!()
 }

--- a/exercises/all-your-base/tests/all-your-base.rs
+++ b/exercises/all-your-base/tests/all-your-base.rs
@@ -137,7 +137,8 @@ fn invalid_positive_digit() {
     let input_base = 2;
     let input_digits = &[1, 2, 1, 0, 1, 0];
     let output_base = 10;
-    assert!(ayb::convert(input_digits, input_base, output_base).is_err());
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Err(ayb::Error::InvalidDigit(2)));
 }
 
 #[test]
@@ -146,7 +147,8 @@ fn input_base_is_one() {
     let input_base = 1;
     let input_digits = &[];
     let output_base = 10;
-    assert!(ayb::convert(input_digits, input_base, output_base).is_err());
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Err(ayb::Error::InvalidInputBase));
 }
 
 #[test]
@@ -155,7 +157,8 @@ fn output_base_is_one() {
     let input_base = 2;
     let input_digits = &[1, 0, 1, 0, 1, 0];
     let output_base = 1;
-    assert!(ayb::convert(input_digits, input_base, output_base).is_err());
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Err(ayb::Error::InvalidOutputBase));
 }
 
 #[test]
@@ -164,7 +167,8 @@ fn input_base_is_zero() {
     let input_base = 0;
     let input_digits = &[];
     let output_base = 10;
-    assert!(ayb::convert(input_digits, input_base, output_base).is_err());
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Err(ayb::Error::InvalidInputBase));
 }
 
 #[test]
@@ -173,5 +177,6 @@ fn output_base_is_zero() {
     let input_base = 10;
     let input_digits = &[7];
     let output_base = 0;
-    assert!(ayb::convert(input_digits, input_base, output_base).is_err());
+    assert_eq!(ayb::convert(input_digits, input_base, output_base),
+               Err(ayb::Error::InvalidOutputBase));
 }


### PR DESCRIPTION
We prefer domain-specific errors to empty tuple because the former are
programmatically inspectable. We would prefer to encourage students to
use domain-specific errors rather than empty tuple.

As discussed in #444:
https://github.com/exercism/rust/issues/444