### PR TITLE
twofer: Added escape characters test

### DIFF
--- a/exercises/twofer/tests/two-fer.rs
+++ b/exercises/twofer/tests/two-fer.rs
@@ -8,7 +8,7 @@ fn empty_string() {
 
 #[test]
 #[ignore]
-fn alice() { 
+fn alice() {
     assert_eq!(twofer("Alice"), "One for Alice, one for me.");
 }
 
@@ -16,4 +16,16 @@ fn alice() {
 #[ignore]
 fn bob() {
     assert_eq!(twofer("Bob"), "One for Bob, one for me.");
+}
+
+#[test]
+#[ignore]
+fn escape_characters_test() {
+    assert_eq!(twofer(" "), "One for you, one for me.");
+
+    assert_eq!(twofer("\n"), "One for you, one for me.");
+
+    assert_eq!(twofer("\n\r"), "One for you, one for me.");
+
+    assert_eq!(twofer("\t"), "One for you, one for me.");
 }


### PR DESCRIPTION
While browsing the solutions for `twofer` exercise,
I have found that a lot of them use such checks as 
`match name {"" => "you", ...` 
or 
`if name == ""`

This checks would not work for cases when name is a string with a single space `" "`,
or a string with escape characters like `"\n"`.

So I suggest a new test that addresses these cases. 

While it adds complexity for the final solution, I think people 
would benefit from it since this sort of problem is really common in programming.