### PR TITLE
Fix typo in problem specification

### DIFF
--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -5,7 +5,7 @@ An [Armstrong number](https://en.wikipedia.org/wiki/Narcissistic_number) is a nu
 For example:
 
 - 9 is an Armstrong number, because `9 = 9^1 = 9`
-- 10 is *not* an Armstrong number, because `10 != 1^2 + 0^2 = 2`
+- 10 is *not* an Armstrong number, because `10 != 1^2 + 0^2 = 1`
 - 153 is an Armstrong number, because: `153 = 1^3 + 5^3 + 3^3 = 1 + 125 + 27 = 153`
 - 154 is *not* an Armstrong number, because: `154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190`
 


### PR DESCRIPTION
Fixed in https://github.com/exercism/problem-specifications/pull/1237/commits/c2e0b3defcc600fe16d73f2ad4b4cad30e313dbe. This brings the change into the rust repo.

---
Edit by @coriolinus:

Fixes #526

This annotation in the first comment in the discussion will automatically close that issue when this is applied.