### PR TITLE
Eliminate stub warnings

### DIFF
--- a/_test/check-stubs.sh
+++ b/_test/check-stubs.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This checks every stub which exists, and emits all of their warnings.
+# To get a list of exercises for which there are warnings on compilation,
+# run it like this:
+#
+# $ _test/check-stubs.sh 2>/dev/null | rev | cut -d/ -f1 | rev
+
+# run 'cargo check' on every exercise which possesses a stub
+repo=$(cd "$(dirname "$0")/.." && pwd)
+
+for stub in $repo/exercises/*/src/lib.rs; do
+    exercise=$(dirname $(dirname $stub))
+    (
+        cd "$exercise"
+        # copy the original stub to a backup
+        backup=$(dirname $stub)/lib.rs.bak
+        cp $stub $backup
+        # deny warnings in the stub
+        sed -i -e '1i #![deny(warnings)]' $stub
+        # quiet so that we only get output when there's an error
+        cargo check --quiet
+        if [ $? != 0 ]; then
+            echo "^- $exercise"
+        fi
+        # reset
+        mv -f $backup $stub
+    )
+done

--- a/exercises/beer-song/src/lib.rs
+++ b/exercises/beer-song/src/lib.rs
@@ -1,7 +1,7 @@
 pub fn verse(n: i32) -> String {
-    unimplemented!()
+    unimplemented!("emit verse {}", n)
 }
 
 pub fn sing(start: i32, end: i32) -> String {
-    unimplemented!()
+    unimplemented!("sing verses {} to {}, inclusive", start, end)
 }

--- a/exercises/bob/src/lib.rs
+++ b/exercises/bob/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn reply(message: &str) -> &str {
-    unimplemented!()
+    unimplemented!("have Bob reply to the incoming message: {}", message)
 }

--- a/exercises/collatz-conjecture/src/lib.rs
+++ b/exercises/collatz-conjecture/src/lib.rs
@@ -1,4 +1,6 @@
-// return Some(x) where x is the number of steps required to reach 1
 pub fn collatz(n: u64) -> Option<u64> {
-    unimplemented!()
+    unimplemented!(
+        "return Some(x) where x is the number of steps required to reach 1 starting with {}",
+        n,
+    )
 }

--- a/exercises/difference-of-squares/src/lib.rs
+++ b/exercises/difference-of-squares/src/lib.rs
@@ -1,11 +1,14 @@
 pub fn square_of_sum(n: usize) -> usize {
-    unimplemented!()
+    unimplemented!("square of sum of 1...{}", n)
 }
 
 pub fn sum_of_squares(n: usize) -> usize {
-    unimplemented!()
+    unimplemented!("sum of squares of 1...{}", n)
 }
 
 pub fn difference(n: usize) -> usize {
-    unimplemented!()
+    unimplemented!(
+        "difference between square of sum of 1...{n} and sum of squares of 1...{n}",
+        n=n,
+    )
 }

--- a/exercises/forth/src/lib.rs
+++ b/exercises/forth/src/lib.rs
@@ -21,6 +21,6 @@ impl Forth {
     }
 
     pub fn eval(&mut self, input: &str) -> ForthResult {
-        unimplemented!()
+        unimplemented!("result of evaluating '{}'", input)
     }
 }

--- a/exercises/grains/src/lib.rs
+++ b/exercises/grains/src/lib.rs
@@ -1,5 +1,5 @@
 pub fn square(s: u32) -> u64 {
-    unimplemented!();
+    unimplemented!("grains of rice on square {}", s);
 }
 
 pub fn total() -> u64 {

--- a/exercises/leap/src/lib.rs
+++ b/exercises/leap/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn is_leap_year(year: i32) -> bool {
-    unimplemented!()
+    unimplemented!("true if {} is a leap year", year)
 }

--- a/exercises/pascals-triangle/src/lib.rs
+++ b/exercises/pascals-triangle/src/lib.rs
@@ -2,7 +2,7 @@ pub struct PascalsTriangle;
 
 impl PascalsTriangle {
     pub fn new(row_count: u32) -> Self {
-        unimplemented!();
+        unimplemented!("create Pascal's triangle with {} rows", row_count);
     }
 
     pub fn rows(&self) -> Vec<Vec<u32>> {

--- a/exercises/perfect-numbers/src/lib.rs
+++ b/exercises/perfect-numbers/src/lib.rs
@@ -6,5 +6,5 @@ pub enum Classification {
 }
 
 pub fn classify(num: u64) -> Option<Classification> {
-    unimplemented!();
+    unimplemented!("classify {}", num);
 }

--- a/exercises/proverb/src/lib.rs
+++ b/exercises/proverb/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn build_proverb(list: Vec<&str>) -> String {
-    unimplemented!()
+    unimplemented!("build a proverb from this list of items: {:?}", list)
 }

--- a/exercises/raindrops/src/lib.rs
+++ b/exercises/raindrops/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn raindrops(n: usize) -> String {
-    unimplemented!()
+    unimplemented!("what sound does Raindrop #{} make?", n)
 }

--- a/exercises/saddle-points/src/lib.rs
+++ b/exercises/saddle-points/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn find_saddle_points(input: &[Vec<u64>]) -> Vec<(usize, usize)> {
-    unimplemented!()
+    unimplemented!("find the saddle points of the following matrix: {:?}", input)
 }

--- a/exercises/simple-linked-list/src/lib.rs
+++ b/exercises/simple-linked-list/src/lib.rs
@@ -1,7 +1,7 @@
 pub struct SimpleLinkedList<T> {
     // Delete this field
-    // _dummy is needed to avoid unused parameter error during compilation
-    _dummy: T,
+    // dummy is needed to avoid unused parameter error during compilation
+    dummy: ::std::marker::PhantomData<T>,
 }
 
 impl<T> SimpleLinkedList<T> {
@@ -13,7 +13,7 @@ impl<T> SimpleLinkedList<T> {
         unimplemented!()
     }
 
-    pub fn push(&mut self, element: T) {
+    pub fn push(&mut self, _element: T) {
         unimplemented!()
     }
 
@@ -34,13 +34,13 @@ impl<T: Clone> SimpleLinkedList<T> {
 
 
 impl<'a, T: Clone> From<&'a [T]> for SimpleLinkedList<T> {
-    fn from(item: &[T]) -> Self {
+    fn from(_item: &[T]) -> Self {
         unimplemented!()
     }
 }
 
 impl<T> Into<Vec<T>> for SimpleLinkedList<T> {
-    fn into(mut self) -> Vec<T> {
+    fn into(self) -> Vec<T> {
         unimplemented!()
     }
 }

--- a/exercises/sum-of-multiples/src/lib.rs
+++ b/exercises/sum-of-multiples/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn sum_of_multiples(limit: u32, factors: &[u32]) -> u32 {
-    unimplemented!()
+    unimplemented!("Sum the multiples of all of {:?} which are less than {}", factors, limit)
 }

--- a/exercises/two-bucket/src/lib.rs
+++ b/exercises/two-bucket/src/lib.rs
@@ -22,5 +22,11 @@ pub fn solve(capacity_1: u8,
              goal: u8,
              start_bucket: &Bucket) -> BucketStats
 {
-    unimplemented!();
+    unimplemented!(
+        "Given one bucket of capacity {}, another of capacity {}, starting with {:?}, find pours to reach {}",
+        capacity_1,
+        capacity_2,
+        start_bucket,
+        goal,
+    );
 }

--- a/exercises/variable-length-quantity/src/lib.rs
+++ b/exercises/variable-length-quantity/src/lib.rs
@@ -6,10 +6,10 @@ pub enum Error {
 
 /// Convert a list of numbers to a stream of bytes encoded with variable length encoding.
 pub fn to_bytes(values: &[u32]) -> Vec<u8> {
-    unimplemented!()
+    unimplemented!("Convert the values {:?} to a list of bytes", values)
 }
 
 /// Given a stream of bytes, extract all numbers which are encoded in there.
 pub fn from_bytes(bytes: &[u8]) -> Result<Vec<u32>, Error> {
-    unimplemented!()
+    unimplemented!("Convert the list of bytes {:?} to a list of numbers", bytes)
 }


### PR DESCRIPTION
Closes #484 

Includes `_test/check-stubs.sh`, which discovers any compilation errors in the stubs.

Eliminates all stub warnings, not just unused variables.

simple-linked-list uses generics which are not bounded by `Debug`, so we can't use the standard "print it in `unimplemented!()` trick there. We fall back on underscore-prefixing affected variables in this case.