### PR TITLE
WIP: configlet fmt

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,21 +1,26 @@
 {
   "language": "Rust",
-  "blurb": "Rust is a compiled programming language designed for speed, concurrency, and memory safety. Rust programs can run almost anywhere, from low-power embedded devices to web servers.",
   "active": true,
+  "blurb": "Rust is a compiled programming language designed for speed, concurrency, and memory safety. Rust programs can run almost anywhere, from low-power embedded devices to web servers.",
+  "foregone": [
+    "binary",
+    "octal",
+    "trinary"
+  ],
   "exercises": [
     {
-      "uuid": "13ec1ebe-d71b-436f-ab12-25305e814171",
       "slug": "hello-world",
+      "uuid": "13ec1ebe-d71b-436f-ab12-25305e814171",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "println!"
+        "println"
       ]
     },
     {
-      "uuid": "f880b1ef-8f66-41f3-bb89-f39a4ed592a2",
       "slug": "gigasecond",
+      "uuid": "f880b1ef-8f66-41f3-bb89-f39a4ed592a2",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
@@ -25,75 +30,75 @@
       ]
     },
     {
-      "uuid": "ef52f576-9c33-4cc1-a018-803ace8897f6",
       "slug": "leap",
+      "uuid": "ef52f576-9c33-4cc1-a018-803ace8897f6",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "mathematics",
         "booleans",
-        "conditionals"
+        "conditionals",
+        "mathematics"
       ]
     },
     {
-      "uuid": "2c12be9b-3a02-4161-8eac-050642ad791f",
       "slug": "raindrops",
+      "uuid": "2c12be9b-3a02-4161-8eac-050642ad791f",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "case (or `format`)",
-        "Mutable string"
+        "case_or_format",
+        "mutable_string"
       ]
     },
     {
-      "uuid": "ecf8d1e3-9400-4d1a-8326-2e2820bce024",
       "slug": "reverse-string",
+      "uuid": "ecf8d1e3-9400-4d1a-8326-2e2820bce024",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "String",
-        "&str",
-        "Iterator"
+        "iterator",
+        "str",
+        "string"
       ]
     },
     {
-      "uuid": "ee5048a7-c625-434d-a0a2-4fd54757ee02",
       "slug": "nth-prime",
+      "uuid": "ee5048a7-c625-434d-a0a2-4fd54757ee02",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": []
+      "topics": null
     },
     {
-      "uuid": "38ef1802-2730-4f94-bafe-d2cd6b3e7f95",
       "slug": "bob",
+      "uuid": "38ef1802-2730-4f94-bafe-d2cd6b3e7f95",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "chars",
-        "string functions"
+        "string_functions"
       ]
     },
     {
-      "uuid": "bb42bc3a-139d-4cab-8b3a-2eac2e1b77b6",
       "slug": "beer-song",
+      "uuid": "bb42bc3a-139d-4cab-8b3a-2eac2e1b77b6",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "case",
-        "string concatenation",
-        "vector (optional)",
-        "loop"
+        "loop",
+        "string_concatenation",
+        "vector_optional"
       ]
     },
     {
-      "uuid": "504f9033-6433-4508-aebb-60ee77b800b9",
       "slug": "proverb",
+      "uuid": "504f9033-6433-4508-aebb-60ee77b800b9",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
@@ -102,8 +107,8 @@
       ]
     },
     {
-      "uuid": "aee49878-f727-400b-8fb5-eaf83447cf87",
       "slug": "difference-of-squares",
+      "uuid": "aee49878-f727-400b-8fb5-eaf83447cf87",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
@@ -113,8 +118,8 @@
       ]
     },
     {
-      "uuid": "be90fe16-9947-45ef-ab8e-eeca4ce3a8c8",
       "slug": "sum-of-multiples",
+      "uuid": "be90fe16-9947-45ef-ab8e-eeca4ce3a8c8",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
@@ -124,8 +129,8 @@
       ]
     },
     {
-      "uuid": "9e69dd5d-472d-43d7-a8bb-60e4a7bed175",
       "slug": "grains",
+      "uuid": "9e69dd5d-472d-43d7-a8bb-60e4a7bed175",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
@@ -135,8 +140,8 @@
       ]
     },
     {
-      "uuid": "6e7cac84-99d1-4f9f-b7d6-48ea43024bc0",
       "slug": "pythagorean-triplet",
+      "uuid": "6e7cac84-99d1-4f9f-b7d6-48ea43024bc0",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
@@ -145,8 +150,8 @@
       ]
     },
     {
-      "uuid": "9f649818-0c82-4b79-b912-4d65b9f60e10",
       "slug": "prime-factors",
+      "uuid": "9f649818-0c82-4b79-b912-4d65b9f60e10",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
@@ -155,19 +160,19 @@
       ]
     },
     {
-      "uuid": "9de405e1-3a05-43cb-8eb3-00b81a2968e9",
       "slug": "series",
+      "uuid": "9de405e1-3a05-43cb-8eb3-00b81a2968e9",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "vectors",
-        "strings"
+        "strings",
+        "vectors"
       ]
     },
     {
-      "uuid": "e652139e-ff3f-4e03-9810-d21f8b0c9e60",
       "slug": "armstrong-numbers",
+      "uuid": "e652139e-ff3f-4e03-9810-d21f8b0c9e60",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
@@ -176,18 +181,18 @@
       ]
     },
     {
-      "uuid": "f9afd650-8103-4373-a284-fa4ecfee7207",
       "slug": "collatz-conjecture",
+      "uuid": "f9afd650-8103-4373-a284-fa4ecfee7207",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "Option"
+        "option"
       ]
     },
     {
-      "uuid": "23d82e48-d074-11e7-8fab-cec278b6b50a",
       "slug": "diffie-hellman",
+      "uuid": "23d82e48-d074-11e7-8fab-cec278b6b50a",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
@@ -196,19 +201,19 @@
       ]
     },
     {
-      "uuid": "ccebfa12-d224-11e7-8941-cec278b6b50a",
       "slug": "saddle-points",
+      "uuid": "ccebfa12-d224-11e7-8941-cec278b6b50a",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "vectors",
-        "iterators"
+        "iterators",
+        "vectors"
       ]
     },
     {
-      "uuid": "79613fd8-b7da-11e7-abc4-cec278b6b50a",
       "slug": "isogram",
+      "uuid": "79613fd8-b7da-11e7-abc4-cec278b6b50a",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
@@ -219,216 +224,216 @@
       ]
     },
     {
-      "uuid": "4ba35adb-230b-49a6-adc9-2d3cd9a4c538",
       "slug": "say",
+      "uuid": "4ba35adb-230b-49a6-adc9-2d3cd9a4c538",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "string concatenation",
-        "modulus"
+        "modulus",
+        "string_concatenation"
       ]
     },
     {
-      "uuid": "4dc9b165-792a-4438-be80-df9aab6f6a9c",
       "slug": "run-length-encoding",
+      "uuid": "4dc9b165-792a-4438-be80-df9aab6f6a9c",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "string concatenation",
-        "conversion between string and int",
-        "use of primitive char",
-        "loop"
+        "conversion_between_string_and_int",
+        "loop",
+        "string_concatenation",
+        "use_of_primitive_char"
       ]
     },
     {
-      "uuid": "c986c240-46de-419c-8ed6-700eb68f8db6",
       "slug": "isbn-verifier",
+      "uuid": "c986c240-46de-419c-8ed6-700eb68f8db6",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "conversion between string and int",
+        "conversion_between_string_and_int",
         "loop",
         "mathematics"
       ]
     },
     {
-      "uuid": "20e7d347-b80a-4656-ac34-0825126939ff",
       "slug": "perfect-numbers",
+      "uuid": "20e7d347-b80a-4656-ac34-0825126939ff",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "Mathematics"
+        "mathematics"
       ]
     },
     {
-      "uuid": "543a3ca2-fb9b-4f20-a873-ff23595d41df",
       "slug": "clock",
+      "uuid": "543a3ca2-fb9b-4f20-a873-ff23595d41df",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "traits",
         "derive",
-        "struct"
+        "struct",
+        "traits"
       ]
     },
     {
-      "uuid": "2874216a-0822-4ec2-892e-d451fd89646a",
       "slug": "hamming",
+      "uuid": "2874216a-0822-4ec2-892e-d451fd89646a",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "Result"
+        "result"
       ]
     },
     {
-      "uuid": "10923b0b-c726-44a7-9e02-b775e7b8b237",
       "slug": "simple-linked-list",
+      "uuid": "10923b0b-c726-44a7-9e02-b775e7b8b237",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "lists",
-        "type_conversion",
-        "struct"
+        "struct",
+        "type_conversion"
       ]
     },
     {
-      "uuid": "ddc0c1da-6b65-4ed1-8bdc-5e71cd05f720",
       "slug": "pascals-triangle",
+      "uuid": "ddc0c1da-6b65-4ed1-8bdc-5e71cd05f720",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "Mathematics",
-        "Vec",
-        "Index (optional)"
+        "index_optional",
+        "mathematics",
+        "vec"
       ]
     },
     {
-      "uuid": "561cc4ff-5e74-4701-a7c2-c4edefa0d068",
       "slug": "scrabble-score",
+      "uuid": "561cc4ff-5e74-4701-a7c2-c4edefa0d068",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "chaining higher-order functions",
-        "HashMap (optional)"
+        "chaining_higher_order_functions",
+        "hashmap_optional"
       ]
     },
     {
-      "uuid": "a24cb7bf-3aac-4051-bcd1-952c2a806187",
       "slug": "pangram",
+      "uuid": "a24cb7bf-3aac-4051-bcd1-952c2a806187",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "filter",
-        "ascii (optional)"
+        "ascii_optional",
+        "filter"
       ]
     },
     {
-      "uuid": "3f54853b-cc65-4282-ab25-8dc3fdf43c03",
       "slug": "nucleotide-count",
+      "uuid": "3f54853b-cc65-4282-ab25-8dc3fdf43c03",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "Result",
+        "entry_api",
         "filter",
-        "entry api",
+        "match",
         "mutablity",
-        "match"
+        "result"
       ]
     },
     {
-      "uuid": "8d64bfc3-fc4b-45c4-85f0-e74dc2ea6812",
       "slug": "luhn",
+      "uuid": "8d64bfc3-fc4b-45c4-85f0-e74dc2ea6812",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "str to digits",
+        "higher_order_functions",
         "iterators",
-        "higher-order functions"
+        "str_to_digits"
       ]
     },
     {
-      "uuid": "8679c221-d150-4230-b1cd-5ea78ae69db7",
       "slug": "largest-series-product",
+      "uuid": "8679c221-d150-4230-b1cd-5ea78ae69db7",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "Result",
-        "windows",
-        "higher-order functions",
-        "char"
+        "char",
+        "higher_order_functions",
+        "result",
+        "windows"
       ]
     },
     {
-      "uuid": "6c5c0dc3-4f5b-4f83-bf67-a45bf4ea6be4",
       "slug": "word-count",
+      "uuid": "6c5c0dc3-4f5b-4f83-bf67-a45bf4ea6be4",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+        "chars",
+        "entry_api",
         "hashmap",
-        "str vs string",
-        "chars",
-        "entry api"
+        "str_vs_string"
       ]
     },
     {
-      "uuid": "53298a14-76a9-4bb9-943a-57c5e79d9cf7",
       "slug": "atbash-cipher",
+      "uuid": "53298a14-76a9-4bb9-943a-57c5e79d9cf7",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "str vs string",
-        "primitive types",
-        "iterators",
+        "ascii",
         "chars",
-        "ascii"
+        "iterators",
+        "primitive_types",
+        "str_vs_string"
       ]
     },
     {
-      "uuid": "0cc485e9-43ba-4d97-a622-ee4cb8b9f1f7",
       "slug": "crypto-square",
+      "uuid": "0cc485e9-43ba-4d97-a622-ee4cb8b9f1f7",
       "difficulty": 4,
       "topics": [
-        "str vs string",
-        "primitive types",
-        "iterators",
-        "chars",
         "arrays",
         "ascii",
+        "chars",
+        "iterators",
+        "primitive_types",
+        "str_vs_string",
         "transforming"
       ]
     },
     {
-      "uuid": "5dbecc83-2c8d-467d-be05-f28a08f7abcf",
       "slug": "rotational-cipher",
+      "uuid": "5dbecc83-2c8d-467d-be05-f28a08f7abcf",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "str vs string",
-        "primitive types",
-        "iterators",
+        "ascii",
         "chars",
-        "ascii"
+        "iterators",
+        "primitive_types",
+        "str_vs_string"
       ]
     },
     {
-      "uuid": "0c8eeef7-4bab-4cf9-9047-c208b5618312",
       "slug": "etl",
+      "uuid": "0c8eeef7-4bab-4cf9-9047-c208b5618312",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
@@ -437,319 +442,319 @@
       ]
     },
     {
-      "uuid": "ddc45979-8a92-4313-a4f8-878562d5a483",
       "slug": "accumulate",
+      "uuid": "ddc45979-8a92-4313-a4f8-878562d5a483",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "function pointer"
+        "function_pointer"
       ]
     },
     {
-      "uuid": "26a9102f-26f6-4238-858e-ba20db66f1a9",
       "slug": "acronym",
+      "uuid": "26a9102f-26f6-4238-858e-ba20db66f1a9",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "map",
-        "flat_map",
         "filter",
+        "flat_map",
         "loops",
-        "Vec"
-      ]
-    },
-    {
-      "uuid": "da784b42-1cec-469e-8e48-0be232b17003",
-      "slug": "sieve",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "vector",
         "map",
-        "while let (optional)"
+        "vec"
       ]
     },
     {
-      "uuid": "9a219d87-cd32-4e12-a879-bfb5747c2369",
+      "slug": "sieve",
+      "uuid": "da784b42-1cec-469e-8e48-0be232b17003",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "map",
+        "vector",
+        "while_let_optional"
+      ]
+    },
+    {
       "slug": "rna-transcription",
+      "uuid": "9a219d87-cd32-4e12-a879-bfb5747c2369",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "Result",
         "match",
-        "struct",
-        "str vs string"
+        "result",
+        "str_vs_string",
+        "struct"
       ]
     },
     {
-      "uuid": "c0bc2af6-d7af-401f-9ed8-bbe31977666c",
       "slug": "triangle",
+      "uuid": "c0bc2af6-d7af-401f-9ed8-bbe31977666c",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "Mathematics",
-        "Struct"
+        "mathematics",
+        "struct"
       ]
     },
     {
-      "uuid": "498be645-734a-49b7-aba7-aae1e051e1f0",
       "slug": "roman-numerals",
+      "uuid": "498be645-734a-49b7-aba7-aae1e051e1f0",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+        "loops",
         "mutable",
         "results",
-        "loops",
         "struct",
         "traits"
       ]
     },
     {
-      "uuid": "54c11dae-3878-4bec-b8d6-775b7d4f317b",
       "slug": "all-your-base",
+      "uuid": "54c11dae-3878-4bec-b8d6-775b7d4f317b",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "Result",
         "enumerate",
         "fold",
-        "map"
+        "map",
+        "result"
       ]
     },
     {
-      "uuid": "5ca03812-c229-48db-b7fd-0889b22f8d1d",
       "slug": "grade-school",
+      "uuid": "5ca03812-c229-48db-b7fd-0889b22f8d1d",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
+        "entry_api",
+        "option",
         "struct",
-        "entry api",
-        "Vec",
-        "Option"
+        "vec"
       ]
     },
     {
-      "uuid": "dd74b65c-0d26-4821-9add-064e32e3a5bd",
       "slug": "binary-search",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "slices",
-        "trait (optional)",
-        "Option"
-      ]
-    },
-    {
-      "uuid": "1beb8b0c-d06d-4569-80e5-866ed01a7a66",
-      "slug": "robot-simulator",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "Immutability",
-        "enum"
-      ]
-    },
-    {
-      "uuid": "40729822-4265-4c14-b03f-a00bff5f24bb",
-      "slug": "bracket-push",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "From trait",
-        "stack or recursion"
-      ]
-    },
-    {
-      "uuid": "f9131b5d-91dd-4514-983d-4abc22bb5d5c",
-      "slug": "luhn-from",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "from trait",
-        "str to digits",
-        "iterators",
-        "higher-order functions"
-      ]
-    },
-    {
-      "uuid": "30c33e3d-8034-4618-8346-2ae906961579",
-      "slug": "queen-attack",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "struct",
-        "trait (optional)",
-        "Result"
-      ]
-    },
-    {
-      "uuid": "fec447a5-cf11-4ddd-b0fd-63bcc4e245cd",
-      "slug": "bowling",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "struct",
-        "Result",
-        "goofy bowling logic"
-      ]
-    },
-    {
-      "uuid": "644ffd17-548e-4405-bfd5-a58df74cc19d",
-      "slug": "sublist",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "enum",
-        "generic over type"
-      ]
-    },
-    {
-      "uuid": "fa94645d-14e1-422d-a832-d24efbb493d8",
-      "slug": "space-age",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "Custom Trait",
-        "From Trait",
-        "Default Trait implementation"
-      ]
-    },
-    {
-      "uuid": "c32c0124-873d-45f4-9287-402aea29f129",
-      "slug": "luhn-trait",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "Custom Trait",
-        "str to digits",
-        "iterators",
-        "higher-order functions"
-      ]
-    },
-    {
-      "uuid": "29583cc6-d56d-4bee-847d-93d74e5a30e7",
-      "slug": "macros",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "macros",
-        "macros-by-example",
-        "hashmap"
-      ]
-    },
-    {
-      "uuid": "94f040d6-3f41-4950-8fe6-acf0945ac83d",
-      "slug": "allergies",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "struct",
-        "enum",
-        "bitwise (probably)",
-        "vectors",
-        "filter"
-      ]
-    },
-    {
-      "uuid": "f1371a9c-c2a4-4fc6-a5fd-3a57c4af16fa",
-      "slug": "variable-length-quantity",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "Encodings",
-        "slices",
-        "bitwise",
-        "Result"
-      ]
-    },
-    {
-      "uuid": "6abac1d1-0d85-4b51-8001-97a07990630d",
-      "slug": "phone-number",
+      "uuid": "dd74b65c-0d26-4821-9add-064e32e3a5bd",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "option",
-        "format",
-        "unwrap_or",
-        "iters",
-        "match"
+        "slices",
+        "trait_optional"
       ]
     },
     {
-      "uuid": "620b55bb-058e-4c6f-a966-ced3b41736db",
-      "slug": "wordy",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "Result",
-        "string parsing",
-        "operators (optional)"
-      ]
-    },
-    {
-      "uuid": "9a2406cc-5037-4761-b820-bb25b1d397c8",
-      "slug": "tournament",
+      "slug": "robot-simulator",
+      "uuid": "1beb8b0c-d06d-4569-80e5-866ed01a7a66",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "enum",
-        "sorting",
-        "hashmap",
-        "structs"
+        "immutability"
       ]
     },
     {
-      "uuid": "9d652e63-6654-4dec-a99f-97e6bc8cf772",
-      "slug": "custom-set",
+      "slug": "bracket-push",
+      "uuid": "40729822-4265-4c14-b03f-a00bff5f24bb",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "generic over type",
-        "vector",
-        "equality",
+        "from_trait",
+        "stack_or_recursion"
+      ]
+    },
+    {
+      "slug": "luhn-from",
+      "uuid": "f9131b5d-91dd-4514-983d-4abc22bb5d5c",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "from_trait",
+        "higher_order_functions",
+        "iterators",
+        "str_to_digits"
+      ]
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "30c33e3d-8034-4618-8346-2ae906961579",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "result",
+        "struct",
+        "trait_optional"
+      ]
+    },
+    {
+      "slug": "bowling",
+      "uuid": "fec447a5-cf11-4ddd-b0fd-63bcc4e245cd",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "goofy_bowling_logic",
+        "result",
         "struct"
       ]
     },
     {
-      "uuid": "7450bd80-2388-42ac-a61f-097e82581475",
-      "slug": "alphametics",
+      "slug": "sublist",
+      "uuid": "644ffd17-548e-4405-bfd5-a58df74cc19d",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "string parsing",
-        "combinations",
-        "mathematics",
-        "external crates (optional)"
+        "enum",
+        "generic_over_type"
       ]
     },
     {
-      "uuid": "1850fb3f-9dad-449a-90b6-9d90038cf34d",
+      "slug": "space-age",
+      "uuid": "fa94645d-14e1-422d-a832-d24efbb493d8",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "custom_trait",
+        "default_trait_implementation",
+        "from_trait"
+      ]
+    },
+    {
+      "slug": "luhn-trait",
+      "uuid": "c32c0124-873d-45f4-9287-402aea29f129",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "custom_trait",
+        "higher_order_functions",
+        "iterators",
+        "str_to_digits"
+      ]
+    },
+    {
+      "slug": "macros",
+      "uuid": "29583cc6-d56d-4bee-847d-93d74e5a30e7",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "hashmap",
+        "macros",
+        "macros_by_example"
+      ]
+    },
+    {
+      "slug": "allergies",
+      "uuid": "94f040d6-3f41-4950-8fe6-acf0945ac83d",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "bitwise_probably",
+        "enum",
+        "filter",
+        "struct",
+        "vectors"
+      ]
+    },
+    {
+      "slug": "variable-length-quantity",
+      "uuid": "f1371a9c-c2a4-4fc6-a5fd-3a57c4af16fa",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "bitwise",
+        "encodings",
+        "result",
+        "slices"
+      ]
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "6abac1d1-0d85-4b51-8001-97a07990630d",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "format",
+        "iters",
+        "match",
+        "option",
+        "unwrap_or"
+      ]
+    },
+    {
+      "slug": "wordy",
+      "uuid": "620b55bb-058e-4c6f-a966-ced3b41736db",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "operators_optional",
+        "result",
+        "string_parsing"
+      ]
+    },
+    {
+      "slug": "tournament",
+      "uuid": "9a2406cc-5037-4761-b820-bb25b1d397c8",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "enum",
+        "hashmap",
+        "sorting",
+        "structs"
+      ]
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "9d652e63-6654-4dec-a99f-97e6bc8cf772",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "equality",
+        "generic_over_type",
+        "struct",
+        "vector"
+      ]
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "7450bd80-2388-42ac-a61f-097e82581475",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "combinations",
+        "external_crates_optional",
+        "mathematics",
+        "string_parsing"
+      ]
+    },
+    {
       "slug": "two-bucket",
+      "uuid": "1850fb3f-9dad-449a-90b6-9d90038cf34d",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
@@ -760,232 +765,227 @@
       ]
     },
     {
-      "uuid": "c21c379b-fb23-449b-809a-3c6ef1c31221",
       "slug": "pig-latin",
+      "uuid": "c21c379b-fb23-449b-809a-3c6ef1c31221",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
-      "topics": []
+      "topics": null
     },
     {
-      "uuid": "c6878b91-70dd-49a0-b7c1-06364fa3d80b",
       "slug": "diamond",
+      "uuid": "c6878b91-70dd-49a0-b7c1-06364fa3d80b",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "String",
+        "parsing",
         "str",
-        "parsing"
+        "string"
       ]
     },
     {
-      "uuid": "8dea3473-36f4-4228-b24b-bee8d9389167",
       "slug": "spiral-matrix",
+      "uuid": "8dea3473-36f4-4228-b24b-bee8d9389167",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "matrix",
-        "nested structures"
+        "nested_structures"
       ]
     },
     {
-      "uuid": "8cdc3424-51da-4cae-a065-9982859d5b55",
       "slug": "palindrome-products",
+      "uuid": "8cdc3424-51da-4cae-a065-9982859d5b55",
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "string comparison",
         "calculation",
+        "string_comparison",
         "structs"
       ]
     },
     {
-      "uuid": "0a33f3ac-cedd-4a40-a132-9d044b0e9977",
       "slug": "poker",
+      "uuid": "0a33f3ac-cedd-4a40-a132-9d044b0e9977",
       "core": false,
       "unlocked_by": null,
       "difficulty": 7,
       "topics": [
-        "lifetimes",
-        "struct",
-        "string parsing",
         "enum",
+        "lifetimes",
+        "string_parsing",
+        "struct",
         "traits"
       ]
     },
     {
-      "uuid": "7cefed7c-37f4-46c5-9a45-68fe4d0fb326",
       "slug": "decimal",
+      "uuid": "7cefed7c-37f4-46c5-9a45-68fe4d0fb326",
       "core": false,
       "unlocked_by": null,
       "difficulty": 7,
       "topics": [
-        "struct",
-        "traits",
-        "string parsing",
         "bigint",
-        "external crates (optional)"
+        "external_crates_optional",
+        "string_parsing",
+        "struct",
+        "traits"
       ]
     },
     {
-      "uuid": "f3172997-91f5-4941-a76e-91c4b8eed401",
       "slug": "anagram",
+      "uuid": "f3172997-91f5-4941-a76e-91c4b8eed401",
       "core": false,
       "unlocked_by": null,
       "difficulty": 7,
       "topics": [
-        "lifetimes",
-        "str vs string",
-        "loops",
         "iter",
+        "lifetimes",
+        "loops",
+        "str_vs_string",
         "vector"
       ]
     },
     {
-      "uuid": "4e01efbc-51ce-4d20-b093-b3d44c4be5e8",
       "slug": "protein-translation",
+      "uuid": "4e01efbc-51ce-4d20-b093-b3d44c4be5e8",
       "core": false,
       "unlocked_by": null,
       "difficulty": 7,
       "topics": [
-        "struct",
-        "hash map",
+        "hash_map",
         "lifetimes",
-        "Result"
+        "result",
+        "struct"
       ]
     },
     {
-      "uuid": "ec7f66c2-749e-4d00-9c11-fa9d106632e4",
       "slug": "robot-name",
+      "uuid": "ec7f66c2-749e-4d00-9c11-fa9d106632e4",
       "core": false,
       "unlocked_by": null,
       "difficulty": 7,
       "topics": [
-        "struct",
-        "slices",
-        "randomness",
         "lifetimes",
-        "self mut"
+        "randomness",
+        "self_mut",
+        "slices",
+        "struct"
       ]
     },
     {
-      "uuid": "a78ed17a-b2c0-485c-814b-e13ccd1f4153",
       "slug": "book-store",
+      "uuid": "a78ed17a-b2c0-485c-814b-e13ccd1f4153",
       "core": false,
       "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "algorithms",
         "groups",
-        "set theory"
+        "set_theory"
       ]
     },
     {
-      "uuid": "704aab91-b83a-4e64-8c21-fb0be5076289",
       "slug": "ocr-numbers",
+      "uuid": "704aab91-b83a-4e64-8c21-fb0be5076289",
       "core": false,
       "unlocked_by": null,
       "difficulty": 10,
       "topics": [
-        "Lines",
-        "Chunks",
+        "chunks",
+        "lines",
         "slices"
       ]
     },
     {
-      "uuid": "e0037ac4-ae5f-4622-b3ad-915648263495",
       "slug": "minesweeper",
+      "uuid": "e0037ac4-ae5f-4622-b3ad-915648263495",
       "core": false,
       "unlocked_by": null,
       "difficulty": 10,
       "topics": [
-        "Board state"
+        "board_state"
       ]
     },
     {
-      "uuid": "5e6f6986-5011-427b-a992-d6d0c81f5101",
       "slug": "dominoes",
+      "uuid": "5e6f6986-5011-427b-a992-d6d0c81f5101",
       "core": false,
       "unlocked_by": null,
       "difficulty": 10,
       "topics": [
-        "Graph theory",
+        "graph_theory",
         "searching"
       ]
     },
     {
-      "uuid": "e114b19f-9a9a-402d-a5cb-1cad8de5088e",
       "slug": "parallel-letter-frequency",
+      "uuid": "e114b19f-9a9a-402d-a5cb-1cad8de5088e",
       "core": false,
       "unlocked_by": null,
       "difficulty": 10,
       "topics": [
-        "multi-threading"
+        "multi_threading"
       ]
     },
     {
-      "uuid": "cc4ccd99-1c97-4ee7-890c-d629b4e1e46d",
       "slug": "rectangles",
+      "uuid": "cc4ccd99-1c97-4ee7-890c-d629b4e1e46d",
       "core": false,
       "unlocked_by": null,
       "difficulty": 10,
       "topics": [
-        "Enum",
+        "algorithm",
+        "enum",
         "structs",
-        "traits",
-        "algorithm"
+        "traits"
       ]
     },
     {
-      "uuid": "55976c49-1be5-4170-8aa3-056c2223abbb",
       "slug": "forth",
+      "uuid": "55976c49-1be5-4170-8aa3-056c2223abbb",
       "core": false,
       "unlocked_by": null,
       "difficulty": 10,
       "topics": [
-        "Parser reimplementation"
+        "parser_reimplementation"
       ]
     },
     {
-      "uuid": "6ff1a539-251b-49d4-81b5-a6b1e9ba66a4",
       "slug": "circular-buffer",
+      "uuid": "6ff1a539-251b-49d4-81b5-a6b1e9ba66a4",
       "core": false,
       "unlocked_by": null,
       "difficulty": 10,
       "topics": [
-        "Buffer reimplementation",
-        "Generics"
+        "buffer_reimplementation",
+        "generics"
       ]
     },
     {
-      "uuid": "8708ccc7-711a-4862-b5a4-ff59fde2241c",
       "slug": "react",
+      "uuid": "8708ccc7-711a-4862-b5a4-ff59fde2241c",
       "core": false,
       "unlocked_by": null,
       "difficulty": 10,
       "topics": [
-        "Lifetimes",
+        "closures",
         "generics",
-        "closures"
+        "lifetimes"
       ]
     },
     {
-      "uuid": "8dae8f4d-368d-477d-907e-bf746921bfbf",
       "slug": "nucleotide-codons",
+      "uuid": "8dae8f4d-368d-477d-907e-bf746921bfbf",
       "deprecated": true
     },
     {
-      "uuid": "496fd79f-1678-4aa2-8110-c32c6aaf545e",
       "slug": "hexadecimal",
+      "uuid": "496fd79f-1678-4aa2-8110-c32c6aaf545e",
       "deprecated": true
     }
