### PR TITLE
travis: No longer run nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ sudo: false
 rust:
   - stable
   - beta
-  - nightly
 env:
   - DENYWARNINGS=
   - DENYWARNINGS=1


### PR DESCRIPTION
We never took action on nightly failing, and we prefer to get results
faster and not use up as many of the organisation-wide five build slots.

Closes https://github.com/exercism/rust/issues/498

---

I don't really consider this high-priority to merge, simply because we only really care about doing fewer builds when there are many PRs in flight so many PRs have to get through Travis CI. In normal circumstances... I guess we don't care?

But I guess I offer the PR so that we have it.

It'd be really interesting if these builds still happen but as a low-priority thing, so that they only happen if we have spare Travis CI slots, but I don't think this capability is offered right now.