### PR TITLE
accumulate: make exercise more idiomatic

### DIFF
--- a/exercises/accumulate/.meta/hints.md
+++ b/exercises/accumulate/.meta/hints.md
@@ -1,8 +1,5 @@
 ## Hints
 
-We are dealing with two types of situations.  One is a function pointer and
-the other is a closure.
-
 It may help to look at the [Fn trait](https://doc.rust-lang.org/std/ops/trait.Fn.html).
 
 Help with passing a closure into a function may be found in

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -27,9 +27,6 @@ Solve this one yourself using other basic tools instead.
 
 ## Hints
 
-We are dealing with two types of situations.  One is a function pointer and
-the other is a closure.
-
 It may help to look at the [Fn trait](https://doc.rust-lang.org/std/ops/trait.Fn.html).
 
 Help with passing a closure into a function may be found in

--- a/exercises/accumulate/example.rs
+++ b/exercises/accumulate/example.rs
@@ -1,18 +1,9 @@
-pub fn map_function(values: Vec<i32>, f: &Fn(i32) -> i32) -> Vec<i32> {
-    let mut out: Vec<i32> = vec![];
-    for val in values {
-        out.push(f(val))
-    }
-    out
-}
-
-pub fn map_closure<F>(values: Vec<i32>, f: F) -> Vec<i32>
+pub fn map<F>(mut values: Vec<i32>, f: F) -> Vec<i32>
 where
     F: Fn(i32) -> i32,
 {
-    let mut out: Vec<i32> = vec![];
-    for val in values {
-        out.push(f(val))
+    for val in &mut values {
+        *val = f(*val);
     }
-    out
+    values
 }

--- a/exercises/accumulate/src/lib.rs
+++ b/exercises/accumulate/src/lib.rs
@@ -1,9 +1,4 @@
 /// What should the type of _function be?
-pub fn map_function(input: Vec<i32>, _function: ???) -> Vec<i32> {
+pub fn map(input: Vec<i32>, _function: ???) -> Vec<i32> {
     unimplemented!("Transform input vector {:?} using passed function", input);
-}
-
-/// What should the type of _closure be?
-pub fn map_closure(input: Vec<i32>, _closure: ???) -> Vec<i32> {
-    unimplemented!("Transform input vector {:?} using passed closure", input);
 }

--- a/exercises/accumulate/tests/accumulate.rs
+++ b/exercises/accumulate/tests/accumulate.rs
@@ -1,24 +1,16 @@
 extern crate accumulate;
 
-use accumulate::{map_closure, map_function};
+use accumulate::map;
 
 fn square(x: i32) -> i32 {
     x * x
-}
-
-fn abs_val(x: i32) -> i32 {
-    if x > 0 {
-        x
-    } else {
-        -x
-    }
 }
 
 #[test]
 fn test_func_square_single() {
     let input = vec![2];
     let expected = vec![4];
-    assert_eq!(map_function(input, &square), expected);
+    assert_eq!(map(input, square), expected);
 }
 
 #[test]
@@ -26,7 +18,7 @@ fn test_func_square_single() {
 fn test_func_square_short() {
     let input = vec![2, 3, 4, 5];
     let expected = vec![4, 9, 16, 25];
-    assert_eq!(map_function(input, &square), expected);
+    assert_eq!(map(input, square), expected);
 }
 
 #[test]
@@ -34,7 +26,7 @@ fn test_func_square_short() {
 fn test_func_square_long_with_neg() {
     let input = vec![2, -3, -2, 3, 4, 3, 4, 5, 100, 8, 16, 34];
     let expected = vec![4, 9, 4, 9, 16, 9, 16, 25, 10000, 64, 256, 1156];
-    assert_eq!(map_function(input, &square), expected);
+    assert_eq!(map(input, square), expected);
 }
 
 #[test]
@@ -42,7 +34,7 @@ fn test_func_square_long_with_neg() {
 fn test_func_abs_value_with_neg() {
     let input = vec![-3];
     let expected = vec![3];
-    assert_eq!(map_function(input, &abs_val), expected);
+    assert_eq!(map(input, i32::abs), expected);
 }
 
 #[test]
@@ -50,7 +42,7 @@ fn test_func_abs_value_with_neg() {
 fn test_func_abs_value_long() {
     let input = vec![-3, 5, -10, 4, 100, -1234, 55443];
     let expected = vec![3, 5, 10, 4, 100, 1234, 55443];
-    assert_eq!(map_function(input, &abs_val), expected);
+    assert_eq!(map(input, i32::abs), expected);
 }
 
 #[test]
@@ -58,7 +50,7 @@ fn test_func_abs_value_long() {
 fn test_closure_square_single() {
     let input = vec![2];
     let expected = vec![4];
-    assert_eq!(map_closure(input, |x| x * x), expected);
+    assert_eq!(map(input, |x| x * x), expected);
 }
 
 #[test]
@@ -66,7 +58,7 @@ fn test_closure_square_single() {
 fn test_closure_square_short() {
     let input = vec![2, 3, 4, 5];
     let expected = vec![4, 9, 16, 25];
-    assert_eq!(map_closure(input, |x| x * x), expected);
+    assert_eq!(map(input, |x| x * x), expected);
 }
 
 #[test]
@@ -74,7 +66,7 @@ fn test_closure_square_short() {
 fn test_closure_square_long_with_neg() {
     let input = vec![2, -3, -2, 3, 4, 3, 4, 5, 100, 8, 16, 34];
     let expected = vec![4, 9, 4, 9, 16, 9, 16, 25, 10000, 64, 256, 1156];
-    assert_eq!(map_closure(input, |x| x * x), expected);
+    assert_eq!(map(input, |x| x * x), expected);
 }
 
 #[test]
@@ -82,7 +74,7 @@ fn test_closure_square_long_with_neg() {
 fn test_closure_abs_value_with_neg() {
     let input = vec![-3];
     let expected = vec![3];
-    assert_eq!(map_closure(input, |x| if x > 0 { x } else { -x }), expected);
+    assert_eq!(map(input, |x| x.abs()), expected);
 }
 
 #[test]
@@ -90,5 +82,5 @@ fn test_closure_abs_value_with_neg() {
 fn test_closure_abs_value_long() {
     let input = vec![-3, 5, -10, 4, 100, -1234, 55443];
     let expected = vec![3, 5, 10, 4, 100, 1234, 55443];
-    assert_eq!(map_closure(input, |x| if x > 0 { x } else { -x }), expected);
+    assert_eq!(map(input, |x| x.abs()), expected);
 }


### PR DESCRIPTION
The distinction between fn pointers and closures is unusal and unnecessary. The common solution with generics works for both anyway.

Furthermore, it was evident from the old examples that this was never about
function pointers (`fn(i32) -> i32`) like the hint claimed, but about trait objects (`&Fn(i32) ->
i32`). Those also implement the `Fn` trait and therefore they, too, work with the generic version.

Edit: I just thought of, maybe I should also change the input and output type. With equal types everything can be done in place which I think takes away from the exercise, it's just iteration, function calling and mutation. A general accumulate has to convert between types which forces creation of a new `Vec`. If the input type is not `Copy`, this also ties into move semantics and ownership.

What do you think?