### PR TITLE
isbn-verifier: Added tests for long string and special characters

### DIFF
--- a/exercises/isbn-verifier/tests/isbn-verifier.rs
+++ b/exercises/isbn-verifier/tests/isbn-verifier.rs
@@ -77,6 +77,18 @@ fn test_invalid_isbn_too_long() {
 
 #[test]
 #[ignore]
+fn test_valid_digits_invalid_length() {
+    assert!(!is_valid_isbn("35982150881"));
+}
+
+#[test]
+#[ignore]
+fn test_special_characters() {
+    assert!(!is_valid_isbn("!@#%!@"));
+}
+
+#[test]
+#[ignore]
 #[allow(non_snake_case)]
 fn test_invalid_isbn_with_check_digit_X_instead_of_0() {
     assert!(!is_valid_isbn("3-598-21515-X"));


### PR DESCRIPTION
Added two tests: one with special characters and one with long digit string. 

The motivation behind these tests is that it is possible to write a solution, that simply filters input string and counts the sum without checking the input string length, and still pass all the tests(for example `test_invalid_isbn_too_long` test, that contains valid isbn and only one extra `X` that could be filtered)  