### PR TITLE
parallel-letter-frequency: Added template to the stub file

### DIFF
--- a/exercises/parallel-letter-frequency/src/lib.rs
+++ b/exercises/parallel-letter-frequency/src/lib.rs
@@ -1,1 +1,12 @@
+use std::collections::HashMap;
 
+pub fn frequency(input: &[&str], worker_count: i32) -> HashMap<char, u32> {
+    unimplemented!(
+        "Count the frequency of letters in the given input '{:?}'. Ensure that you are using {} to process the input.",
+        input,
+        match worker_count {
+            1 => format!("1 worker"),
+            _ => format!("{} workers", worker_count),
+        }
+    );
+}

--- a/exercises/parallel-letter-frequency/src/lib.rs
+++ b/exercises/parallel-letter-frequency/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-pub fn frequency(input: &[&str], worker_count: i32) -> HashMap<char, u32> {
+pub fn frequency(input: &[&str], worker_count: usize) -> HashMap<char, usize> {
     unimplemented!(
         "Count the frequency of letters in the given input '{:?}'. Ensure that you are using {} to process the input.",
         input,


### PR DESCRIPTION
Contributes to #551 

Was not sure about `worker_count` type:  on one hand it is a variable that hold the count of something, so
`i32` is natural here, on the other hand this variable would be used to chunk the input data in separate parts, therefore a lot of casts like `as usize`.