### PR TITLE
acronym: Add test for empty string

### DIFF
--- a/exercises/acronym/tests/acronym.rs
+++ b/exercises/acronym/tests/acronym.rs
@@ -11,7 +11,6 @@ fn basic() {
   assert_eq!(acronym::abbreviate("Portable Network Graphics"), "PNG");
 }
 
-
 #[test]
 #[ignore]
 fn lowercase_words() {

--- a/exercises/acronym/tests/acronym.rs
+++ b/exercises/acronym/tests/acronym.rs
@@ -1,9 +1,16 @@
 extern crate acronym;
 
 #[test]
+fn empty() {
+  assert_eq!(acronym::abbreviate(""), "");
+}
+
+#[test]
+#[ignore]
 fn basic() {
   assert_eq!(acronym::abbreviate("Portable Network Graphics"), "PNG");
 }
+
 
 #[test]
 #[ignore]


### PR DESCRIPTION
This will add a test with an empty string as input to the acronym exercise.