### PR TITLE
Add a bonus test in reverse string

### DIFF
--- a/exercises/reverse-string/.meta/hints.md
+++ b/exercises/reverse-string/.meta/hints.md
@@ -1,3 +1,10 @@
 ## Bonus
 Test your function on this string: `uüu` and see what happens. Try to write a function that properly
 reverses this string. Hint: grapheme clusters
+
+To get the bonus test to run, remove the ignore flag (`#[ignore]`) from the
+last test, and execute the tests with:
+
+```bash
+$ cargo test --features grapheme
+```

--- a/exercises/reverse-string/Cargo.toml
+++ b/exercises/reverse-string/Cargo.toml
@@ -3,4 +3,7 @@ name = "reverse_string"
 version = "1.0.0"
 authors = ["Peter Goodspeed-Niklaus <peter.r.goodspeedniklaus@gmail.com>"]
 
+[features]
+grapheme = []
+
 [dependencies]

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -10,6 +10,13 @@ output: "looc"
 Test your function on this string: `uüu` and see what happens. Try to write a function that properly
 reverses this string. Hint: grapheme clusters
 
+To get the bonus test to run, remove the ignore flag (`#[ignore]`) from the
+last test, and execute the tests with:
+
+```bash
+$ cargo test --features grapheme
+```
+
 
 ## Rust Installation
 
@@ -29,13 +36,6 @@ pass, remove the ignore flag (`#[ignore]`) from the next test and get the tests
 to pass again.  The test file is located in the `tests` directory.   You can
 also remove the ignore flag from all the tests to get them to run all at once
 if you wish.
-
-To get the bonus test to run, remove the ignore flag (`#[ignore]`) from the
-last test, and execute the tests with:
-
-```bash
-$ cargo test --features grapheme
-```
 
 Make sure to read the [Modules](https://doc.rust-lang.org/book/second-edition/ch07-00-modules.html) chapter if you
 haven't already, it will help you with organizing your files.

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -30,6 +30,13 @@ to pass again.  The test file is located in the `tests` directory.   You can
 also remove the ignore flag from all the tests to get them to run all at once
 if you wish.
 
+To get the bonus test to run, remove the ignore flag (`#[ignore]`) from the
+last test, and execute the tests with:
+
+```bash
+$ cargo test --features grapheme
+```
+
 Make sure to read the [Modules](https://doc.rust-lang.org/book/second-edition/ch07-00-modules.html) chapter if you
 haven't already, it will help you with organizing your files.
 

--- a/exercises/reverse-string/tests/reverse-string.rs
+++ b/exercises/reverse-string/tests/reverse-string.rs
@@ -62,3 +62,11 @@ fn test_a_palindrome() {
 fn test_wide_characters() {
     process_reverse_case("子猫", "猫子");
 }
+
+#[test]
+#[ignore]
+#[cfg(feature="graphemes")]
+/// grapheme clusters
+fn test_grapheme_clusters() {
+    process_reverse_case("uüu", "uüu");
+}

--- a/exercises/reverse-string/tests/reverse-string.rs
+++ b/exercises/reverse-string/tests/reverse-string.rs
@@ -65,7 +65,7 @@ fn test_wide_characters() {
 
 #[test]
 #[ignore]
-#[cfg(feature="graphemes")]
+#[cfg(feature="grapheme")]
 /// grapheme clusters
 fn test_grapheme_clusters() {
     process_reverse_case("uüu", "uüu");


### PR DESCRIPTION
The Readme talks about a bonus test case with grapheme clusters, but it
wasn't in the test suite.
Looking through the submitted solutions, very few of them attempted
reversing on grapheme clusters.
This might encourage more people to attempt it.