### PR TITLE
Fix ignore counts

### DIFF
--- a/exercises/binary-search/.meta/hints.md
+++ b/exercises/binary-search/.meta/hints.md
@@ -25,7 +25,12 @@ are some additional things you could try.
 - Additionally this find function can work not only on slices, but at the
   same time also on a Vec or an Array.
 
-You can find tests (commented out) for these bonus tasks in the test file.
+To run the bonus tests, remove the `#[ignore]` flag and execute the tests with
+the `generic` feature, like this:
+
+```bash
+$ cargo test --features generic
+```
 
 Then please share your thoughts in a comment on the submission. Did this
 experiment make the code better? Worse? Did you learn anything from it?

--- a/exercises/binary-search/Cargo.toml
+++ b/exercises/binary-search/Cargo.toml
@@ -3,3 +3,6 @@ name = "binary-search"
 version = "1.1.0"
 
 [dependencies]
+
+[features]
+generic = []

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -61,7 +61,12 @@ are some additional things you could try.
 - Additionally this find function can work not only on slices, but at the
   same time also on a Vec or an Array.
 
-You can find tests (commented out) for these bonus tasks in the test file.
+To run the bonus tests, remove the `#[ignore]` flag and execute the tests with
+the `generic` feature, like this:
+
+```bash
+$ cargo test --features generic
+```
 
 Then please share your thoughts in a comment on the submission. Did this
 experiment make the code better? Worse? Did you learn anything from it?

--- a/exercises/binary-search/tests/binary-search.rs
+++ b/exercises/binary-search/tests/binary-search.rs
@@ -79,22 +79,26 @@ fn nothing_is_included_in_an_empty_array() {
     assert_eq!(find(&[], 1), None);
 }
 
-/* --------------------------------------- Optional Bonus Tests -------------------------------*/
+#[test]
+#[ignore]
+#[cfg(feature = "generic")]
+fn works_for_arrays() {
+    assert_eq!(find([6], 6), Some(0));
+}
 
-//#[test]
-//fn works_for_arrays() {
-//    assert_eq!(find([6], 6), Some(0));
-//}
-//
-//#[test]
-//fn works_for_vec() {
-//    let vector = vec![6];
-//    assert_eq!(find(&vector, 6), Some(0));
-//    assert_eq!(find(vector, 6), Some(0));
-//}
-//
-//#[test]
-//fn works_for_str_elements() {
-//    assert_eq!(find(["a"], "a"), Some(0));
-//    assert_eq!(find(["a", "b"], "b"), Some(1));
-//}
+#[test]
+#[ignore]
+#[cfg(feature = "generic")]
+fn works_for_vec() {
+    let vector = vec![6];
+    assert_eq!(find(&vector, 6), Some(0));
+    assert_eq!(find(vector, 6), Some(0));
+}
+
+#[test]
+#[ignore]
+#[cfg(feature = "generic")]
+fn works_for_str_elements() {
+    assert_eq!(find(["a"], "a"), Some(0));
+    assert_eq!(find(["a", "b"], "b"), Some(1));
+}

