### PR TITLE
diffie-hellman: Added big numbers tests

### DIFF
--- a/exercises/diffie-hellman/.meta/hints.md
+++ b/exercises/diffie-hellman/.meta/hints.md
@@ -1,0 +1,2 @@
+One possible solution for this exercise is to implement your own modular exponentiation function.
+To learn more about it refer to the [following page](https://en.wikipedia.org/wiki/Modular_exponentiation).

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -38,7 +38,8 @@ The calculations produce the same result!  Alice and Bob now share
 secret s.
 
 One possible solution for this exercise is to implement your own modular exponentiation function.
-To learn more about it refer to the [following page][modular-exponentiation].
+To learn more about it refer to the [following page](https://en.wikipedia.org/wiki/Modular_exponentiation).
+
 
 ## Rust Installation
 
@@ -92,7 +93,6 @@ If you want to know more about Exercism, take a look at the [contribution guide]
 [modules]: https://doc.rust-lang.org/book/second-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/second-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/second-edition/ch11-02-running-tests.html
-[modular-exponentiation]: https://en.wikipedia.org/wiki/Modular_exponentiation
 
 ## Source
 

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -37,6 +37,9 @@ Bob calculates
 The calculations produce the same result!  Alice and Bob now share
 secret s.
 
+One possible solution for this exercise is to implement your own modular exponentiation function.
+To learn more about it refer to the [following page][modular-exponentiation].
+
 ## Rust Installation
 
 Refer to the [exercism help page][help-page] for Rust installation and learning
@@ -89,6 +92,7 @@ If you want to know more about Exercism, take a look at the [contribution guide]
 [modules]: https://doc.rust-lang.org/book/second-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/second-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/second-edition/ch11-02-running-tests.html
+[modular-exponentiation]: https://en.wikipedia.org/wiki/Modular_exponentiation
 
 ## Source
 

--- a/exercises/diffie-hellman/example.rs
+++ b/exercises/diffie-hellman/example.rs
@@ -2,14 +2,36 @@ extern crate rand;
 
 use rand::distributions::{IndependentSample, Range};
 
+/// Right-to-left modular exponentiation implementation
+/// For more information see https://en.wikipedia.org/wiki/Modular_exponentiation
+fn modular_exponentiation(base: u64, exponent: u64, modulus: u64) -> u64 {
+    let mut result = 1;
+
+    let mut e = exponent;
+
+    let mut b = base;
+
+    while e > 0 {
+        if (e & 1) == 1 {
+            result = (result * b) % modulus;
+        }
+
+        e >>= 1;
+
+        b = (b * b) % modulus;
+    }
+
+    result
+}
+
 pub fn private_key(p: u64) -> u64 {
     Range::new(2, p).ind_sample(&mut rand::thread_rng())
 }
 
 pub fn public_key(p: u64, g: u64, a: u64) -> u64 {
-    g.pow(a as u32) % p
+    modular_exponentiation(g, a, p)
 }
 
 pub fn secret(p: u64, b_pub: u64, a: u64) -> u64 {
-    b_pub.pow(a as u32) % p
+    modular_exponentiation(b_pub, a, p)
 }

--- a/exercises/diffie-hellman/tests/diffie-hellman.rs
+++ b/exercises/diffie-hellman/tests/diffie-hellman.rs
@@ -41,6 +41,36 @@ fn test_secret_key_correct() {
 
 #[test]
 #[ignore]
+fn test_public_key_correct_big_numbers() {
+    let p: u64 = 4_294_967_299;
+
+    let g: u64 = 8;
+
+    let private_key: u64 = 4_294_967_296;
+
+    let expected: u64 = 4096;
+
+    assert_eq!(public_key(p, g, private_key), expected);
+}
+
+#[test]
+#[ignore]
+fn test_secret_key_correct_big_numbers() {
+    let p: u64 = 4_294_967_927;
+
+    let private_key_a = 4_294_967_300;
+
+    let public_key_b = 843;
+
+    let secret = secret(p, public_key_b, private_key_a);
+
+    let expected = 1_389_354_282;
+
+    assert_eq!(secret, expected);
+}
+
+#[test]
+#[ignore]
 fn test_changed_secret_key() {
     let p: u64 = 13;
     let g: u64 = 11;


### PR DESCRIPTION
Mainly to prevent using `a as u32` solution, since it yields false results when a is larger then u32::MAX 