### PR TITLE
Formatted existing examples with rustfmt

### DIFF
--- a/bin/format_exercises
+++ b/bin/format_exercises
@@ -25,6 +25,8 @@ for exercise_dir in ${EXERCISES_PATH}/*; do
 			cd "$exercise_dir"
 
 			cargo fmt
+
+			[ -f example.rs ] && rustfmt example.rs
 		)
 	fi
 

--- a/exercises/accumulate/example.rs
+++ b/exercises/accumulate/example.rs
@@ -6,7 +6,10 @@ pub fn map_function(values: Vec<i32>, f: &Fn(i32) -> i32) -> Vec<i32> {
     out
 }
 
-pub fn map_closure<F>(values: Vec<i32>, f: F) -> Vec<i32> where F: Fn(i32) -> i32 {
+pub fn map_closure<F>(values: Vec<i32>, f: F) -> Vec<i32>
+where
+    F: Fn(i32) -> i32,
+{
     let mut out: Vec<i32> = vec![];
     for val in values {
         out.push(f(val))

--- a/exercises/acronym/example.rs
+++ b/exercises/acronym/example.rs
@@ -1,9 +1,10 @@
 pub fn abbreviate(phrase: &str) -> String {
-    phrase.split(|c: char| c.is_whitespace() || !c.is_alphanumeric())
-          .flat_map(|word| split_camel(word))
-          .filter_map(|word| word.chars().next())
-          .collect::<String>()
-          .to_uppercase()
+    phrase
+        .split(|c: char| c.is_whitespace() || !c.is_alphanumeric())
+        .flat_map(|word| split_camel(word))
+        .filter_map(|word| word.chars().next())
+        .collect::<String>()
+        .to_uppercase()
 }
 
 fn split_camel(phrase: &str) -> Vec<String> {

--- a/exercises/acronym/tests/acronym.rs
+++ b/exercises/acronym/tests/acronym.rs
@@ -2,7 +2,7 @@ extern crate acronym;
 
 #[test]
 fn empty() {
-  assert_eq!(acronym::abbreviate(""), "");
+    assert_eq!(acronym::abbreviate(""), "");
 }
 
 #[test]

--- a/exercises/all-your-base/example.rs
+++ b/exercises/all-your-base/example.rs
@@ -38,7 +38,11 @@ pub enum Error {
 ///  * Never output leading 0 digits. However, your function must be able to
 ///     process input with leading 0 digits.
 ///
-pub fn convert<P: AsRef<[Digit]>>(digits: P, from_base: Digit, to_base: Digit) -> Result<Vec<Digit>, Error> {
+pub fn convert<P: AsRef<[Digit]>>(
+    digits: P,
+    from_base: Digit,
+    to_base: Digit,
+) -> Result<Vec<Digit>, Error> {
     // check that both bases are in the correct range
     if from_base < 2 {
         return Err(Error::InvalidInputBase);
@@ -53,7 +57,9 @@ pub fn convert<P: AsRef<[Digit]>>(digits: P, from_base: Digit, to_base: Digit) -
     }
 
     // convert all digits into a single large number
-    let mut immediate = digits.as_ref().iter()
+    let mut immediate = digits
+        .as_ref()
+        .iter()
         .rev()
         .enumerate()
         .map(|(i, &num)| num * from_base.pow(i as u32))

--- a/exercises/allergies/example.rs
+++ b/exercises/allergies/example.rs
@@ -1,7 +1,16 @@
 pub struct Allergies(pub usize);
 
 #[derive(PartialEq, Debug)]
-pub enum Allergen { Eggs, Peanuts, Shellfish, Strawberries, Tomatoes, Chocolate, Pollen, Cats }
+pub enum Allergen {
+    Eggs,
+    Peanuts,
+    Shellfish,
+    Strawberries,
+    Tomatoes,
+    Chocolate,
+    Pollen,
+    Cats,
+}
 
 impl Allergies {
     pub fn new(score: usize) -> Allergies {
@@ -10,17 +19,30 @@ impl Allergies {
 
     pub fn is_allergic_to(&self, allergen: &Allergen) -> bool {
         let allergens = Allergies::allergens();
-        let index = allergens.iter().position(|x: &Allergen| x == allergen).unwrap();
+        let index = allergens
+            .iter()
+            .position(|x: &Allergen| x == allergen)
+            .unwrap();
         (self.0 & (1 << index)) != 0
     }
 
     pub fn allergies(&self) -> Vec<Allergen> {
-        Allergies::allergens().into_iter().filter(|allergen| self.is_allergic_to(allergen)).collect()
+        Allergies::allergens()
+            .into_iter()
+            .filter(|allergen| self.is_allergic_to(allergen))
+            .collect()
     }
 
     fn allergens() -> Vec<Allergen> {
-        vec![Allergen::Eggs, Allergen::Peanuts, Allergen::Shellfish,
-            Allergen::Strawberries, Allergen::Tomatoes, Allergen::Chocolate,
-            Allergen::Pollen, Allergen::Cats]
+        vec![
+            Allergen::Eggs,
+            Allergen::Peanuts,
+            Allergen::Shellfish,
+            Allergen::Strawberries,
+            Allergen::Tomatoes,
+            Allergen::Chocolate,
+            Allergen::Pollen,
+            Allergen::Cats,
+        ]
     }
 }

--- a/exercises/alphametics/example.rs
+++ b/exercises/alphametics/example.rs
@@ -6,14 +6,14 @@ extern crate permutohedron;
 use itertools::Itertools;
 use permutohedron::Heap as Permutations;
 
-
+use std::char;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::char;
 
 fn test_equation(puzzle: &str, substitutions: &HashMap<char, u8>) -> bool {
     // Create a new String with characters changed to numbers
-    let puzzle: String = puzzle.chars()
+    let puzzle: String = puzzle
+        .chars()
         .map(|c| {
             if let Some(&n) = substitutions.get(&c) {
                 // If the character is in the substitutions, get the number and
@@ -33,13 +33,20 @@ fn test_equation(puzzle: &str, substitutions: &HashMap<char, u8>) -> bool {
     let right = equation[1].trim().parse::<u32>().unwrap();
 
     // Sum the parts on the left side
-    let left: u32 = equation[0].split('+').map(str::trim).map(|n| n.parse::<u32>().unwrap()).sum();
+    let left: u32 = equation[0]
+        .split('+')
+        .map(str::trim)
+        .map(|n| n.parse::<u32>().unwrap())
+        .sum();
 
     // Create a String with just the numbers and spaces
-    let just_numbers =
-        puzzle.chars().filter(|c| c.is_digit(10) || c.is_whitespace()).collect::<String>();
+    let just_numbers = puzzle
+        .chars()
+        .filter(|c| c.is_digit(10) || c.is_whitespace())
+        .collect::<String>();
     // Split this into the numbers and check every number's first character
-    let no_leading_zeroes = just_numbers.split_whitespace()
+    let no_leading_zeroes = just_numbers
+        .split_whitespace()
         .all(|number| number.chars().next().unwrap() != '0');
 
     // Return true if left and right side is equal and the equation doesnt
@@ -47,11 +54,12 @@ fn test_equation(puzzle: &str, substitutions: &HashMap<char, u8>) -> bool {
     left == right && no_leading_zeroes
 }
 
-
 pub fn solve(puzzle: &str) -> Option<HashMap<char, u8>> {
     // Get unique letters from the puzzle
-    let letters: HashSet<char> =
-        puzzle.chars().filter(|&c| c.is_alphabetic() && c.is_uppercase()).collect();
+    let letters: HashSet<char> = puzzle
+        .chars()
+        .filter(|&c| c.is_alphabetic() && c.is_uppercase())
+        .collect();
     let letters: Vec<char> = letters.into_iter().collect();
 
     // All available numbers for substitution

--- a/exercises/anagram/example.rs
+++ b/exercises/anagram/example.rs
@@ -7,8 +7,12 @@ fn sort(word: &String) -> String {
 pub fn anagrams_for<'a>(word: &str, inputs: &[&'a str]) -> Vec<&'a str> {
     let lower = word.to_lowercase();
     let sorted = sort(&lower);
-    inputs.iter().filter(|input| {
-        let input_lower = input.to_lowercase();
-        lower != input_lower && sorted == sort(&input_lower)
-    }).cloned().collect()
+    inputs
+        .iter()
+        .filter(|input| {
+            let input_lower = input.to_lowercase();
+            lower != input_lower && sorted == sort(&input_lower)
+        })
+        .cloned()
+        .collect()
 }

--- a/exercises/atbash-cipher/example.rs
+++ b/exercises/atbash-cipher/example.rs
@@ -12,23 +12,23 @@ fn get_transpose(ch: char) -> char {
 
 pub fn encode(plaintext: &str) -> String {
     plaintext
-    .to_lowercase()
-    .chars()
-    .filter(|&ch| ch.is_ascii())
-    .filter(|&ch| ch.is_alphanumeric())
-    .map(|ch| get_transpose(ch))
-    .collect::<Vec<char>>()
-    .chunks(5)
-    .map(|slice| slice.iter().cloned().collect::<String>())
-    .collect::<Vec<String>>()
-    .join(" ")
+        .to_lowercase()
+        .chars()
+        .filter(|&ch| ch.is_ascii())
+        .filter(|&ch| ch.is_alphanumeric())
+        .map(|ch| get_transpose(ch))
+        .collect::<Vec<char>>()
+        .chunks(5)
+        .map(|slice| slice.iter().cloned().collect::<String>())
+        .collect::<Vec<String>>()
+        .join(" ")
 }
 
 pub fn decode(ciphertext: &str) -> String {
     ciphertext
-    .split::<char>(' ')
-    .collect::<String>()
-    .chars()
-    .map(|ch| get_transpose(ch))
-    .collect::<String>()
+        .split::<char>(' ')
+        .collect::<String>()
+        .chars()
+        .map(|ch| get_transpose(ch))
+        .collect::<String>()
 }

--- a/exercises/beer-song/example.rs
+++ b/exercises/beer-song/example.rs
@@ -1,22 +1,28 @@
 pub fn verse(n: i32) -> String {
     match n {
         0 => "No more bottles of beer on the wall, no more bottles of beer.\n\
-              Go to the store and buy some more, 99 bottles of beer on the wall.\n".to_string(),
+              Go to the store and buy some more, 99 bottles of beer on the wall.\n"
+            .to_string(),
         1 => "1 bottle of beer on the wall, 1 bottle of beer.\n\
-              Take it down and pass it around, no more bottles of beer on the wall.\n".to_string(),
+              Take it down and pass it around, no more bottles of beer on the wall.\n"
+            .to_string(),
         2 => "2 bottles of beer on the wall, 2 bottles of beer.\n\
-              Take one down and pass it around, 1 bottle of beer on the wall.\n".to_string(),
-        n if n > 2 && n <= 99 =>
-            format!(
-                "{n} bottles of beer on the wall, {n} bottles of beer.\n\
-                 Take one down and pass it around, {n_minus_1} bottles of beer on the wall.\n",
-                n=n,
-                n_minus_1=n - 1),
-        _ =>
-            panic!(),
+              Take one down and pass it around, 1 bottle of beer on the wall.\n"
+            .to_string(),
+        n if n > 2 && n <= 99 => format!(
+            "{n} bottles of beer on the wall, {n} bottles of beer.\n\
+             Take one down and pass it around, {n_minus_1} bottles of beer on the wall.\n",
+            n = n,
+            n_minus_1 = n - 1
+        ),
+        _ => panic!(),
     }
 }
 
 pub fn sing(start: i32, end: i32) -> String {
-    (end .. start + 1).rev().map(|n| verse(n)).collect::<Vec<_>>().join("\n")
+    (end..start + 1)
+        .rev()
+        .map(|n| verse(n))
+        .collect::<Vec<_>>()
+        .join("\n")
 }

--- a/exercises/binary-search/example.rs
+++ b/exercises/binary-search/example.rs
@@ -1,10 +1,9 @@
 use std::cmp::Ordering;
 
 pub fn find<C, T>(elements: C, needle: T) -> Option<usize>
-    where
-        C: AsRef<[T]>,
-        T: Ord,
-
+where
+    C: AsRef<[T]>,
+    T: Ord,
 {
     let mut base = 0usize;
     let mut slice: &[T] = elements.as_ref();

--- a/exercises/bob/example.rs
+++ b/exercises/bob/example.rs
@@ -1,9 +1,15 @@
 pub fn reply(message: &str) -> &str {
-    if is_silence(message) { "Fine. Be that way!" }
-    else if is_yelling(message) && is_question(message) { "Calm down, I know what I'm doing!" }
-    else if is_yelling(message) { "Whoa, chill out!" }
-    else if is_question(message) { "Sure." }
-    else { "Whatever." }
+    if is_silence(message) {
+        "Fine. Be that way!"
+    } else if is_yelling(message) && is_question(message) {
+        "Calm down, I know what I'm doing!"
+    } else if is_yelling(message) {
+        "Whoa, chill out!"
+    } else if is_question(message) {
+        "Sure."
+    } else {
+        "Whatever."
+    }
 }
 
 fn is_silence(message: &str) -> bool {

--- a/exercises/book-store/example.rs
+++ b/exercises/book-store/example.rs
@@ -1,9 +1,9 @@
+use std::cell::RefCell;
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashSet};
 use std::collections::hash_map::DefaultHasher;
+use std::collections::{BTreeSet, HashSet};
 use std::hash::{Hash, Hasher};
 use std::mem;
-use std::cell::RefCell;
 
 type Book = usize;
 type GroupedBasket = Vec<Group>;
@@ -25,17 +25,15 @@ impl Group {
     }
 
     fn price(&self) -> Price {
-        (self.0.borrow().len() as Price) * BOOK_PRICE *
-            match self.0.borrow().len() {
-                2 => 95,
-                3 => 90,
-                4 => 80,
-                5 => 75,
-                _ => 100,
-            } / 100
+        (self.0.borrow().len() as Price) * BOOK_PRICE * match self.0.borrow().len() {
+            2 => 95,
+            3 => 90,
+            4 => 80,
+            5 => 75,
+            _ => 100,
+        } / 100
     }
 }
-
 
 impl Ord for Group {
     // we want to order groups first by qty contained DESC, then by lowest value ASC
@@ -45,14 +43,12 @@ impl Ord for Group {
                 if self.0.borrow().len() == 0 {
                     Ordering::Equal
                 } else {
-                    self.0.borrow().iter().next().unwrap().cmp(
-                        other
-                            .0
-                            .borrow()
-                            .iter()
-                            .next()
-                            .unwrap(),
-                    )
+                    self.0
+                        .borrow()
+                        .iter()
+                        .next()
+                        .unwrap()
+                        .cmp(other.0.borrow().iter().next().unwrap())
                 }
             }
             otherwise => otherwise,

--- a/exercises/bowling/example.rs
+++ b/exercises/bowling/example.rs
@@ -98,7 +98,9 @@ impl Frame {
 
 impl BowlingGame {
     pub fn new() -> Self {
-        BowlingGame { frames: vec![Frame::new()] }
+        BowlingGame {
+            frames: vec![Frame::new()],
+        }
     }
 
     pub fn roll(&mut self, pins: u16) -> Result<(), Error> {

--- a/exercises/bracket-push/example.rs
+++ b/exercises/bracket-push/example.rs
@@ -45,13 +45,18 @@ pub struct MatchingBrackets {
 
 impl From<Vec<(char, char)>> for MatchingBrackets {
     fn from(v: Vec<(char, char)>) -> Self {
-        MatchingBrackets { collection: v.into_iter().collect::<HashMap<char, char>>() }
+        MatchingBrackets {
+            collection: v.into_iter().collect::<HashMap<char, char>>(),
+        }
     }
 }
 
 impl MatchingBrackets {
     fn contains(&self, other: &char) -> bool {
-        let known = self.collection.keys().chain(self.collection.values()).collect::<Vec<_>>();
+        let known = self.collection
+            .keys()
+            .chain(self.collection.values())
+            .collect::<Vec<_>>();
         known.contains(&other)
     }
 

--- a/exercises/circular-buffer/example.rs
+++ b/exercises/circular-buffer/example.rs
@@ -19,7 +19,7 @@ impl<T: Default + Clone> CircularBuffer<T> {
             buffer: vec![T::default(); size + 1],
             size: size + 1,
             start: 0,
-            end: 0
+            end: 0,
         }
     }
 

--- a/exercises/clock/example.rs
+++ b/exercises/clock/example.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-#[derive(Eq,PartialEq,Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct Clock {
-    minutes: i32
+    minutes: i32,
 }
 
 impl fmt::Display for Clock {
@@ -23,7 +23,9 @@ impl Clock {
         while mins < 0 {
             mins += 1440;
         }
-        Clock { minutes: mins % 1440 }
+        Clock {
+            minutes: mins % 1440,
+        }
     }
 
     pub fn add_minutes(&mut self, minutes: i32) -> Self {

--- a/exercises/collatz-conjecture/example.rs
+++ b/exercises/collatz-conjecture/example.rs
@@ -1,10 +1,10 @@
 pub fn collatz_positive(n: u64) -> u64 {
     if n == 1 {
         0
-    } else  {
+    } else {
         1 + match n % 2 {
             0 => collatz_positive(n / 2),
-            _ => collatz_positive(n * 3 + 1)
+            _ => collatz_positive(n * 3 + 1),
         }
     }
 }

--- a/exercises/custom-set/example.rs
+++ b/exercises/custom-set/example.rs
@@ -5,14 +5,16 @@ pub struct CustomSet<T> {
 
 impl<T: Ord + Clone> PartialEq for CustomSet<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.collection.iter().all(|x| other.contains(&x)) &&
-        other.collection.iter().all(|x| self.contains(&x))
+        self.collection.iter().all(|x| other.contains(&x))
+            && other.collection.iter().all(|x| self.contains(&x))
     }
 }
 
 impl<T: Ord + Clone> CustomSet<T> {
     pub fn new(inputs: &[T]) -> CustomSet<T> {
-        let mut s = CustomSet { collection: Vec::new() };
+        let mut s = CustomSet {
+            collection: Vec::new(),
+        };
         for input in inputs {
             s.add(input.clone());
         }
@@ -43,25 +45,25 @@ impl<T: Ord + Clone> CustomSet<T> {
 
     pub fn intersection(&self, other: &Self) -> CustomSet<T> {
         CustomSet::new(&self.collection
-                            .iter()
-                            .cloned()
-                            .filter(|c| other.contains(c))
-                            .collect::<Vec<_>>())
+            .iter()
+            .cloned()
+            .filter(|c| other.contains(c))
+            .collect::<Vec<_>>())
     }
 
     pub fn union(&self, other: &Self) -> CustomSet<T> {
         CustomSet::new(&self.collection
-                            .iter()
-                            .cloned()
-                            .chain(other.collection.iter().cloned())
-                            .collect::<Vec<_>>())
+            .iter()
+            .cloned()
+            .chain(other.collection.iter().cloned())
+            .collect::<Vec<_>>())
     }
 
     pub fn difference(&self, other: &Self) -> CustomSet<T> {
         CustomSet::new(&self.collection
-                            .iter()
-                            .cloned()
-                            .filter(|c| !other.contains(c))
-                            .collect::<Vec<_>>())
+            .iter()
+            .cloned()
+            .filter(|c| !other.contains(c))
+            .collect::<Vec<_>>())
     }
 }

--- a/exercises/decimal/example.rs
+++ b/exercises/decimal/example.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 use std::fmt;
-use std::ops::{Add, Sub, Mul};
+use std::ops::{Add, Mul, Sub};
 
 #[macro_use]
 extern crate try_opt;
@@ -71,8 +71,8 @@ impl Decimal {
             let precision_difference =
                 (higher_precision.decimal_index - lower_precision.decimal_index) as usize;
 
-            lower_precision.digits = &lower_precision.digits *
-                pow(BigInt::from(10_usize), precision_difference);
+            lower_precision.digits =
+                &lower_precision.digits * pow(BigInt::from(10_usize), precision_difference);
             lower_precision.decimal_index += precision_difference;
         }
         if one.decimal_index < two.decimal_index {
@@ -111,7 +111,7 @@ macro_rules! auto_impl_decimal_ops {
                 )
             }
         }
-    }
+    };
 }
 
 auto_impl_decimal_ops!(Add, add, |s, o| s + o, |s, _| s);
@@ -136,7 +136,7 @@ macro_rules! auto_impl_decimal_cow {
                 }
             }
         }
-    }
+    };
 }
 
 auto_impl_decimal_cow!(PartialEq, eq, |a, b| a == b, bool);

--- a/exercises/difference-of-squares/example.rs
+++ b/exercises/difference-of-squares/example.rs
@@ -4,7 +4,7 @@ pub fn square_of_sum(n: usize) -> usize {
 }
 
 pub fn sum_of_squares(n: usize) -> usize {
-    (0..n+1).map(|x| x*x).fold(0, |accum, x| accum + x)
+    (0..n + 1).map(|x| x * x).fold(0, |accum, x| accum + x)
 }
 
 pub fn difference(n: usize) -> usize {

--- a/exercises/dominoes/example.rs
+++ b/exercises/dominoes/example.rs
@@ -8,29 +8,30 @@ pub type Domino = (usize, usize);
 /// dots and row dots. Positions are mirrored ((3,4) == (4,3)), except for positions with equal row
 /// and column numbers.
 struct AvailabilityTable {
-    m: Vec<usize>
+    m: Vec<usize>,
 }
 
 impl AvailabilityTable {
     fn new() -> AvailabilityTable {
-        AvailabilityTable { m: iter::repeat(0).take(6 * 6).collect() }
+        AvailabilityTable {
+            m: iter::repeat(0).take(6 * 6).collect(),
+        }
     }
 
     fn get(&self, x: usize, y: usize) -> usize {
-        self.m[(x-1) * 6 + (y-1)]
+        self.m[(x - 1) * 6 + (y - 1)]
     }
 
     fn set(&mut self, x: usize, y: usize, v: usize) {
         let m = &mut self.m[..];
-        m[(x-1) * 6 + (y-1)] = v;
+        m[(x - 1) * 6 + (y - 1)] = v;
     }
 
     fn add(&mut self, x: usize, y: usize) {
         if x == y {
             let n = self.get(x, y);
             self.set(x, y, n + 1) // Along the diagonal
-        }
-        else {
+        } else {
             let m = self.get(x, y);
             self.set(x, y, m + 1);
             let n = self.get(y, x);
@@ -43,25 +44,23 @@ impl AvailabilityTable {
             if x == y {
                 let n = self.get(x, y);
                 self.set(x, y, n - 1) // Along the diagonal
-            }
-            else {
+            } else {
                 let m = self.get(x, y);
                 self.set(x, y, m - 1);
                 let n = self.get(y, x);
                 self.set(y, x, n - 1);
             }
-        }
-        else {
+        } else {
             // For this toy code hard explicit fail is best
             panic!("remove for 0 stones: ({:?}, {:?})", x, y)
         }
     }
 
     fn pop_first(&mut self, x: usize) -> Option<usize> {
-        for y in 1 .. 7 {
+        for y in 1..7 {
             if self.get(x, y) > 0 {
                 self.remove(x, y);
-                return Some(y)
+                return Some(y);
             }
         }
         None
@@ -70,12 +69,16 @@ impl AvailabilityTable {
 
 pub fn chain(dominoes: &[Domino]) -> Option<Vec<Domino>> {
     match dominoes.len() {
-        0 => Some(vec!()),
-        1 => if dominoes[0].0 == dominoes[0].1 { Some(vec![dominoes[0]]) } else { None },
+        0 => Some(vec![]),
+        1 => if dominoes[0].0 == dominoes[0].1 {
+            Some(vec![dominoes[0]])
+        } else {
+            None
+        },
         _ => {
             // First check if the total number of each amount of dots is even, if not it's not
             // possible to complete a cycle. This follows from that it's an Eulerian path.
-            let mut v: Vec<usize> = vec!(0, 0, 0, 0, 0, 0);
+            let mut v: Vec<usize> = vec![0, 0, 0, 0, 0, 0];
             // Keep the mutable borrow in a small scope here to allow v.iter().
             {
                 let vs = &mut v[..];
@@ -86,14 +89,13 @@ pub fn chain(dominoes: &[Domino]) -> Option<Vec<Domino>> {
             }
             for n in v.iter() {
                 if n % 2 != 0 {
-                    return None
+                    return None;
                 }
             }
             let chain = chain_worker(dominoes);
             if chain.len() == dominoes.len() {
                 Some(chain)
-            }
-            else {
+            } else {
                 None
             }
         }
@@ -106,7 +108,6 @@ fn chain_worker(dominoes: &[Domino]) -> Vec<Domino> {
     let mut t = AvailabilityTable::new();
     for dom in doms.iter() {
         t.add(dom.0, dom.1)
-
     }
     let mut v: Vec<Domino> = Vec::new();
     v.push(first);

--- a/exercises/etl/example.rs
+++ b/exercises/etl/example.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
 
 pub fn transform(input: &BTreeMap<i32, Vec<char>>) -> BTreeMap<char, i32> {
-    input.iter().flat_map(|(&n, vec)| {
-        vec.iter().map(move |c| (c.to_ascii_lowercase(), n))
-    }).collect()
+    input
+        .iter()
+        .flat_map(|(&n, vec)| vec.iter().map(move |c| (c.to_ascii_lowercase(), n)))
+        .collect()
 }

--- a/exercises/grade-school/example.rs
+++ b/exercises/grade-school/example.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
 
 pub struct School {
-    grades: HashMap<u32, Vec<String>>
+    grades: HashMap<u32, Vec<String>>,
 }
 
 impl School {
     pub fn new() -> School {
-        School { grades: HashMap::new() }
+        School {
+            grades: HashMap::new(),
+        }
     }
 
     pub fn add(&mut self, grade: u32, student: &str) {

--- a/exercises/hexadecimal/example.rs
+++ b/exercises/hexadecimal/example.rs
@@ -16,7 +16,7 @@ fn parse_hex_digit(c: char) -> Option<i64> {
         'd' => Some(13),
         'e' => Some(14),
         'f' => Some(15),
-        _   => None,
+        _ => None,
     }
 }
 
@@ -28,8 +28,6 @@ pub fn hex_to_int(string: &str) -> Option<i64> {
         .rev()
         .enumerate()
         .fold(Some(0), |acc, (pos, c)| {
-            parse_hex_digit(c).and_then(|n| {
-                acc.map(|acc| acc + n * base.pow(pos as u32))
-            })
+            parse_hex_digit(c).and_then(|n| acc.map(|acc| acc + n * base.pow(pos as u32)))
         })
 }

--- a/exercises/isbn-verifier/example.rs
+++ b/exercises/isbn-verifier/example.rs
@@ -8,14 +8,13 @@ enum IsbnType {
 /// Checks if an 'X' is valid at the given position for the given ISBN type
 #[allow(non_snake_case)]
 fn is_X_valid(position: &usize, isbn_type: &IsbnType) -> bool {
-    (isbn_type == &IsbnType::Isbn10 && position == &9 ) ||
-    (isbn_type == &IsbnType::Isbn13 && position == &12)
+    (isbn_type == &IsbnType::Isbn10 && position == &9)
+        || (isbn_type == &IsbnType::Isbn13 && position == &12)
 }
 
 /// Checks if a '-' is valid at the given position for the given ISBN type
 fn is_dash_valid(position: &usize, isbn_type: &IsbnType) -> bool {
-    isbn_type == &IsbnType::Isbn13 &&
-    (position == &1 || position == &5 || position == &11)
+    isbn_type == &IsbnType::Isbn13 && (position == &1 || position == &5 || position == &11)
 }
 
 /// Determines whether the supplied string is a valid ISBN number
@@ -30,10 +29,10 @@ pub fn is_valid_isbn(isbn: &str) -> bool {
     let mut coefficient = 10;
     for (position, c) in isbn.char_indices() {
         let digit_value = match c {
-            '0' ... '9' => c.to_digit(10).unwrap(),
+            '0'...'9' => c.to_digit(10).unwrap(),
             'X' if is_X_valid(&position, &isbn_type) => 10,
             '-' if is_dash_valid(&position, &isbn_type) => continue,
-            _   => return false,
+            _ => return false,
         };
 
         checksum += coefficient * digit_value;

--- a/exercises/isogram/example.rs
+++ b/exercises/isogram/example.rs
@@ -1,12 +1,18 @@
 pub fn check(word: &str) -> bool {
-
     // Filter all non-Alphabetic character out and collect them in a new String
-    let normalized_string: String = word.to_lowercase().chars().filter(|c| c.is_alphabetic()).collect();
+    let normalized_string: String = word.to_lowercase()
+        .chars()
+        .filter(|c| c.is_alphabetic())
+        .collect();
 
     /* Find the char element from back and front and compare the index.
        If it is the same unique char the index will be the same.*/
     let is_unique = |x: char, word: &str| word.find(x).unwrap() == word.rfind(x).unwrap();
 
     // Length should be the same if it is a isogram
