### PR TITLE
macros: Allow stub to not compile

### DIFF
--- a/exercises/macros/.meta/ALLOWED_TO_NOT_COMPILE
+++ b/exercises/macros/.meta/ALLOWED_TO_NOT_COMPILE
@@ -1,0 +1,2 @@
+Stub doesn't compile because there is no rule for the macro forms in the test file.
+Providing these rules would reduce student learning, so we do not.


### PR DESCRIPTION
The stub in fact does not compile and has never compiled ever since the
exercise was added in https://github.com/exercism/rust/pull/401.

However, it is intentional that the stub does not compile, so we allow
it not to.

This was not caught by https://github.com/exercism/rust/pull/372 because
of https://github.com/exercism/rust/pull/381 having tricked the Rust
compiler into thinking it had already compiled the stub.

This is required to be able to merge
https://github.com/exercism/rust/pull/483.