### PR TITLE
Add a template to the `accumulate` exercise

### DIFF
--- a/exercises/accumulate/src/lib.rs
+++ b/exercises/accumulate/src/lib.rs
@@ -1,8 +1,8 @@
-pub fn map_function<T, R>(xs: Vec<T>, f: &Fn(T) -> R) -> Vec<R> {
+pub fn map_function<T, R>(_xs: Vec<T>, _f: &Fn(T) -> R) -> Vec<R> {
     panic!("Implement your solution here")
 }
 
-pub fn map_closure<F, T, R>(xs: Vec<T>, f: F) -> Vec<R>
+pub fn map_closure<F, T, R>(_xs: Vec<T>, _f: F) -> Vec<R>
 where
     F: Fn(T) -> R,
 {

--- a/exercises/accumulate/src/lib.rs
+++ b/exercises/accumulate/src/lib.rs
@@ -1,0 +1,7 @@
+pub fn map_function<T, R>(xs: Vec<T>, f: &Fn(T) -> R) -> Vec<R> {
+    panic!("Implement your solution here")
+}
+
+pub fn map_closure<T, R>(xs: Vec<T>, f: &Fn(T) -> R) -> Vec<R> {
+    panic!("Implement your solution here")
+}

--- a/exercises/accumulate/src/lib.rs
+++ b/exercises/accumulate/src/lib.rs
@@ -2,6 +2,9 @@ pub fn map_function<T, R>(xs: Vec<T>, f: &Fn(T) -> R) -> Vec<R> {
     panic!("Implement your solution here")
 }
 
-pub fn map_closure<T, R>(xs: Vec<T>, f: &Fn(T) -> R) -> Vec<R> {
+pub fn map_closure<F, T, R>(xs: Vec<T>, f: F) -> Vec<R>
+where
+    F: Fn(T) -> R,
+{
     panic!("Implement your solution here")
 }

--- a/exercises/accumulate/src/lib.rs
+++ b/exercises/accumulate/src/lib.rs
@@ -1,10 +1,10 @@
 pub fn map_function<T, R>(_xs: Vec<T>, _f: &Fn(T) -> R) -> Vec<R> {
-    panic!("Implement your solution here")
+    unimplemented!()
 }
 
 pub fn map_closure<F, T, R>(_xs: Vec<T>, _f: F) -> Vec<R>
 where
     F: Fn(T) -> R,
 {
-    panic!("Implement your solution here")
+    unimplemented!()
 }


### PR DESCRIPTION
With an empty `src/lib.rs` the test suite won't compile until a
learner has written a more or less complete solution. This means they
can't pass the first test until they've understood the whole suite.

This commit adds stub implementations of the `map_function` and
`map_closure` functions so that the test suite compiles as each test
is passed.

The template I wrote uses generics types instead of having all arguments be
`i32`s. This seemed more natural to me, but I'm happy to change the template
to be more concrete if that's preferable.