### PR TITLE
 largest-series-product: Expect specific errors; add stub

### DIFF
--- a/exercises/largest-series-product/example.rs
+++ b/exercises/largest-series-product/example.rs
@@ -1,10 +1,16 @@
-pub fn lsp(string_digits: &str, span: usize) -> Result<u64, String> {
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    SpanTooLong,
+    InvalidDigit(char),
+}
+
+pub fn lsp(string_digits: &str, span: usize) -> Result<u64, Error> {
     if span == 0 {
         return Ok(1);
     }
 
-    if string_digits.chars().any(|c| !c.is_digit(10)) {
-        return Err(String::from("All characters must be numbers"));
+    if let Some(invalid) = string_digits.chars().find(|c| !c.is_digit(10)) {
+        return Err(Error::InvalidDigit(invalid));
     }
 
     let products: Vec<u64> = string_digits.chars()
@@ -17,6 +23,6 @@ pub fn lsp(string_digits: &str, span: usize) -> Result<u64, String> {
     if let Some(&x) = products.iter().max() {
         Ok(x)
     } else {
-        Err(String::from("Span longer than string"))
+        Err(Error::SpanTooLong)
     }
 }

--- a/exercises/largest-series-product/src/lib.rs
+++ b/exercises/largest-series-product/src/lib.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    SpanTooLong,
+    InvalidDigit(char),
+}
+
+pub fn lsp(string_digits: &str, span: usize) -> Result<u64, Error> {
+    unimplemented!("largest series product of a span of {} digits in {}", span, string_digits);
+}

--- a/exercises/largest-series-product/tests/largest-series-product.rs
+++ b/exercises/largest-series-product/tests/largest-series-product.rs
@@ -65,7 +65,7 @@ fn returns_zero_if_all_products_are_zero() {
 #[test]
 #[ignore]
 fn a_span_is_longer_than_number_is_an_error() {
-    assert!(lsp("123", 4).is_err());
+    assert_eq!(Err(Error::SpanTooLong), lsp("123", 4));
 }
 
 // There may be some confusion about whether this should be 1 or error.
@@ -95,11 +95,11 @@ fn a_non_empty_string_and_no_span_returns_one() {
 #[test]
 #[ignore]
 fn empty_string_and_non_zero_span_is_an_error() {
-    assert!(lsp("", 1).is_err());
+    assert_eq!(Err(Error::SpanTooLong), lsp("", 1));
 }
 
 #[test]
 #[ignore]
 fn a_string_with_non_digits_is_an_error() {
-    assert!(lsp("1234a5", 2).is_err());
+    assert_eq!(Err(Error::InvalidDigit('a')), lsp("1234a5", 2));
 }


### PR DESCRIPTION
To encourage students to be specific about error information.

Since specific errors were just added, stub is provided to help get
student running.

We decided that stubs are a good idea in
#269

We decided that domain-specific errors are a good idea in
#444