### PR TITLE
grep: Fixed typo in the README

### DIFF
--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -95,7 +95,7 @@ $ cargo test
 ```
 
 All but the first test have been ignored. After you get the first test to
-pass, open the tests source file wich is located in the `tests` directory
+pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
 Continue, until you pass every test. 
@@ -112,7 +112,7 @@ To run a specific test, for example `some_test`, you can use:
 $ cargo test some_test
 ```
 
-If the specfic test is ignored use:
+If the specific test is ignored use:
 
 ```bash
 $ cargo test some_test -- --ignored


### PR DESCRIPTION
Basically applies #578 for the `grep` exercise.

It seems like `bob` was also updated from the latest `problem-specification`.

It is a minor change, so maybe it is OK to leave it in this PR?