### PR TITLE
Remove #[allow(unused_variables)]

### DIFF
--- a/exercises/all-your-base/src/lib.rs
+++ b/exercises/all-your-base/src/lib.rs
@@ -36,7 +36,6 @@ pub enum Error {
 ///  * Never output leading 0 digits. However, your function must be able to
 ///     process input with leading 0 digits.
 ///
-#[allow(unused_variables)]
 pub fn convert(number: &[u32], from_base: u32, to_base: u32) -> Result<Vec<u32>, Error> {
-    unimplemented!()
+    unimplemented!("Convert {:?} from base {} to base {}", number, from_base, to_base)
 }

--- a/exercises/grade-school/src/lib.rs
+++ b/exercises/grade-school/src/lib.rs
@@ -1,5 +1,3 @@
-#[allow(unused_variables)]
-
 pub struct School {
 }
 
@@ -9,7 +7,7 @@ impl School {
     }
 
     pub fn add(&mut self, grade: u32, student: &str) {
-        unimplemented!()
+        unimplemented!("Add {} to the roster for {}", student, grade)
     }
 
     pub fn grades(&self) -> Vec<u32> {
@@ -21,6 +19,6 @@ impl School {
     // By returning an owned vector instead,
     // the internal implementation is free to use whatever it chooses.
     pub fn grade(&self, grade: u32) -> Option<Vec<String>> {
-        unimplemented!()
+        unimplemented!("Return the list of students in {}", grade)
     }
 }

--- a/exercises/ocr-numbers/src/lib.rs
+++ b/exercises/ocr-numbers/src/lib.rs
@@ -7,7 +7,6 @@ pub enum Error {
     InvalidColumnCount(usize),
 }
 
-#[allow(unused_variables)]
 pub fn convert(input: &str) -> Result<String, Error> {
-    unimplemented!();
+    unimplemented!("Convert the input '{}' to a string", input);
 }

--- a/exercises/react/src/lib.rs
+++ b/exercises/react/src/lib.rs
@@ -1,5 +1,3 @@
-#[allow(unused_variables)]
-
 // Because these are passed without & to some functions,
 // it will probably be necessary for these two types to be Copy.
 pub type CellID = ();
@@ -20,7 +18,7 @@ pub enum RemoveCallbackError {
 pub struct Reactor<T> {
     // Just so that the compiler doesn't complain about an unused type parameter.
     // You probably want to delete this field.
-    dummy: T,
+    dummy: ::std::marker::PhantomData<T>,
 }
 
 // You are guaranteed that Reactor will only be tested against types that are Copy + PartialEq.
@@ -30,7 +28,7 @@ impl <T: Copy + PartialEq> Reactor<T> {
     }
 
     // Creates an input cell with the specified initial value, returning its ID.
-    pub fn create_input(&mut self, initial: T) -> CellID {
+    pub fn create_input(&mut self, _initial: T) -> CellID {
         unimplemented!()
     }
 
@@ -47,7 +45,7 @@ impl <T: Copy + PartialEq> Reactor<T> {
     // Notice that there is no way to *remove* a cell.
     // This means that you may assume, without checking, that if the dependencies exist at creation
     // time they will continue to exist as long as the Reactor exists.
-    pub fn create_compute<F: Fn(&[T]) -> T>(&mut self, dependencies: &[CellID], compute_func: F) -> Result<CellID, CellID> {
+    pub fn create_compute<F: Fn(&[T]) -> T>(&mut self, _dependencies: &[CellID], _compute_func: F) -> Result<CellID, CellID> {
         unimplemented!()
     }
 
@@ -59,7 +57,7 @@ impl <T: Copy + PartialEq> Reactor<T> {
     // It turns out this introduces a significant amount of extra complexity to this exercise.
     // We chose not to cover this here, since this exercise is probably enough work as-is.
     pub fn value(&self, id: CellID) -> Option<T> {
-        unimplemented!()
+        unimplemented!("Get the value of the cell whose id is {:?}", id)
     }
 
     // Sets the value of the specified input cell.
@@ -73,7 +71,7 @@ impl <T: Copy + PartialEq> Reactor<T> {
     // a `set_value(&mut self, new_value: T)` method on `Cell`.
     //
     // As before, that turned out to add too much extra complexity.
-    pub fn set_value(&mut self, id: CellID, new_value: T) -> Result<(), SetValueError> {
+    pub fn set_value(&mut self, _id: CellID, _new_value: T) -> Result<(), SetValueError> {
         unimplemented!()
     }
 
@@ -89,7 +87,7 @@ impl <T: Copy + PartialEq> Reactor<T> {
     // * Exactly once if the compute cell's value changed as a result of the set_value call.
     //   The value passed to the callback should be the final value of the compute cell after the
     //   set_value call.
-    pub fn add_callback<F: FnMut(T) -> ()>(&mut self, id: CellID, callback: F) -> Option<CallbackID> {
+    pub fn add_callback<F: FnMut(T) -> ()>(&mut self, _id: CellID, _callback: F) -> Option<CallbackID> {
         unimplemented!()
     }
 
@@ -99,6 +97,10 @@ impl <T: Copy + PartialEq> Reactor<T> {
     //
     // A removed callback should no longer be called.
     pub fn remove_callback(&mut self, cell: CellID, callback: CallbackID) -> Result<(), RemoveCallbackError> {
-        unimplemented!()
+        unimplemented!(
+            "Remove the callback identified by the CallbackID {:?} from the cell {:?}",
+            callback,
+            cell,
+        )
     }
 }

--- a/exercises/robot-simulator/src/lib.rs
+++ b/exercises/robot-simulator/src/lib.rs
@@ -12,9 +12,12 @@ pub enum Direction {
 pub struct Robot;
 
 impl Robot {
-    #[allow(unused_variables)]
     pub fn new(x: isize, y: isize, d: Direction) -> Self {
-        unimplemented!()
+        unimplemented!(
+            "Create a robot at (x, y) ({}, {}) facing {:?}",
+            x, y,
+            d,
+        )
     }
 
     pub fn turn_right(self) -> Self {
@@ -29,9 +32,8 @@ impl Robot {
         unimplemented!()
     }
 
-    #[allow(unused_variables)]
     pub fn instructions(self, instructions: &str) -> Self {
-        unimplemented!()
+        unimplemented!("Follow the given sequence of instructions: {}", instructions)
     }
 
     pub fn position(&self) -> (isize, isize) {

--- a/exercises/space-age/src/lib.rs
+++ b/exercises/space-age/src/lib.rs
@@ -1,18 +1,21 @@
 // The code below is a stub. Just enough to satisfy the compiler.
 // In order to pass the tests you can add-to or change any of this code.
-#![allow(unused_variables)]
 
+#[derive(Debug)]
 pub struct Duration;
 
 impl From<u64> for Duration {
     fn from(s: u64) -> Self {
-        unimplemented!()
+        unimplemented!("s, measured in seconds: {}", s)
     }
 }
 
 pub trait Planet {
     fn years_during(d: &Duration) -> f64 {
-        unimplemented!();
+        unimplemented!(
+            "convert a duration ({:?}) to the number of years on this planet for that duration",
+            d,
+        );
     }
 }
 


### PR DESCRIPTION
Closes #481.

Note that in the case of the react exercise, it wasn't possible to follow the standard procedure of adding a use of the variables in the unimplemented block. This is because react uses the generic types `F` and `T`, which are not bounded by the `Debug` trait. In that case, I fell back to the underscore-prefix pattern; students who reach a level 10 exercise should not be confused by it.