### PR TITLE
crypto-square: Bring exercise implementation in line with README

### DIFF
--- a/exercises/crypto-square/example.rs
+++ b/exercises/crypto-square/example.rs
@@ -40,10 +40,18 @@ fn prepare(input: &str) -> Vec<char> {
     output.extend(
         input
             .chars()
-            .filter(|&c| c.is_ascii() && !c.is_whitespace())
-            .map(|c| c.to_ascii_lowercase())
-            .filter(|&c| c >= 'a' && c <= 'z'),
+            .filter(|&c| c.is_ascii() && !c.is_whitespace() && !c.is_ascii_punctuation())
+            .map(|c| c.to_ascii_lowercase()),
     );
+
+    // add space padding to the end such that the actual string returned
+    // forms a perfect rectangle
+    let (r, c) = dimensions(output.len());
+    let padding_qty = (r * c) - output.len();
+    for _ in 0..padding_qty {
+        output.push(' ');
+    }
+
     output.shrink_to_fit();
 
     output

--- a/exercises/crypto-square/tests/crypto-square.rs
+++ b/exercises/crypto-square/tests/crypto-square.rs
@@ -10,7 +10,6 @@ fn test_empty_input() {
     test("", "")
 }
 
-
 #[test]
 #[ignore]
 fn test_encrypt_also_decrypts_square() {
@@ -28,7 +27,7 @@ fn test_encrypt_also_decrypts_square() {
 fn test_example() {
     test(
         "If man was meant to stay on the ground, god would have given us roots.",
-        "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau",
+        "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau ",
     )
 }
 
@@ -56,15 +55,6 @@ fn test_everything_becomes_lowercase() {
 
 #[test]
 #[ignore]
-fn test_ignore_non_ascii_chars() {
-    test(
-        "She got her education, then got rich programming: 👩‍🎓🎓👩‍💻💰",
-        "setnhm hrigpm eeoori gdnton outrgg tchir haeca",
-    );
-}
-
-#[test]
-#[ignore]
 fn test_long() {
     test(
         r#"
@@ -79,10 +69,12 @@ and the others, too.
 
 -- John F. Kennedy, 12 September 1962
         "#,
-        &(String::from("wohaseagabnttenwan eoennaronedcwpghnf cnmdoseaisshettidk ") +
-              "hwodtyhlztkaaoocte oeoobbaweoilrnphhn ocnteuriaflleeowen shihctdlnolewwseoe " +
-              "eoneabbldusnietitd totoueesmrbglapnhy oshtscceeeeelrotes geiheaaranciienere " +
-              "otsetuuvseasnuensp todrhsseuruognadtt ogeteeetrgsntwntoe tochyttoeieeoidoom " +
-              "htaiahhotettalowjb eodnrearhshhclnioe mtegeytgeaaacienhr"),
+        &(String::from("womdbudlmecsgwdwob enooetbsenaotioihe ")
+            + "cwotcbeeaeunolnnnr henhaecrsrsealeaf1 ocieucavugetciwnk9 "
+            + "ohnosauerithcnhde6 sotteusteehaegitn2 eohhtseotsatptchn  "
+            + "tsiehetohatwtohee  oesrethrenceopwod  gtdtyhagbdhanoety  "
+            + "ooehaetaesaresih1  tgcirygnsklewtne2  ooaneaoitilweptrs  "
+            + "ttdgerazoleiaoese  hoesaeleflnlrnntp  etanshwaosgleedot  "
+            + "mhnoyainubeiuatoe  oedtbrldreinnnojm "),
     )
 }


### PR DESCRIPTION
The initial implementation of this exercise diverged from the
README: it stripped out the extra padding spaces specified, and
it eliminated all non-alphabetical characters instead of just
getting rid of punctuation.

This commit rectifies both of those diversions. This closes #458.
However, in doing so it uses a method only introduced in Rust 1.24;
only those people who are relatively recent in their Rust compilers
will be able to compile the example.

As the example is not primarily for students, this should be acceptable.