### PR TITLE
Update "The Rust Book" links to 2018-edition.

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,6 +1,6 @@
 ## Learning Rust
 
-* [The Rust Programming Language](https://doc.rust-lang.org/book/second-edition/) is a great resource for getting started with Rust as well as diving deeper into specific features of Rust.
+* [The Rust Programming Language](https://doc.rust-lang.org/book/2018-edition/) is a great resource for getting started with Rust as well as diving deeper into specific features of Rust.
 * [Rust by Example](https://doc.rust-lang.org/stable/rust-by-example/) shows you examples of the most common things you will be writing in Rust.
 * [Into_rust()](http://intorust.com/) "Screencasts for learning Rust."
 * [Rustlings](https://github.com/carols10cents/rustlings) "Small exercises to get you used to reading and writing Rust code."


### PR DESCRIPTION
Update `The Rust Programming Language` link to point to 2018-edition.

> The 2018 edition of the book is a "living version" of the book; based on the second edition, it will be updated as Rust updates. If you're not sure what version of the book to read, you should prefer this version. [(Source)](https://doc.rust-lang.org/book/)