### PR TITLE
Swaps all `_` only parameters for `input`

### DIFF
--- a/exercises/alphametics/src/lib.rs
+++ b/exercises/alphametics/src/lib.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
 
-pub fn solve(_: &str) -> Option<HashMap<char, u8>> {
-    unimplemented!()
+pub fn solve(input: &str) -> Option<HashMap<char, u8>> {
+    unimplemented!("Solve the alphametric {}", input)
 }

--- a/exercises/alphametics/src/lib.rs
+++ b/exercises/alphametics/src/lib.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
 
 pub fn solve(input: &str) -> Option<HashMap<char, u8>> {
-    unimplemented!("Solve the alphametric {}", input)
+    unimplemented!("Solve the alphametric {:?}", input)
 }

--- a/exercises/alphametics/src/lib.rs
+++ b/exercises/alphametics/src/lib.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
 
 pub fn solve(input: &str) -> Option<HashMap<char, u8>> {
-    unimplemented!("Solve the alphametric {:?}", input)
+    unimplemented!("Solve the alphametic {:?}", input)
 }

--- a/exercises/book-store/src/lib.rs
+++ b/exercises/book-store/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn lowest_price(input: &[usize]) -> usize {
-    unimplemented!("Find the lowest price of the bookbasket: {}", input)
+    unimplemented!("Find the lowest price of the bookbasket: {:?}", input)
 }

--- a/exercises/book-store/src/lib.rs
+++ b/exercises/book-store/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn lowest_price(_: &[usize]) -> usize {
-    unimplemented!()
+pub fn lowest_price(input: &[usize]) -> usize {
+    unimplemented!("Find the lowest price of the bookbasket: {}", input)
 }

--- a/exercises/book-store/src/lib.rs
+++ b/exercises/book-store/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn lowest_price(input: &[usize]) -> usize {
-    unimplemented!("Find the lowest price of the bookbasket: {:?}", input)
+pub fn lowest_price(books: &[usize]) -> usize {
+    unimplemented!("Find the lowest price of the bookbasket with books {:?}", books)
 }

--- a/exercises/crypto-square/src/lib.rs
+++ b/exercises/crypto-square/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn encrypt(input: &str) -> String {
-    unimplemented!("Encrypt {} using a square code", input)
+    unimplemented!("Encrypt {:?} using a square code", input)
 }

--- a/exercises/crypto-square/src/lib.rs
+++ b/exercises/crypto-square/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn encrypt(_: &str) -> String {
-    unimplemented!()
+pub fn encrypt(input: &str) -> String {
+    unimplemented!("Encrypt {} using a square code", input)
 }

--- a/exercises/decimal/src/lib.rs
+++ b/exercises/decimal/src/lib.rs
@@ -5,6 +5,6 @@ pub struct Decimal {
 
 impl Decimal {
     pub fn try_from(input: &str) -> Option<Decimal> {
-        unimplemented!("Create a new decimal with a value of {}", input)
+        unimplemented!("Create a new decimal with a value of {:?}", input)
     }
 }

--- a/exercises/decimal/src/lib.rs
+++ b/exercises/decimal/src/lib.rs
@@ -5,6 +5,6 @@ pub struct Decimal {
 
 impl Decimal {
     pub fn try_from(input: &str) -> Option<Decimal> {
-        unimplemented!("Create a new decimal with a value of {:?}", input)
+        unimplemented!("Create a new decimal with a value of {}", input)
     }
 }

--- a/exercises/decimal/src/lib.rs
+++ b/exercises/decimal/src/lib.rs
@@ -4,7 +4,7 @@ pub struct Decimal {
 }
 
 impl Decimal {
-    pub fn try_from(_: &str) -> Option<Decimal> {
-        unimplemented!()
+    pub fn try_from(input: &str) -> Option<Decimal> {
+        unimplemented!("Create a new decimal with a value of {}", input)
     }
 }

--- a/exercises/poker/src/lib.rs
+++ b/exercises/poker/src/lib.rs
@@ -2,6 +2,6 @@
 ///
 /// Note the type signature: this function should return _the same_ reference to
 /// the winning hand(s) as were passed in, not reconstructed strings which happen to be equal.
-pub fn winning_hands<'a>(input: &[&'a str]) -> Option<Vec<&'a str>> {
-    unimplemented!("Out of {:?}, which hand wins?", input)
+pub fn winning_hands<'a>(hands: &[&'a str]) -> Option<Vec<&'a str>> {
+    unimplemented!("Out of {:?}, which hand wins?", hands)
 }

--- a/exercises/poker/src/lib.rs
+++ b/exercises/poker/src/lib.rs
@@ -2,6 +2,6 @@
 ///
 /// Note the type signature: this function should return _the same_ reference to
 /// the winning hand(s) as were passed in, not reconstructed strings which happen to be equal.
-pub fn winning_hands<'a>(_: &[&'a str]) -> Option<Vec<&'a str>> {
-    unimplemented!()
+pub fn winning_hands<'a>(input: &[&'a str]) -> Option<Vec<&'a str>> {
+    unimplemented!("Out of {}, which hand wins?", input)
 }

--- a/exercises/poker/src/lib.rs
+++ b/exercises/poker/src/lib.rs
@@ -3,5 +3,5 @@
 /// Note the type signature: this function should return _the same_ reference to
 /// the winning hand(s) as were passed in, not reconstructed strings which happen to be equal.
 pub fn winning_hands<'a>(input: &[&'a str]) -> Option<Vec<&'a str>> {
-    unimplemented!("Out of {}, which hand wins?", input)
+    unimplemented!("Out of {:?}, which hand wins?", input)
 }


### PR DESCRIPTION
Resolves #442 

Changed the parameter to `input`, and uses it in `unimplemented!()` to silence the unused variable warning.

Some of the exercises reported in the issue used `_` as a prefix and not as a lone parameter (e.g. in isbn-verifier, `_isbn`).  I wasn't if those were also a problem, so I didn't change them.

Changed exercises:
- [x] alphametics
- [x] book-store
- [x] crypto-square
- [x] decimal
- [ ] diffie-hellman
- [ ] isbn-verifier
- [x] poker
- [ ] ~reverse-string~
- [ ] series

(reverse-string was already changed)