### PR TITLE
ensure-lib-src-rs-exist: Updated the script to check if the stub file is empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: rust
 script:
 - "./_test/check-exercises.sh"
-- "sh ./_test/ensure-lib-src-rs-exist.sh"
+- "bash ./_test/ensure-lib-src-rs-exist.sh"
 - "sh ./_test/ensure-stubs-compile.sh"
 - "sh ./_test/count-ignores.sh"
 - "./bin/fetch-configlet"

--- a/_test/ensure-lib-src-rs-exist.sh
+++ b/_test/ensure-lib-src-rs-exist.sh
@@ -15,18 +15,19 @@ IGNORED_EXERCISES=(
 )
 
 for dir in $repo/exercises/*/; do
-  exercise=$(basename "$dir")
-  if [ ! -f "$dir/src/lib.rs" ]; then
-	# https://github.com/exercism/rust/pull/270
-	echo "$exercise is missing a src/lib.rs; please create one (an empty file is acceptable)"
-	missing="$missing\n$exercise"
+	exercise=$(basename "$dir")
+
+	if [ ! -f "$dir/src/lib.rs" ]; then
+		# https://github.com/exercism/rust/pull/270
+		echo "$exercise is missing a src/lib.rs; please create one (an empty file is acceptable)"
+		missing="$missing\n$exercise"
 	else
 		#Check if the stub file is empty
 		if [ ! -s "$dir/src/lib.rs" ] || [ "$(cat "$dir/src/lib.rs")" == "" ] && [[ " ${IGNORED_EXERCISES[*]} " != *"$exercise"* ]]; then
 			echo "$exercise has src/lib.rs stub file, but it is empty."
 			empty_stub="$empty_stub\n$exercise"
 		fi
-  fi
+	fi
 done
 
 if [ -n "$missing" ]; then

--- a/_test/ensure-lib-src-rs-exist.sh
+++ b/_test/ensure-lib-src-rs-exist.sh
@@ -4,16 +4,45 @@ repo=$(cd "$(dirname "$0")/.." && pwd)
 
 missing=""
 
+empty_stub=""
+
+check_status=0
+
+IGNORED_EXERCISES=(
+	"two-fer" #deprecated
+	"nucleotide-codons" #deprecated
+	"hexadecimal" #deprecated
+)
+
 for dir in $repo/exercises/*/; do
   exercise=$(basename "$dir")
-  if [ ! -f $dir/src/lib.rs ]; then
-    # https://github.com/exercism/rust/pull/270
-    echo "$exercise is missing a src/lib.rs; please create one (an empty file is acceptable)"
-    missing="$missing\n$exercise"
+  if [ ! -f "$dir/src/lib.rs" ]; then
+	# https://github.com/exercism/rust/pull/270
+	echo "$exercise is missing a src/lib.rs; please create one (an empty file is acceptable)"
+	missing="$missing\n$exercise"
+	else
+		#Check if the stub file is empty
+		if [ ! -s "$dir/src/lib.rs" ] || [ "$(cat "$dir/src/lib.rs")" == "" ] && [[ " ${IGNORED_EXERCISES[*]} " != *"$exercise"* ]]; then
+			echo "$exercise has src/lib.rs stub file, but it is empty."
+			empty_stub="$empty_stub\n$exercise"
+		fi
   fi
 done
 
 if [ -n "$missing" ]; then
-  echo "Exercises missing src/lib.rs:$missing"
-  exit 1
+	printf "\nExercises missing src/lib.rs:$missing\n"
+
+	check_status=1
+fi
+
+if [ -n "$empty_stub" ]; then
+	printf "\nExercises with empty src/lib.rs stub file:$empty_stub\n"
+
+	check_status=1
+fi
+
+if [ "$check_status" -ne 0 ]; then
+	exit 1
+else
+	exit 0
 fi


### PR DESCRIPTION
As discussed in #551 the script in this PR now has a check to ensure that the stub files of the exercises
are not empty.

The reasons why `ensure-lib-src-rs-exist.sh` was chosen for this PR and not `ensure-stubs-compile.sh` are:
- The content of the stub file is not a concern of `ensure-stubs-compile.sh` - it should check if the stub compiles, even if it is empty
- When `ensure-lib-src-rs-exist.sh` checks for the stub and thinks it exists only because the file exists (even though it could be empty) is sort of false-positive

The `[ "$(cat "$dir/src/lib.rs")" == "" ]` line was added for the check, because when `rustfmt` works on an empty file it inserts the `0a` symbol in it, and the `-s` flag check is useless in this case.

In case this PR is merged, closes #551