-  ],
-  "foregone": [
-    "binary",
-    "octal",
-    "trinary"
   ]
 }

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -1,59 +1,59 @@
 {
   "maintainers": [
     {
+      "alumnus": false,
+      "avatar_url": null,
+      "bio": null,
       "github_username": "IanWhitney",
-      "show_on_website": false,
-      "alumnus": false,
-      "name": null,
-      "bio": null,
       "link_text": null,
       "link_url": null,
-      "avatar_url": null
+      "name": null,
+      "show_on_website": false
     },
     {
+      "alumnus": true,
       "github_username": "etrepum",
-      "show_on_website": false,
-      "alumnus": true
+      "show_on_website": false
     },
     {
+      "alumnus": false,
+      "avatar_url": null,
+      "bio": null,
       "github_username": "ijanos",
-      "show_on_website": false,
-      "alumnus": false,
-      "name": null,
-      "bio": null,
       "link_text": null,
       "link_url": null,
-      "avatar_url": null
+      "name": null,
+      "show_on_website": false
     },
     {
+      "alumnus": false,
+      "avatar_url": null,
+      "bio": null,
       "github_username": "petertseng",
-      "show_on_website": false,
-      "alumnus": false,
-      "name": null,
-      "bio": null,
       "link_text": null,
       "link_url": null,
-      "avatar_url": null
+      "name": null,
+      "show_on_website": false
     },
     {
+      "alumnus": false,
+      "avatar_url": null,
+      "bio": null,
       "github_username": "EduardoBautista",
-      "show_on_website": false,
-      "alumnus": false,
-      "name": null,
-      "bio": null,
       "link_text": null,
       "link_url": null,
-      "avatar_url": null
+      "name": null,
+      "show_on_website": false
     },
     {
-      "github_username": "coriolinus",
-      "show_on_website": false,
       "alumnus": false,
-      "name": null,
+      "avatar_url": null,
       "bio": null,
+      "github_username": "coriolinus",
       "link_text": null,
       "link_url": null,
-      "avatar_url": null
+      "name": null,
+      "show_on_website": false
     }
   ]
 }


### PR DESCRIPTION
Configlet 3.9.0, released just now, now applies a fixed ordering to the `config.json` and `maintainers.json` files. 

Closes #516.

The first commit here only applies configlet fmt to the existing files. I'll come back later this week and write a check-script which ensures that all future exercises have applied compatible ordering when manipulating these files.