### PR TITLE
Replace first edition Rust book links with second edition

### DIFF
--- a/exercises/decimal/.meta/description.md
+++ b/exercises/decimal/.meta/description.md
@@ -15,5 +15,5 @@ It would be very easy to implement this exercise by using the [bigdecimal](https
 # Hints
 
 - Instead of implementing arbitrary-precision arithmetic from scratch, consider building your type on top of the [num_bigint](https://crates.io/crates/num-bigint) crate.
-- You might be able to [derive](https://doc.rust-lang.org/book/first-edition/traits.html#deriving) some of the required traits.
+- You might be able to [derive](https://doc.rust-lang.org/book/second-edition/appendix-03-derivable-traits.html) some of the required traits.
 - `Decimal` is assumed to be a signed type. You do not have to create a separate unsigned type, though you may do so as an implementation detail if you so choose.

--- a/exercises/decimal/README.md
+++ b/exercises/decimal/README.md
@@ -17,7 +17,7 @@ It would be very easy to implement this exercise by using the [bigdecimal](https
 # Hints
 
 - Instead of implementing arbitrary-precision arithmetic from scratch, consider building your type on top of the [num_bigint](https://crates.io/crates/num-bigint) crate.
-- You might be able to [derive](https://doc.rust-lang.org/book/first-edition/traits.html#deriving) some of the required traits.
+- You might be able to [derive](https://doc.rust-lang.org/book/second-edition/appendix-03-derivable-traits.html) some of the required traits.
 - `Decimal` is assumed to be a signed type. You do not have to create a separate unsigned type, though you may do so as an implementation detail if you so choose.
 
 ## Rust Installation

--- a/exercises/macros/.meta/description.md
+++ b/exercises/macros/.meta/description.md
@@ -8,7 +8,7 @@ What is a macro? [Wikipedia](https://en.wikipedia.org/wiki/Macro_(computer_scien
 
 Illuminating! But to be more concrete, macros are a special syntax which allows you to generate code at compile time. Macros can be used compile-time calculation, but more often they're just another way to abstract your code. For example, you've probably already used `println!()` and `vec![]`. These each take an arbitrary number of arguments, so you can't express them as simple functions. On the other hand, they always expand to some amount of absolutely standard Rust code. If you're interested, you can use the [cargo expand](https://github.com/dtolnay/cargo-expand) subcommand to view the results of macro expansion in your code.
 
-For further information about macros in Rust, The Rust Book has a [good chapter](https://doc.rust-lang.org/book/first-edition/macros.html) on them.
+For further information about macros in Rust, The Rust Book has a [good chapter](https://doc.rust-lang.org/book/second-edition/appendix-04-macros.html) on them.
 
 ## Problem Statement
 

--- a/exercises/macros/README.md
+++ b/exercises/macros/README.md
@@ -10,7 +10,7 @@ What is a macro? [Wikipedia](https://en.wikipedia.org/wiki/Macro_(computer_scien
 
 Illuminating! But to be more concrete, macros are a special syntax which allows you to generate code at compile time. Macros can be used compile-time calculation, but more often they're just another way to abstract your code. For example, you've probably already used `println!()` and `vec![]`. These each take an arbitrary number of arguments, so you can't express them as simple functions. On the other hand, they always expand to some amount of absolutely standard Rust code. If you're interested, you can use the [cargo expand](https://github.com/dtolnay/cargo-expand) subcommand to view the results of macro expansion in your code.
 
-For further information about macros in Rust, The Rust Book has a [good chapter](https://doc.rust-lang.org/book/first-edition/macros.html) on them.
+For further information about macros in Rust, The Rust Book has a [good chapter](https://doc.rust-lang.org/book/second-edition/appendix-04-macros.html) on them.
 
 ## Problem Statement
 

--- a/exercises/parallel-letter-frequency/.meta/hints.md
+++ b/exercises/parallel-letter-frequency/.meta/hints.md
@@ -28,5 +28,5 @@ rustup run nightly cargo bench
 
 Learn more about nightly Rust:
 
-- [Nightly Rust](https://doc.rust-lang.org/book/first-edition/release-channels.html)
+- [Nightly Rust](https://doc.rust-lang.org/book/second-edition/ch01-03-how-rust-is-made-and-nightly-rust.html)
 - [Rustup: Working with nightly](https://github.com/rust-lang-nursery/rustup.rs#working-with-nightly-rust)

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -37,7 +37,7 @@ rustup run nightly cargo bench
 
 Learn more about nightly Rust:
 
-- [Nightly Rust](https://doc.rust-lang.org/book/first-edition/release-channels.html)
+- [Nightly Rust](https://doc.rust-lang.org/book/second-edition/ch01-03-how-rust-is-made-and-nightly-rust.html)
 - [Rustup: Working with nightly](https://github.com/rust-lang-nursery/rustup.rs#working-with-nightly-rust)
 
 


### PR DESCRIPTION
I think all first edition chapters have second edition equivalents. Rationale in individual commit messages. 

If all additions are accepted, these three commits collectively close https://github.com/exercism/rust/issues/356.