### PR TITLE
ensure-stubs-compile: Ensure compilation: Touch src/lib.rs

### DIFF
--- a/_test/ensure-stubs-compile.sh
+++ b/_test/ensure-stubs-compile.sh
@@ -11,6 +11,11 @@ for dir in $repo/exercises/*/; do
   # it probably contains function signatures, and these should compile.
   if grep -v '^//' $dir/src/lib.rs | grep '\S' > /dev/null; then
     allowed_file=$dir/.meta/ALLOWED_TO_NOT_COMPILE
+
+    # In Travis CI, we may have already compiled using the example solution.
+    # Touch the src/lib.rs file so that we surely recompile using the stub.
+    touch $dir/src/lib.rs
+
     if [ -f $allowed_file ]; then
       echo "$exercise's stub is allowed to not compile"
     elif ! (cd $dir && cargo test --quiet --no-run); then


### PR DESCRIPTION
Since https://github.com/exercism/rust/pull/372 we compile stubs to
ensure they are correct.

We were observed to still be compiling stubs as of
d44df84079a6d26c50b3d3d00c09d0da8f0b3c6f, whose parent is
a471e1854b86227a95bc8ab35c726c939369c484, the evidence being the build
of https://github.com/exercism/rust/pull/388:
https://travis-ci.org/exercism/rust/builds/298485455
We can see that many warnings are emitted from compiling the
stubs.

As of https://travis-ci.org/exercism/rust/builds/299096339 those
warnings disappeared.

Diagnosis: The test-exercise introduced in #381 tricks the compiler by
leaving the file in place, rather than the previous check-exercises
which always worked inside a temporary directory. As a result, when
running `ensure-stubs-compile` (which happens after `test-exercise` in
our Travis ordering), the compiler believes that the file is already
compiled and does not attempt to compile it again, even though it
should. The compiler compiled the example, but now it should be
compiling the stub.

To ensure that the compiler actually compiles the stub, we touch the
stub file.

As proof that this commit is correct: Travis CI build will fail
until https://github.com/exercism/rust/pull/482 is merged.
This demonstrates that stubs were not being compiled before this commit
and that after this commit they are being compiled.