-    normalized_string.len() == normalized_string.chars().filter(|&x| is_unique(x, normalized_string.as_str())).count()
+    normalized_string.len()
+        == normalized_string
+            .chars()
+            .filter(|&x| is_unique(x, normalized_string.as_str()))
+            .count()
 }

--- a/exercises/largest-series-product/example.rs
+++ b/exercises/largest-series-product/example.rs
@@ -13,7 +13,8 @@ pub fn lsp(string_digits: &str, span: usize) -> Result<u64, Error> {
         return Err(Error::InvalidDigit(invalid));
     }
 
-    let products: Vec<u64> = string_digits.chars()
+    let products: Vec<u64> = string_digits
+        .chars()
         .map(|c| c.to_digit(10).unwrap() as u64)
         .collect::<Vec<u64>>()
         .windows(span)

--- a/exercises/luhn-from/example.rs
+++ b/exercises/luhn-from/example.rs
@@ -21,7 +21,9 @@ impl Luhn {
 
 impl From<String> for Luhn {
     fn from(s: String) -> Self {
-        Luhn { digits: s.chars().collect() }
+        Luhn {
+            digits: s.chars().collect(),
+        }
     }
 }
 

--- a/exercises/luhn/example.rs
+++ b/exercises/luhn/example.rs
@@ -1,10 +1,12 @@
 pub fn is_valid(candidate: &str) -> bool {
-    if candidate.chars().filter(|c| c.is_digit(10)).take(2).count() <= 1 ||
-       candidate.chars().any(|c| !c.is_digit(10) && c != ' ') {
+    if candidate.chars().filter(|c| c.is_digit(10)).take(2).count() <= 1
+        || candidate.chars().any(|c| !c.is_digit(10) && c != ' ')
+    {
         return false;
     }
 
-    candidate.chars()
+    candidate
+        .chars()
         .filter_map(|c| c.to_digit(10))
         .rev()
         .enumerate()

--- a/exercises/nth-prime/example.rs
+++ b/exercises/nth-prime/example.rs
@@ -1,12 +1,12 @@
 fn is_prime(n: u32) -> bool {
     let mut i: u32 = 3;
     while (i * i) < (n + 1) {
-      if n % i == 0 {
-         return false;
-      }
-      i += 1;
-   }
-   return true;
+        if n % i == 0 {
+            return false;
+        }
+        i += 1;
+    }
+    return true;
 }
 
 pub fn nth(n: u32) -> Option<u32> {

--- a/exercises/nucleotide-codons/example.rs
+++ b/exercises/nucleotide-codons/example.rs
@@ -1,36 +1,42 @@
 use std::collections::HashMap;
 
 pub struct CodonInfo<'a> {
-    actual_codons: HashMap<&'a str, &'a str>
+    actual_codons: HashMap<&'a str, &'a str>,
 }
 
 pub fn parse<'a>(pairs: Vec<(&'a str, &'a str)>) -> CodonInfo<'a> {
-    CodonInfo{
-        actual_codons: pairs.into_iter().collect()
+    CodonInfo {
+        actual_codons: pairs.into_iter().collect(),
     }
 }
 
 impl<'a> CodonInfo<'a> {
     pub fn name_for(&self, codon: &str) -> Result<&'a str, &'static str> {
         if codon.len() != 3 {
-            return Err("invalid length")
+            return Err("invalid length");
         }
 
         let mut valid = true;
-        let lookup: String = codon.chars().map(|l| {
-            // Get an example of a "letter" represented by the possibly encoded letter.
-            // Since every codon represented by the compressed notation has to be of
-            // the desired amino acid just picking one at random will do.
-            match l {
-                'A' | 'W' | 'M' | 'R' | 'D' | 'H' | 'V' | 'N' => 'A',
-                'C' | 'S' | 'Y' | 'B' => 'C',
-                'G' | 'K' => 'G',
-                'T' => 'T',
-                _ => { valid = false; ' ' }
-            }
-        }).collect();
+        let lookup: String = codon
+            .chars()
+            .map(|l| {
+                // Get an example of a "letter" represented by the possibly encoded letter.
+                // Since every codon represented by the compressed notation has to be of
+                // the desired amino acid just picking one at random will do.
+                match l {
+                    'A' | 'W' | 'M' | 'R' | 'D' | 'H' | 'V' | 'N' => 'A',
+                    'C' | 'S' | 'Y' | 'B' => 'C',
+                    'G' | 'K' => 'G',
+                    'T' => 'T',
+                    _ => {
+                        valid = false;
+                        ' '
+                    }
+                }
+            })
+            .collect();
         if !valid {
-            return Err("invalid char")
+            return Err("invalid char");
         }
 
         // If the input table is correct (which it is) every valid codon is in it

--- a/exercises/nucleotide-count/example.rs
+++ b/exercises/nucleotide-count/example.rs
@@ -2,13 +2,23 @@ use std::collections::HashMap;
 
 static VALID_NUCLEOTIDES: &'static str = "ACGT";
 
-pub fn count(nucleotide: char, input: &str) -> Result<usize, char> {
-    let valid = |x: char| VALID_NUCLEOTIDES.contains(x);
-    if valid(nucleotide) && input.chars().all(valid) {
-        Ok(input.chars().filter(|&c| c == nucleotide).count())
+fn valid(c: char) -> Result<char, char> {
+    if VALID_NUCLEOTIDES.contains(c) {
+        Ok(c)
     } else {
-        Err(nucleotide)
+        Err(c)
     }
+}
+
+pub fn count(nucleotide: char, input: &str) -> Result<usize, char> {
+    valid(nucleotide)?;
+    let mut count = 0;
+    for c in input.chars() {
+        if valid(c)? == nucleotide {
+            count += 1;
+        }
+    }
+    Ok(count)
 }
 
 pub fn nucleotide_counts(input: &str) -> Result<HashMap<char, usize>, char> {

--- a/exercises/nucleotide-count/example.rs
+++ b/exercises/nucleotide-count/example.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 static VALID_NUCLEOTIDES: &'static str = "ACGT";
 
 pub fn count(nucleotide: char, input: &str) -> Result<usize, char> {
-    let valid = |x: char| { VALID_NUCLEOTIDES.contains(x) };
+    let valid = |x: char| VALID_NUCLEOTIDES.contains(x);
     if valid(nucleotide) && input.chars().all(valid) {
         Ok(input.chars().filter(|&c| c == nucleotide).count())
     } else {

--- a/exercises/pangram/example.rs
+++ b/exercises/pangram/example.rs
@@ -2,12 +2,12 @@ use std::collections::BTreeSet;
 use std::iter::FromIterator;
 
 pub fn is_pangram(sentence: &str) -> bool {
-    sentence.to_lowercase()
-            .chars()
-            .filter(|c| c.is_alphabetic())
-            .filter(|c| c.is_ascii())
-            .collect::<BTreeSet<char>>() == english_letter_set()
-
+    sentence
+        .to_lowercase()
+        .chars()
+        .filter(|c| c.is_alphabetic())
+        .filter(|c| c.is_ascii())
+        .collect::<BTreeSet<char>>() == english_letter_set()
 }
 
 fn english_letter_set() -> BTreeSet<char> {

--- a/exercises/parallel-letter-frequency/example.rs
+++ b/exercises/parallel-letter-frequency/example.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
-use std::thread;
 use std::sync::mpsc::channel;
-
+use std::thread;
 
 /// Compute the frequency of each letter (technically of each unicode codepoint) using the given
 /// number of worker threads.
@@ -9,9 +8,13 @@ pub fn frequency(texts: &[&str], num_workers: usize) -> HashMap<char, usize> {
     assert!(num_workers > 0);
     let part_size_floor = texts.len() / num_workers;
     let rem = texts.len() % num_workers;
-    let part_size = if rem > 0 { part_size_floor + 1 } else { part_size_floor };
+    let part_size = if rem > 0 {
+        part_size_floor + 1
+    } else {
+        part_size_floor
+    };
     let mut parts: Vec<Vec<String>> = Vec::with_capacity(part_size);
-    for _ in 0 .. num_workers {
+    for _ in 0..num_workers {
         parts.push(Vec::with_capacity(part_size));
     }
     let mut i = 0;

--- a/exercises/pascals-triangle/example.rs
+++ b/exercises/pascals-triangle/example.rs
@@ -4,11 +4,15 @@ pub struct PascalsTriangle {
 
 impl PascalsTriangle {
     pub fn new(row_count: u32) -> Self {
-        PascalsTriangle { row_count: row_count }
+        PascalsTriangle {
+            row_count: row_count,
+        }
     }
 
     pub fn rows(&self) -> Vec<Vec<u32>> {
-        (0..self.row_count).map(|row| PascalsTriangle::row(row)).collect()
+        (0..self.row_count)
+            .map(|row| PascalsTriangle::row(row))
+            .collect()
     }
 
     pub fn row(number: u32) -> Vec<u32> {

--- a/exercises/perfect-numbers/example.rs
+++ b/exercises/perfect-numbers/example.rs
@@ -2,7 +2,7 @@ pub fn classify(num: u64) -> Option<Classification> {
     if num == 0 {
         return None;
     }
-    let sum: u64 = (1..num).filter(|i| num%i == 0).sum();
+    let sum: u64 = (1..num).filter(|i| num % i == 0).sum();
     if sum == num {
         Some(Classification::Perfect)
     } else if sum < num {
@@ -16,5 +16,5 @@ pub fn classify(num: u64) -> Option<Classification> {
 pub enum Classification {
     Abundant,
     Perfect,
-    Deficient
+    Deficient,
 }

--- a/exercises/phone-number/example.rs
+++ b/exercises/phone-number/example.rs
@@ -1,21 +1,17 @@
 pub fn number(s: &str) -> Option<String> {
     let digits: String = s.chars().filter(|&c| c.is_digit(10)).collect();
     match digits.len() {
-        10 => {
-            match (digits.chars().nth(0), digits.chars().nth(3)) {
-                (Some('0'), _) => None,
-                (Some('1'), _) => None,
-                (_, Some('0')) => None,
-                (_, Some('1')) => None,
-                _ => Some(digits),
-            }
-        }
-        11 => {
-            match digits.chars().nth(0) {
-                Some('1') => Some(digits[1..].to_string()),
-                _ => None,
-            }
-        }
+        10 => match (digits.chars().nth(0), digits.chars().nth(3)) {
+            (Some('0'), _) => None,
+            (Some('1'), _) => None,
+            (_, Some('0')) => None,
+            (_, Some('1')) => None,
+            _ => Some(digits),
+        },
+        11 => match digits.chars().nth(0) {
+            Some('1') => Some(digits[1..].to_string()),
+            _ => None,
+        },
         _ => None,
     }
 }

--- a/exercises/pig-latin/example.rs
+++ b/exercises/pig-latin/example.rs
@@ -1,4 +1,5 @@
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate lazy_static;
 extern crate regex;
 
 use regex::Regex;
@@ -24,5 +25,8 @@ pub fn translate_word(word: &str) -> String {
 }
 
 pub fn translate(text: &str) -> String {
-    text.split(" ").map(|w| translate_word(w)).collect::<Vec<_>>().join(" ")
+    text.split(" ")
+        .map(|w| translate_word(w))
+        .collect::<Vec<_>>()
+        .join(" ")
 }

--- a/exercises/poker/example.rs
+++ b/exercises/poker/example.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use std::cmp::Ordering;
+use std::fmt;
 
 #[macro_use]
 extern crate try_opt;
@@ -181,8 +181,8 @@ impl PokerHand {
     fn is_ace_low_straight(cards: &[Card]) -> bool {
         // special case: ace-low straight
         // still depends on the sorted precondition
-        cards[0].rank.value() == 2 && cards[4].rank == Rank::Ace &&
-            cards
+        cards[0].rank.value() == 2 && cards[4].rank == Rank::Ace
+            && cards
                 .windows(2)
                 .take(3) // (0, 1), (1, 2), (2, 3) --> skips 4, ace
                 .map(|pair| pair[1].rank.value() - pair[0].rank.value())
@@ -201,8 +201,8 @@ impl PokerHand {
             let is_straight = cards
                 .windows(2)
                 .map(|pair| pair[1].rank.value() - pair[0].rank.value())
-                .all(|diff| diff == 1) ||
-                PokerHand::is_ace_low_straight(cards);
+                .all(|diff| diff == 1)
+                || PokerHand::is_ace_low_straight(cards);
 
             if is_flush && is_straight {
                 return Some(PokerHand::StraightFlush);
@@ -269,9 +269,10 @@ impl<'a> Hand<'a> {
     }
 
     fn cmp_high_card(&self, other: &Hand, card: usize) -> Ordering {
-        let mut ordering = self.cards[card].rank.value().cmp(
-            &other.cards[card].rank.value(),
-        );
+        let mut ordering = self.cards[card]
+            .rank
+            .value()
+            .cmp(&other.cards[card].rank.value());
         if card != 0 {
             ordering = ordering.then_with(|| self.cmp_high_card(other, card - 1));
         }

--- a/exercises/prime-factors/example.rs
+++ b/exercises/prime-factors/example.rs
@@ -1,7 +1,7 @@
 pub fn factors(n: u64) -> Vec<u64> {
     let mut val = n;
     let mut out: Vec<u64> = vec![];
-    let mut possible:u64 = 2;
+    let mut possible: u64 = 2;
     while val > 1 {
         while val % possible == 0 {
             out.push(possible);

--- a/exercises/protein-translation/example.rs
+++ b/exercises/protein-translation/example.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
 pub struct CodonInfo<'a> {
-    actual_codons: HashMap<&'a str, &'a str>
+    actual_codons: HashMap<&'a str, &'a str>,
 }
 
 pub fn parse<'a>(pairs: Vec<(&'a str, &'a str)>) -> CodonInfo<'a> {
-    CodonInfo{
-        actual_codons: pairs.into_iter().collect()
+    CodonInfo {
+        actual_codons: pairs.into_iter().collect(),
     }
 }
 
@@ -14,12 +14,13 @@ impl<'a> CodonInfo<'a> {
     pub fn name_for(&self, codon: &str) -> Result<&'a str, &'static str> {
         match self.actual_codons.get(&codon) {
             Some(name) => Ok(name),
-            None => Err("Invalid")
+            None => Err("Invalid"),
         }
     }
 
     pub fn of_rna(&self, strand: &str) -> Result<Vec<&'a str>, &'static str> {
-        strand.chars()
+        strand
+            .chars()
             .collect::<Vec<char>>()
             .chunks(3)
             .map(|chars| self.name_for(&chars.iter().collect::<String>()))

--- a/exercises/proverb/example.rs
+++ b/exercises/proverb/example.rs
@@ -1,4 +1,3 @@
-
 pub fn build_proverb(items: Vec<&str>) -> String {
     let mut stanzas = Vec::with_capacity(items.len());
     for index in 0..items.len() {

--- a/exercises/pythagorean-triplet/example.rs
+++ b/exercises/pythagorean-triplet/example.rs
@@ -1,9 +1,9 @@
 pub fn find() -> Option<u32> {
     for a in 1..1000 {
-        for b in (a+1)..(1000-a) {
+        for b in (a + 1)..(1000 - a) {
             let c = 1000 - (a + b);
-            if a*a + b*b == c*c {
-                return Some(a*b*c);
+            if a * a + b * b == c * c {
+                return Some(a * b * c);
             }
         }
     }

--- a/exercises/queen-attack/example.rs
+++ b/exercises/queen-attack/example.rs
@@ -12,9 +12,9 @@ impl ChessPiece for Queen {
     }
 
     fn can_attack<T: ChessPiece>(&self, piece: &T) -> bool {
-        self.position.horizontal_from(&piece.position()) ||
-        self.position.vertical_from(&piece.position()) ||
-        self.position.diagonal_from(&piece.position())
+        self.position.horizontal_from(&piece.position())
+            || self.position.vertical_from(&piece.position())
+            || self.position.diagonal_from(&piece.position())
     }
 }
 

--- a/exercises/rna-transcription/example.rs
+++ b/exercises/rna-transcription/example.rs
@@ -1,5 +1,3 @@
-
-
 /// The possible nucleotides in DNA and RNA
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum Nucleotide {
@@ -7,7 +5,7 @@ pub enum Nucleotide {
     Cytosine,
     Guanine,
     Thymine,
-    Uracil
+    Uracil,
 }
 
 impl Nucleotide {
@@ -19,7 +17,9 @@ impl Nucleotide {
             'G' => Nucleotide::Guanine,
             'T' => Nucleotide::Thymine,
             'U' => Nucleotide::Uracil,
-            _ => { return None; }
+            _ => {
+                return None;
+            }
         })
     }
 }
@@ -38,8 +38,12 @@ impl DNA {
         let mut out = Vec::new();
         for (idx, ch) in input.chars().enumerate() {
             match Nucleotide::from_char(ch) {
-                Some(Nucleotide::Uracil) | None => { return Err(idx); },
-                Some(n) => { out.push(n);  },
+                Some(Nucleotide::Uracil) | None => {
+                    return Err(idx);
+                }
+                Some(n) => {
+                    out.push(n);
+                }
             }
         }
         Ok(DNA(out))
@@ -52,7 +56,7 @@ impl DNA {
                 Nucleotide::Cytosine => Nucleotide::Guanine,
                 Nucleotide::Guanine => Nucleotide::Cytosine,
                 Nucleotide::Thymine => Nucleotide::Adenine,
-                Nucleotide::Uracil => unreachable!()
+                Nucleotide::Uracil => unreachable!(),
             }
         }
         RNA(self.0)
@@ -70,8 +74,12 @@ impl RNA {
         let mut out = Vec::new();
         for (idx, ch) in input.chars().enumerate() {
             match Nucleotide::from_char(ch) {
-                Some(Nucleotide::Thymine) | None => { return Err(idx); },
-                Some(n) => { out.push(n);  },
+                Some(Nucleotide::Thymine) | None => {
+                    return Err(idx);
+                }
+                Some(n) => {
+                    out.push(n);
+                }
             }
         }
         Ok(RNA(out))

--- a/exercises/robot-name/example.rs
+++ b/exercises/robot-name/example.rs
@@ -2,7 +2,7 @@ extern crate rand;
 use rand::{thread_rng, Rng};
 
 pub struct Robot {
-    name: String
+    name: String,
 }
 
 fn generate_name() -> String {
@@ -20,7 +20,9 @@ fn generate_name() -> String {
 
 impl Robot {
     pub fn new() -> Robot {
-        Robot { name: generate_name() }
+        Robot {
+            name: generate_name(),
+        }
     }
 
     pub fn name<'a>(&'a self) -> &'a str {
@@ -30,5 +32,4 @@ impl Robot {
     pub fn reset_name(&mut self) {
         self.name = generate_name();
     }
-
 }

--- a/exercises/robot-simulator/example.rs
+++ b/exercises/robot-simulator/example.rs
@@ -78,8 +78,11 @@ impl Robot {
     }
 
     pub fn instructions(&self, instructions: &str) -> Self {
-        instructions.chars().fold(self.clone(),
-                                  |robot, instruction| robot.execute(instruction))
+        instructions
+            .chars()
+            .fold(self.clone(), |robot, instruction| {
+                robot.execute(instruction)
+            })
     }
 
     pub fn position(&self) -> (i32, i32) {

--- a/exercises/roman-numerals/example.rs
+++ b/exercises/roman-numerals/example.rs
@@ -1,18 +1,20 @@
 use std::fmt;
 
-static ROMAN_MAP: [(usize, &'static str); 13] = [(1, "I"),
-                                                 (4, "IV"),
-                                                 (5, "V"),
-                                                 (9, "IX"),
-                                                 (10, "X"),
-                                                 (40, "XL"),
-                                                 (50, "L"),
-                                                 (90, "XC"),
-                                                 (100, "C"),
-                                                 (400, "CD"),
-                                                 (500, "D"),
-                                                 (900, "CM"),
-                                                 (1000, "M")];
+static ROMAN_MAP: [(usize, &'static str); 13] = [
+    (1, "I"),
+    (4, "IV"),
+    (5, "V"),
+    (9, "IX"),
+    (10, "X"),
+    (40, "XL"),
+    (50, "L"),
+    (90, "XC"),
+    (100, "C"),
+    (400, "CD"),
+    (500, "D"),
+    (900, "CM"),
+    (1000, "M"),
+];
 
 pub struct Roman {
     num: usize,
@@ -37,7 +39,6 @@ impl fmt::Display for Roman {
         write!(f, "{}", result)
     }
 }
-
 
 impl Roman {
     fn new(num: usize) -> Roman {

--- a/exercises/rotational-cipher/example.rs
+++ b/exercises/rotational-cipher/example.rs
@@ -1,16 +1,12 @@
 pub fn rotate(text: &str, shift_key: u8) -> String {
-
-    text.chars().map(|c| {
-        let case = if c.is_uppercase() {
-            'A'
-        } else {
-            'a'
-        } as u8;
-        if c.is_alphabetic() {
-            (((c as u8 - case + shift_key) % 26) + case) as char
-        } else {
-            c
-        }
-    }).collect::<String>()
-
+    text.chars()
+        .map(|c| {
+            let case = if c.is_uppercase() { 'A' } else { 'a' } as u8;
+            if c.is_alphabetic() {
+                (((c as u8 - case + shift_key) % 26) + case) as char
+            } else {
+                c
+            }
+        })
+        .collect::<String>()
 }

--- a/exercises/run-length-encoding/example.rs
+++ b/exercises/run-length-encoding/example.rs
@@ -3,30 +3,36 @@ use std::cmp;
 pub fn encode(input: &str) -> String {
     input
         .chars()
-        .fold((String::new(), ' ', 0, 1), |(mut acc, last, last_n, pos), c| {
-            // acc = where answer is accumulated
-            // last = last character read
-            // last_n = accum count for last
-            if c == last {
-                if pos == input.len() { // end of string
-                    acc += (last_n + 1).to_string().as_str();
-                    acc.push(c);
+        .fold(
+            (String::new(), ' ', 0, 1),
+            |(mut acc, last, last_n, pos), c| {
+                // acc = where answer is accumulated
+                // last = last character read
+                // last_n = accum count for last
+                if c == last {
+                    if pos == input.len() {
+                        // end of string
+                        acc += (last_n + 1).to_string().as_str();
+                        acc.push(c);
+                    }
+                    (acc, last, last_n + 1, pos + 1)
+                } else {
+                    if last_n > 1 {
+                        acc += last_n.to_string().as_str();
+                    }
+                    if last_n > 0 {
+                        // ignore initial last (single whitespace)
+                        acc.push(last);
+                    }
+                    if pos == input.len() {
+                        // end of string
+                        acc.push(c);
+                    }
+                    (acc, c, 1, pos + 1)
                 }
-                (acc, last, last_n + 1, pos + 1)
-            }
-            else {
-                if last_n > 1 {
-                    acc += last_n.to_string().as_str();
-                }
-                if last_n > 0 { // ignore initial last (single whitespace)
-                    acc.push(last);
-                }
-                if pos == input.len() { // end of string
-                    acc.push(c);
-                }
-                (acc, c, 1, pos + 1)
-            }
-        }).0
+            },
+        )
+        .0
 }
 
 pub fn decode(input: &str) -> String {
@@ -34,12 +40,11 @@ pub fn decode(input: &str) -> String {
         .chars()
         .fold((String::new(), 0), |(mut acc, last_n), c| {
             if let Some(d) = c.to_digit(10) {
-                (acc, 10*last_n + d)
-            }
-            else {
-                acc += c.to_string()
-                    .repeat(cmp::max(last_n, 1) as usize).as_str();
+                (acc, 10 * last_n + d)
+            } else {
+                acc += c.to_string().repeat(cmp::max(last_n, 1) as usize).as_str();
                 (acc, 0)
             }
-        }).0
+        })
+        .0
 }

--- a/exercises/saddle-points/example.rs
+++ b/exercises/saddle-points/example.rs
@@ -6,7 +6,6 @@ pub fn find_saddle_points(input: &[Vec<u64>]) -> Vec<(usize, usize)> {
 
     for i in 0..width {
         for j in 0..height {
-
             let column = input.iter().map(|x| x[j]).collect::<Vec<u64>>();
             let row = &input[i];
 

--- a/exercises/say/example.rs
+++ b/exercises/say/example.rs
@@ -1,13 +1,39 @@
-const SMALL: &'static [&'static str] = &["zero", "one", "two", "three", "four", "five",
-                                         "six", "seven", "eight", "nine", "ten",
-                                         "eleven", "twelve", "thirteen", "fourteen", "fifteen",
-                                         "sixteen", "seventeen", "eighteen", "nineteen"];
+const SMALL: &'static [&'static str] = &[
+    "zero",
+    "one",
+    "two",
+    "three",
+    "four",
+    "five",
+    "six",
+    "seven",
+    "eight",
+    "nine",
+    "ten",
+    "eleven",
+    "twelve",
+    "thirteen",
+    "fourteen",
+    "fifteen",
+    "sixteen",
+    "seventeen",
+    "eighteen",
+    "nineteen",
+];
 
-const TENS: &'static [&'static str] = &["ones", "ten", "twenty", "thirty", "forty",
-                                        "fifty", "sixty", "seventy", "eighty", "ninety"];
+const TENS: &'static [&'static str] = &[
+    "ones", "ten", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety",
+];
 
-const SCALE: &'static [&'static str] = &["", "thousand", "million", "billion",
-                                         "trillion", "quadrillion", "quintillion"];
+const SCALE: &'static [&'static str] = &[
+    "",
+    "thousand",
+    "million",
+    "billion",
+    "trillion",
+    "quadrillion",
+    "quintillion",
+];
 
 pub fn encode(n: u64) -> String {
     if n < 20 {

--- a/exercises/series/example.rs
+++ b/exercises/series/example.rs
@@ -1,13 +1,11 @@
 pub fn series(digits: &str, len: usize) -> Vec<String> {
     match len {
         0 => vec!["".to_string(); digits.len() + 1],
-        _ => {
-            digits
-                .chars()
-                .collect::<Vec<char>>()
-                .windows(len)
-                .map(|window| window.into_iter().collect::<String>())
-                .collect::<Vec<String>>()
-        }
+        _ => digits
+            .chars()
+            .collect::<Vec<char>>()
+            .windows(len)
+            .map(|window| window.into_iter().collect::<String>())
+            .collect::<Vec<String>>(),
     }
 }

--- a/exercises/simple-linked-list/example.rs
+++ b/exercises/simple-linked-list/example.rs
@@ -8,7 +8,6 @@ struct Node<T> {
     next: Option<Box<Node<T>>>,
 }
 
-
 impl<T> SimpleLinkedList<T> {
     pub fn new() -> Self {
         SimpleLinkedList { head: None, len: 0 }
@@ -54,7 +53,6 @@ impl<T: Clone> SimpleLinkedList<T> {
         rev_list
     }
 }
-
 
 impl<'a, T: Clone> From<&'a [T]> for SimpleLinkedList<T> {
     fn from(item: &[T]) -> Self {

--- a/exercises/spiral-matrix/example.rs
+++ b/exercises/spiral-matrix/example.rs
@@ -4,7 +4,6 @@ pub fn spiral_matrix(size: usize) -> Vec<Vec<usize>> {
     let mut counter: usize = 1;
     let mut sidelen = size;
     for i in 0..num_concentric_squares {
-
         for j in 0..sidelen {
             matrix[i][i + j] = counter;
             counter += 1;

--- a/exercises/tournament/example.rs
+++ b/exercises/tournament/example.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 enum GameResult {
     Win,
     Draw,
-    Loss
+    Loss,
 }
 
 struct TeamResult {
@@ -15,7 +15,11 @@ struct TeamResult {
 
 impl TeamResult {
     fn new() -> TeamResult {
-        TeamResult { wins: 0, draws: 0, losses: 0 }
+        TeamResult {
+            wins: 0,
+            draws: 0,
+            losses: 0,
+        }
     }
     fn add_game_result(&mut self, result: GameResult) {
         match result {
@@ -30,7 +34,9 @@ pub fn tally(input: &str) -> String {
     let mut results: HashMap<String, TeamResult> = HashMap::new();
     for line in input.to_string().lines() {
         let parts: Vec<&str> = line.trim_right().split(';').collect();
-        if parts.len() != 3 { continue; }
+        if parts.len() != 3 {
+            continue;
+        }
         let team1 = parts[0];
         let team2 = parts[1];
         let outcome = parts[2];
@@ -38,41 +44,48 @@ pub fn tally(input: &str) -> String {
             "win" => {
                 add_game_result(&mut results, team1.to_string(), GameResult::Win);
                 add_game_result(&mut results, team2.to_string(), GameResult::Loss);
-            },
+            }
             "draw" => {
                 add_game_result(&mut results, team1.to_string(), GameResult::Draw);
                 add_game_result(&mut results, team2.to_string(), GameResult::Draw);
-            },
+            }
             "loss" => {
                 add_game_result(&mut results, team1.to_string(), GameResult::Loss);
                 add_game_result(&mut results, team2.to_string(), GameResult::Win);
-            },
-            _ => () // Ignore bad lines
+            }
+            _ => (), // Ignore bad lines
         }
     }
     write_tally(&results)
 }
 
 fn write_tally(results: &HashMap<String, TeamResult>) -> String {
-    let mut v: Vec<_> = results.iter().map(|(team, r)| {
-        let games = r.wins + r.draws + r.losses;
-        let points = r.wins * 3 + r.draws;
-        (team, games, r, points)
-    }).collect();
+    let mut v: Vec<_> = results
+        .iter()
+        .map(|(team, r)| {
+            let games = r.wins + r.draws + r.losses;
+            let points = r.wins * 3 + r.draws;
+            (team, games, r, points)
+        })
+        .collect();
     // Sort by points descending, then name A-Z.
-    v.sort_by(|a, b|
-              match a.3.cmp(&(b.3)).reverse() {
-                  Equal => a.0.cmp(&(b.0)),
-                  other => other
-              });
+    v.sort_by(|a, b| match a.3.cmp(&(b.3)).reverse() {
+        Equal => a.0.cmp(&(b.0)),
+        other => other,
+    });
     let mut lines = vec![format!("{:30} | MP |  W |  D |  L |  P", "Team")];
     lines.extend(v.iter().map(|&(ref team, games, r, points)| {
-        format!("{:30} | {:2} | {:2} | {:2} | {:2} | {:2}",
-                team, games, r.wins, r.draws, r.losses, points)
+        format!(
+            "{:30} | {:2} | {:2} | {:2} | {:2} | {:2}",
+            team, games, r.wins, r.draws, r.losses, points
+        )
     }));
     lines.join("\n")
 }
 
 fn add_game_result(results: &mut HashMap<String, TeamResult>, team: String, result: GameResult) {
-    results.entry(team).or_insert(TeamResult::new()).add_game_result(result);
+    results
+        .entry(team)
+        .or_insert(TeamResult::new())
+        .add_game_result(result);
 }

--- a/exercises/triangle/example.rs
+++ b/exercises/triangle/example.rs
@@ -1,5 +1,5 @@
-use std::iter::FromIterator;
 use std::collections::BTreeSet;
+use std::iter::FromIterator;
 
 pub struct Triangle {
     sides: [u16; 3],

--- a/exercises/two-bucket/example.rs
+++ b/exercises/two-bucket/example.rs
@@ -15,7 +15,7 @@ use std::collections::{HashSet, VecDeque};
 #[derive(PartialEq, Eq, Debug)]
 pub enum Bucket {
     One,
-    Two
+    Two,
 }
 
 /// A struct to hold your results in.
@@ -31,11 +31,7 @@ pub struct BucketStats {
 }
 
 /// Solve the bucket problem
-pub fn solve(capacity_1: u8,
-             capacity_2: u8,
-             goal: u8,
-             start_bucket: &Bucket) -> BucketStats
-{
+pub fn solve(capacity_1: u8, capacity_2: u8, goal: u8, start_bucket: &Bucket) -> BucketStats {
     let state = match *start_bucket {
         Bucket::One => (capacity_1, 0),
         Bucket::Two => (0, capacity_2),

--- a/exercises/two-fer/example.rs
+++ b/exercises/two-fer/example.rs
@@ -1,6 +1,6 @@
-pub fn twofer(name: &str)-> String {
+pub fn twofer(name: &str) -> String {
     match name {
         "" => "One for you, one for me.".to_string(),
-        _ => format!("One for {}, one for me.",name),
+        _ => format!("One for {}, one for me.", name),
     }
 }

--- a/exercises/variable-length-quantity/example.rs
+++ b/exercises/variable-length-quantity/example.rs
@@ -77,7 +77,7 @@ fn to_bytes_single(mut value: u32) -> Vec<u8> {
 pub fn from_bytes(bytes: &[u8]) -> Result<Vec<u32>, Error> {
     let mut res = vec![];
     let mut tmp = 0;
-    for (i,b) in bytes.iter().enumerate() {
+    for (i, b) in bytes.iter().enumerate() {
         // test if first 7 bit are set, to check for overflow
         if (tmp & 0xfe_00_00_00) > 0 {
             return Err(Error::Overflow);
@@ -92,14 +92,13 @@ pub fn from_bytes(bytes: &[u8]) -> Result<Vec<u32>, Error> {
             tmp = 0;
         } else {
             // check for incomplete bytes
-            if i+1 == bytes.len() {
+            if i + 1 == bytes.len() {
                 // the next index would be past the end,
                 // i.e. there are no more bytes.
                 return Err(Error::IncompleteNumber);
             }
         }
     }
-
 
     Ok(res)
 }

--- a/exercises/word-count/example.rs
+++ b/exercises/word-count/example.rs
@@ -4,7 +4,10 @@ pub fn word_count(input: &str) -> HashMap<String, u32> {
     let mut map: HashMap<String, u32> = HashMap::new();
     let lower = input.to_lowercase();
     let slice: &str = lower.as_ref();
-    for word in slice.split(|c: char| !c.is_alphanumeric()).filter(|s| !s.is_empty()) {
+    for word in slice
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|s| !s.is_empty())
+    {
         *map.entry(word.to_string()).or_insert(0) += 1;
     }
     map

--- a/exercises/wordy/example.rs
+++ b/exercises/wordy/example.rs
@@ -18,14 +18,18 @@ impl Token {
     }
 
     fn is_operator(&self) -> bool {
-        self.value == String::from("plus") || self.value == String::from("minus") ||
-        self.value == String::from("multiplied") || self.value == String::from("divided")
+        self.value == String::from("plus")
+            || self.value == String::from("minus")
+            || self.value == String::from("multiplied")
+            || self.value == String::from("divided")
     }
 }
 
 impl WordProblem {
     pub fn new(c: &str) -> Self {
-        WordProblem { command: String::from(c) }
+        WordProblem {
+            command: String::from(c),
+        }
     }
 
     pub fn answer(&self) -> Result<isize, ()> {
@@ -74,7 +78,9 @@ impl WordProblem {
     fn tokens(&self) -> Vec<Token> {
         self.command
             .split(|c: char| c.is_whitespace() || c == '?')
-            .map(|w| Token { value: String::from(w) })
+            .map(|w| Token {
+                value: String::from(w),
+            })
             .filter(|t| t.is_valid())
             .collect()
     }


### PR DESCRIPTION
Also updated `bin/format_exercises` script to format examples.

Side-note: `format_exercises` fails on the old directory left from `twofer` exercise, that contains only `Cargo.lock` and `target`. Should this directory be removed?