--- a/exercises/triangle/.meta/hints.md
+++ b/exercises/triangle/.meta/hints.md
@@ -9,3 +9,18 @@ Implementation of this can take many forms. Here are some topics that may help y
 - [BTreeSet](https://doc.rust-lang.org/std/collections/btree_set/struct.BTreeSet.html)
 
 Or maybe you will come up with an approach that uses none of those!
+
+## Non-integer lengths
+
+The base exercise tests identification of triangles whose sides are all
+integers. However, some triangles cannot be represented by pure integers. A simple example is a right triangle (an isocoles triangle whose equal sides are separated by 90 degrees) whose equal sides both have length of 1. Its hypotenuse is the square root of 2, which is an irrational number: no simple multiplication can represent this number as an integer.
+
+It would be tedious to rewrite the analysis functions to handle both integer and floating-point cases, and particularly tedious to do so for all potential integer and floating point types: given signed and unsigned variants of bitwidths 8, 16, 32, 64, and 128, that would be 10 reimplementations of fundamentally the same code even before considering floats!
+
+There's a better way: [generics](https://doc.rust-lang.org/stable/book/second-edition/ch10-00-generics.html). By rewriting your Triangle as a `Triangle<T>`, you can write your code once, and hand off the work of generating all those specializations to the compiler. Note that in order to use mathematical operations, you'll need to constrain your generic type to types which support those operations using traits.
+
+There are some bonus tests you can run which test your implementation on floating-point numbers. To enable them, run your tests with the `generic` feature flag, like this:
+
+```bash
+cargo test --features generic
+```

--- a/exercises/triangle/Cargo.toml
+++ b/exercises/triangle/Cargo.toml
@@ -1,3 +1,6 @@
 [package]
 name = "triangle"
 version = "0.0.0"
+
+[features]
+generic = []

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -34,6 +34,21 @@ Implementation of this can take many forms. Here are some topics that may help y
 
 Or maybe you will come up with an approach that uses none of those!
 
+## Non-integer lengths
+
+The base exercise tests identification of triangles whose sides are all
+integers. However, some triangles cannot be represented by pure integers. A simple example is a right triangle (an isocoles triangle whose equal sides are separated by 90 degrees) whose equal sides both have length of 1. Its hypotenuse is the square root of 2, which is an irrational number: no simple multiplication can represent this number as an integer.
+
+It would be tedious to rewrite the analysis functions to handle both integer and floating-point cases, and particularly tedious to do so for all potential integer and floating point types: given signed and unsigned variants of bitwidths 8, 16, 32, 64, and 128, that would be 10 reimplementations of fundamentally the same code even before considering floats!
+
+There's a better way: [generics](https://doc.rust-lang.org/stable/book/second-edition/ch10-00-generics.html). By rewriting your Triangle as a `Triangle<T>`, you can write your code once, and hand off the work of generating all those specializations to the compiler. Note that in order to use mathematical operations, you'll need to constrain your generic type to types which support those operations using traits.
+
+There are some bonus tests you can run which test your implementation on floating-point numbers. To enable them, run your tests with the `generic` feature flag, like this:
+
+```bash
+cargo test --features generic
+```
+
 
 ## Rust Installation
 

--- a/exercises/triangle/example.rs
+++ b/exercises/triangle/example.rs
@@ -1,20 +1,28 @@
-use std::collections::BTreeSet;
-use std::iter::FromIterator;
+use std::ops::Add;
 
-pub struct Triangle {
-    sides: [u16; 3],
+pub struct Triangle<T> {
+    sides: [T; 3],
 }
 
-impl Triangle {
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+impl<T> Triangle<T>
+where
+    T: Copy + PartialEq + PartialOrd + Add<Output = T> + Default,
+{
     fn valid_sides(&self) -> bool {
-        (self.sides.iter().all(|&s| s > 0)) &&
-            (self.sides[0] + self.sides[1] >= self.sides[2]) &&
-            (self.sides[1] + self.sides[2] >= self.sides[0]) &&
-            (self.sides[2] + self.sides[0] >= self.sides[1])
+        (self.sides.iter().all(|&s| s > T::default()))
+            && (self.sides[0] + self.sides[1] >= self.sides[2])
+            && (self.sides[1] + self.sides[2] >= self.sides[0])
+            && (self.sides[2] + self.sides[0] >= self.sides[1])
     }
 
-    pub fn build(sides: [u16; 3]) -> Option<Triangle> {
+    fn count_distinct_pairs(&self) -> usize {
+        [(0, 1), (0, 2), (1, 2)]
+            .iter()
+            .map(|&(a, b)| if self.sides[a] != self.sides[b] { 1 } else { 0 })
+            .sum()
+    }
+
+    pub fn build(sides: [T; 3]) -> Option<Triangle<T>> {
         let t = Triangle { sides: sides };
 
         if t.valid_sides() {
@@ -25,14 +33,14 @@ impl Triangle {
     }
 
     pub fn is_equilateral(&self) -> bool {
-        BTreeSet::from_iter(self.sides.iter()).len() == 1
+        self.count_distinct_pairs() == 0
     }
 
     pub fn is_isosceles(&self) -> bool {
-        BTreeSet::from_iter(self.sides.iter()).len() == 2
+        self.count_distinct_pairs() == 2
     }
 
     pub fn is_scalene(&self) -> bool {
-        BTreeSet::from_iter(self.sides.iter()).len() == 3
+        self.count_distinct_pairs() == 3
     }
 }

--- a/exercises/triangle/tests/triangle.rs
+++ b/exercises/triangle/tests/triangle.rs
@@ -131,37 +131,34 @@ fn sum_of_two_sides_must_equal_or_exceed_the_remaining_side_two() {
     assert!(triangle.is_none());
 }
 
-// Optional Tests
-//
-// Support Triangles with non-integer sides.
-//
-// You'll probably want to use the Num crate
-//
-// https://crates.io/crates/num
-//
+#[test]
+#[ignore]
+#[cfg(feature = "generic")]
+fn scalene_triangle_with_floating_point_sides() {
+    let sides = [0.4, 0.6, 0.3];
+    let triangle = Triangle::build(sides).unwrap();
+    assert!(!triangle.is_equilateral());
+    assert!(!triangle.is_isosceles());
+    assert!(triangle.is_scalene());
+}
 
-// #[test]
-// fn scalene_triangle_with_floating_point_sides() {
-//     let sides = [0.4, 0.6, 0.3];
-//     let triangle = Triangle::build(sides).unwrap();
-//     assert!(!triangle.is_equilateral());
-//     assert!(!triangle.is_isosceles());
-//     assert!(triangle.is_scalene());
-// }
-//
-// #[test]
-// fn equilateral_triangles_with_floating_point_sides() {
-//     let sides = [0.2, 0.2, 0.2];
-//     let triangle = Triangle::build(sides).unwrap();
-//     assert!(triangle.is_equilateral());
-//     assert!(!triangle.is_scalene());
-// }
-//
-// #[test]
-// fn isosceles_triangle_with_floating_point_sides() {
-//     let sides = [0.3, 0.4, 0.4];
-//     let triangle = Triangle::build(sides).unwrap();
-//     assert!(!triangle.is_equilateral());
-//     assert!(triangle.is_isosceles());
-//     assert!(!triangle.is_scalene());
-// }
+#[test]
+#[ignore]
+#[cfg(feature = "generic")]
+fn equilateral_triangles_with_floating_point_sides() {
+    let sides = [0.2, 0.2, 0.2];
+    let triangle = Triangle::build(sides).unwrap();
+    assert!(triangle.is_equilateral());
+    assert!(!triangle.is_scalene());
+}
+
+#[test]
+#[ignore]
+#[cfg(feature = "generic")]
+fn isosceles_triangle_with_floating_point_sides() {
+    let sides = [0.3, 0.4, 0.4];
+    let triangle = Triangle::build(sides).unwrap();
+    assert!(!triangle.is_equilateral());
+    assert!(triangle.is_isosceles());
+    assert!(!triangle.is_scalene());
+}


### PR DESCRIPTION
Currently, Travis always fails. This is my fault: I edited the [`_test/count-ignores.sh`](https://github.com/exercism/rust/blob/master/_test/count-ignores.sh) script to identify `#[ignore]` and `#[test]` attributes which appear anywhere on a line, not just at its beginning. This identified two exercises which had commented-out tests, which were not ignored: binary-search and triangle.

It would have been possible to revert to the old behavior, but that was also demonstrably wrong, incorrectly failing #577. Instead, I've added `#[ignore]` flags to the appropriate tests, uncommented them, and put them behind a feature gate, as we've done before for the reverse-string exercise. 

Travis does not currently check that feature-gated tests pass, but in case we add that capability in the future, I've ensured that the example solutions do correctly solve the feature-gated tests.

Requesting relatively high-priority review, as I am reluctant to merge any other PR until Travis passes.