### PR TITLE
 ensure-stubs-compile: Deny warnings in tests

### DIFF
--- a/_test/ensure-stubs-compile.sh
+++ b/_test/ensure-stubs-compile.sh
@@ -16,12 +16,24 @@ for dir in $repo/exercises/*/; do
     # Touch the src/lib.rs file so that we surely recompile using the stub.
     touch $dir/src/lib.rs
 
+    # Backup tests; this script will modify them.
+    cp -r $dir/tests $dir/tests.orig
+
+    # Deny warnings in the tests that may result from compiling the stubs.
+    # This helps avoid, for example, an overflowing literal warning
+    # that could be caused by a stub with a type that is too small.
+    sed -i -e '1i #![deny(warnings)]' $dir/tests/*.rs
+
     if [ -f $allowed_file ]; then
       echo "$exercise's stub is allowed to not compile"
     elif ! (cd $dir && cargo test --quiet --no-run); then
       echo "$exercise's stub does not compile; please make it compile or remove all non-commented lines"
       broken="$broken\n$exercise"
     fi
+
+    # Restore tests.
+    rm -r $dir/tests
+    mv $dir/tests.orig $dir/tests
   fi
 done
 

--- a/exercises/prime-factors/src/lib.rs
+++ b/exercises/prime-factors/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn factors(n: u64) -> Vec<u64> {
+pub fn factors(n: u32) -> Vec<u32> {
     unimplemented!("This should calculate the prime factors of {}", n)
 }

--- a/exercises/prime-factors/src/lib.rs
+++ b/exercises/prime-factors/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn factors(n: u32) -> Vec<u32> {
+pub fn factors(n: u64) -> Vec<u64> {
     unimplemented!("This should calculate the prime factors of {}", n)
 }


### PR DESCRIPTION
We'd eventually like to deny all warnings from the stubs themselves as
well, but this is a good intermediate state.
    
Immediate motivation is avoiding an overflowing literal, but I imagine
there are other unforeseen benefits as well.
    
Note that this required backing up and restoring the tests directory,
since we are editing it.

Closes #461 

Note for reviewers: This PR contains a commit that re-breaks the stub, to validate that this check in fact prevents such stubs. I'd like to see the CI fail with that commit, then that commit reverted, then the CI pass. The entire thing should be squashed when merging so that the net change is only to ensure-stubs-compile.