### PR TITLE
accumulate: Added template to stub file

### DIFF
--- a/exercises/accumulate/.meta/ALLOWED_TO_NOT_COMPILE
+++ b/exercises/accumulate/.meta/ALLOWED_TO_NOT_COMPILE
@@ -1,0 +1,2 @@
+Stub doesn't compile because there is no type specified for _function and _closure arguments. 
+This exercise teaches students about the use of function pointers and closures, therefore specifying the type of arguments for them would reduce learning.

--- a/exercises/accumulate/src/lib.rs
+++ b/exercises/accumulate/src/lib.rs
@@ -1,1 +1,7 @@
+pub fn map_function(input: Vec<i32>, _function: impl Fn(i32) -> i32) -> Vec<i32> {
+    unimplemented!("Transform input vector {:?} using passed function", input);
+}
 
+pub fn map_closure(input: Vec<i32>, _closure: impl Fn(i32) -> i32) -> Vec<i32> {
+    unimplemented!("Transform input vector {:?} using passed closure", input);
+}

--- a/exercises/accumulate/src/lib.rs
+++ b/exercises/accumulate/src/lib.rs
@@ -1,7 +1,9 @@
-pub fn map_function(input: Vec<i32>, _function: impl Fn(i32) -> i32) -> Vec<i32> {
+/// What should the type of _function be?
+pub fn map_function(input: Vec<i32>, _function: ???) -> Vec<i32> {
     unimplemented!("Transform input vector {:?} using passed function", input);
 }
 
-pub fn map_closure(input: Vec<i32>, _closure: impl Fn(i32) -> i32) -> Vec<i32> {
+/// What should the type of _closure be?
+pub fn map_closure(input: Vec<i32>, _closure: ???) -> Vec<i32> {
     unimplemented!("Transform input vector {:?} using passed closure", input);
 }


### PR DESCRIPTION
Contributes to #551 

I really doubt that the template is needed here, since the point of the exercise is to teach students about closures and how to pass them as function arguments and fully implementing the functions reduces learning.

If this is the case, then perhaps something like this would suffice:

```rust
/*
/// What should _function type be?
pub fn map_function(input: Vec<i32>, _function: ???) -> Vec<i32> {
    unimplemented!("Transform input vector {:?} using passed function", input);
}

/// What should _closure type be? 
pub fn map_closure(input: Vec<i32>, _closure: ???) -> Vec<i32> {
    unimplemented!("Transform input vector {:?} using passed closure", input);
}
*/
```
Or without multi-line comments and `ALLOWED_TO_NOT_COMPILE`?