### PR TITLE
hamming: Update return type

### DIFF
--- a/exercises/hamming/example.rs
+++ b/exercises/hamming/example.rs
@@ -1,7 +1,7 @@
-pub fn hamming_distance(a : &str, b: &str) -> Result<usize, &'static str> {
+pub fn hamming_distance(a: &str, b: &str) -> Option<usize> {
     if a.len() != b.len() {
-        return Result::Err("inputs of different length");
+        return None;
     }
 
-    Result::Ok(a.chars().zip(b.chars()).filter(|&(a, b)| a != b).count())
+    Some(a.chars().zip(b.chars()).filter(|&(a, b)| a != b).count())
 }

--- a/exercises/hamming/src/lib.rs
+++ b/exercises/hamming/src/lib.rs
@@ -1,6 +1,6 @@
 /// Return the Hamming distance between the strings,
-/// or an error if the lengths are mismatched.
-pub fn hamming_distance(s1: &str, s2: &str) -> Result<usize, ()> {
+/// or None if the lengths are mismatched.
+pub fn hamming_distance(s1: &str, s2: &str) -> Option<usize> {
     unimplemented!("What is the Hamming Distance between {:?} and {:?}",
                    s1, s2);
 }

--- a/exercises/hamming/src/lib.rs
+++ b/exercises/hamming/src/lib.rs
@@ -1,6 +1,6 @@
 /// Return the Hamming distance between the strings,
 /// or an error if the lengths are mismatched.
-pub fn hamming_distance(s1: &str, s2: &str) -> Result<u64, ()> {
+pub fn hamming_distance(s1: &str, s2: &str) -> Result<usize, ()> {
     unimplemented!("What is the Hamming Distance between {:?} and {:?}",
                    s1, s2);
 }

--- a/exercises/hamming/tests/hamming.rs
+++ b/exercises/hamming/tests/hamming.rs
@@ -2,41 +2,41 @@ extern crate hamming;
 
 #[test]
 fn test_no_difference_between_empty_strands() {
-    assert_eq!(hamming::hamming_distance("", ""), Ok(0));
+    assert_eq!(hamming::hamming_distance("", ""), Some(0));
 }
 
 #[test]
 #[ignore]
 fn test_no_difference_between_identical_strands() {
-    assert_eq!(hamming::hamming_distance("GGACTGA", "GGACTGA"), Ok(0));
+    assert_eq!(hamming::hamming_distance("GGACTGA", "GGACTGA"), Some(0));
 }
 
 #[test]
 #[ignore]
 fn test_complete_hamming_distance_in_small_strand() {
-    assert_eq!(hamming::hamming_distance("ACT", "GGA"), Ok(3));
+    assert_eq!(hamming::hamming_distance("ACT", "GGA"), Some(3));
 }
 
 #[test]
 #[ignore]
 fn test_small_hamming_distance_in_the_middle_somewhere() {
-    assert_eq!(hamming::hamming_distance("GGACG", "GGTCG"), Ok(1));
+    assert_eq!(hamming::hamming_distance("GGACG", "GGTCG"), Some(1));
 }
 
 #[test]
 #[ignore]
 fn test_larger_distance() {
-    assert_eq!(hamming::hamming_distance("ACCAGGG", "ACTATGG"), Ok(2));
+    assert_eq!(hamming::hamming_distance("ACCAGGG", "ACTATGG"), Some(2));
 }
 
 #[test]
 #[ignore]
 fn test_first_string_is_longer() {
-    assert!(hamming::hamming_distance("AAA", "AA").is_err());
+    assert_eq!(hamming::hamming_distance("AAA", "AA"), None);
 }
 
 #[test]
 #[ignore]
 fn test_second_string_is_longer() {
-    assert!(hamming::hamming_distance("A", "AA").is_err());
+    assert_eq!(hamming::hamming_distance("A", "AA"), None);
 }


### PR DESCRIPTION
This is effectively a difference of two sizes, so we should return `usize`