### PR TITLE
armstrong-numbers: remove leading underscore from variable in stub

### DIFF
--- a/exercises/armstrong-numbers/src/lib.rs
+++ b/exercises/armstrong-numbers/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn is_armstrong_number(_num: u32) -> bool {
-    unimplemented!()
+pub fn is_armstrong_number(num: u32) -> bool {
+    unimplemented!("true if {} is an armstrong number", num)
 }


### PR DESCRIPTION
This discrepancy was discovered by the following useful command:

```shell
xrust$ rg 'fn .*\b_' exercises/ -trust
```