### PR TITLE
gigaseconds: RustFmt-ed tests source file

### DIFF
--- a/exercises/gigasecond/tests/gigasecond.rs
+++ b/exercises/gigasecond/tests/gigasecond.rs
@@ -12,39 +12,60 @@ extern crate gigasecond;
  *
  * In order to use the crate, your solution will need to start with the two following lines
 */
+
 extern crate chrono;
 use chrono::{TimeZone, Utc};
 
 #[test]
 fn test_date() {
-    let start_date = Utc.ymd(2011, 4, 25).and_hms(0,0,0);
-    assert_eq!(gigasecond::after(start_date), Utc.ymd(2043, 1, 1).and_hms(1,46,40));
+    let start_date = Utc.ymd(2011, 4, 25).and_hms(0, 0, 0);
+
+    assert_eq!(
+        gigasecond::after(start_date),
+        Utc.ymd(2043, 1, 1).and_hms(1, 46, 40)
+    );
 }
 
 #[test]
 #[ignore]
 fn test_another_date() {
-    let start_date = Utc.ymd(1977, 6, 13).and_hms(0,0,0);
-    assert_eq!(gigasecond::after(start_date), Utc.ymd(2009, 2, 19).and_hms(1,46,40));
+    let start_date = Utc.ymd(1977, 6, 13).and_hms(0, 0, 0);
+
+    assert_eq!(
+        gigasecond::after(start_date),
+        Utc.ymd(2009, 2, 19).and_hms(1, 46, 40)
+    );
 }
 
 #[test]
 #[ignore]
 fn test_third_date() {
-    let start_date = Utc.ymd(1959, 7, 19).and_hms(0,0,0);
-    assert_eq!(gigasecond::after(start_date), Utc.ymd(1991, 3, 27).and_hms(1,46,40));
+    let start_date = Utc.ymd(1959, 7, 19).and_hms(0, 0, 0);
+
+    assert_eq!(
+        gigasecond::after(start_date),
+        Utc.ymd(1991, 3, 27).and_hms(1, 46, 40)
+    );
 }
 
 #[test]
 #[ignore]
 fn test_datetime() {
-    let start_date = Utc.ymd(2015, 1, 24).and_hms(22,0,0);
-    assert_eq!(gigasecond::after(start_date), Utc.ymd(2046, 10, 2).and_hms(23,46,40));
+    let start_date = Utc.ymd(2015, 1, 24).and_hms(22, 0, 0);
+
+    assert_eq!(
+        gigasecond::after(start_date),
+        Utc.ymd(2046, 10, 2).and_hms(23, 46, 40)
+    );
 }
 
 #[test]
 #[ignore]
 fn test_another_datetime() {
-    let start_date = Utc.ymd(2015, 1, 24).and_hms(23,59,59);
-    assert_eq!(gigasecond::after(start_date), Utc.ymd(2046, 10, 3).and_hms(1,46,39));
+    let start_date = Utc.ymd(2015, 1, 24).and_hms(23, 59, 59);
+
+    assert_eq!(
+        gigasecond::after(start_date),
+        Utc.ymd(2046, 10, 3).and_hms(1, 46, 39)
+    );
 }


### PR DESCRIPTION
Since README for language track mentions that `rustfmt` should be applied for Rust sources. 