### PR TITLE
brackets: simplify required interface

### DIFF
--- a/exercises/bracket-push/.meta/hints.md
+++ b/exercises/bracket-push/.meta/hints.md
@@ -1,6 +1,0 @@
-# Bracket Push in Rust
-
-Reading about these Rust topics may help you implement a solution.
-
-- Lifetimes and Structs: https://doc.rust-lang.org/book/second-edition/ch10-03-lifetime-syntax.html#lifetime-annotations-in-method-definitions
-- From trait: https://doc.rust-lang.org/std/convert/trait.From.html

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -4,14 +4,6 @@ Given a string containing brackets `[]`, braces `{}`, parentheses `()`,
 or any combination thereof, verify that any and all pairs are matched
 and nested correctly.
 
-# Bracket Push in Rust
-
-Reading about these Rust topics may help you implement a solution.
-
-- Lifetimes and Structs: https://doc.rust-lang.org/book/second-edition/ch10-03-lifetime-syntax.html#lifetime-annotations-in-method-definitions
-- From trait: https://doc.rust-lang.org/std/convert/trait.From.html
-
-
 ## Rust Installation
 
 Refer to the [exercism help page][help-page] for Rust installation and learning

--- a/exercises/bracket-push/example.rs
+++ b/exercises/bracket-push/example.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
 
-pub struct Brackets {
+pub fn brackets_are_balanced(string: &str) -> bool {
+    Brackets::from(string).are_balanced()
+}
+
+struct Brackets {
     raw_brackets: Vec<char>,
     pairs: MatchingBrackets,
 }
@@ -12,7 +16,7 @@ impl<'a> From<&'a str> for Brackets {
 }
 
 impl Brackets {
-    pub fn new(s: String, pairs: Option<Vec<(char, char)>>) -> Self {
+    fn new(s: String, pairs: Option<Vec<(char, char)>>) -> Self {
         let p = match pairs {
             Some(x) => MatchingBrackets::from(x),
             None => MatchingBrackets::from(vec![('[', ']'), ('{', '}'), ('(', ')')]),
@@ -24,7 +28,7 @@ impl Brackets {
         }
     }
 
-    pub fn are_balanced(&self) -> bool {
+    fn are_balanced(&self) -> bool {
         let mut unclosed: Vec<char> = Vec::new();
 
         for &bracket in self.raw_brackets.iter() {
@@ -39,7 +43,7 @@ impl Brackets {
     }
 }
 
-pub struct MatchingBrackets {
+struct MatchingBrackets {
     collection: HashMap<char, char>,
 }
 

--- a/exercises/bracket-push/src/lib.rs
+++ b/exercises/bracket-push/src/lib.rs
@@ -1,13 +1,3 @@
-pub struct Brackets;
-
-impl<'a> From<&'a str> for Brackets {
-    fn from(input: &str) -> Self {
-        unimplemented!("From the '{}' input construct a new Brackets struct", input);
-    }
-}
-
-impl Brackets {
-    pub fn are_balanced(&self) -> bool {
-        unimplemented!("Check if your Brackets struct contains balanced brackets");
-    }
+pub fn brackets_are_balanced(string: &str) -> bool {
+    unimplemented!("Check if the string \"{}\" contains balanced brackets", string);
 }

--- a/exercises/bracket-push/tests/bracket-push.rs
+++ b/exercises/bracket-push/tests/bracket-push.rs
@@ -1,82 +1,82 @@
 extern crate bracket_push;
 
-use bracket_push::*;
+use bracket_push::brackets_are_balanced;
 
 #[test]
 fn paired_square_brackets() {
-    assert!(Brackets::from("[]").are_balanced());
+    assert!(brackets_are_balanced("[]"));
 }
 
 #[test]
 #[ignore]
 fn empty_string() {
-    assert!(Brackets::from("").are_balanced());
+    assert!(brackets_are_balanced(""));
 }
 
 #[test]
 #[ignore]
 fn unpaired_brackets() {
-    assert!(!Brackets::from("[[").are_balanced());
+    assert!(!brackets_are_balanced("[["));
 }
 
 #[test]
 #[ignore]
 fn wrong_ordered_brackets() {
-    assert!(!Brackets::from("}{").are_balanced());
+    assert!(!brackets_are_balanced("}{"));
 }
 
 #[test]
 #[ignore]
 fn wrong_closing_bracket() {
-    assert!(!Brackets::from("{]").are_balanced());
+    assert!(!brackets_are_balanced("{]"));
 }
 
 #[test]
 #[ignore]
 fn paired_with_whitespace() {
-    assert!(Brackets::from("{ }").are_balanced());
+    assert!(brackets_are_balanced("{ }"));
 }
 
 #[test]
 #[ignore]
 fn simple_nested_brackets() {
-    assert!(Brackets::from("{[]}").are_balanced());
+    assert!(brackets_are_balanced("{[]}"));
 }
 
 #[test]
 #[ignore]
 fn several_paired_brackets() {
-    assert!(Brackets::from("{}[]").are_balanced());
+    assert!(brackets_are_balanced("{}[]"));
 }
 
 #[test]
 #[ignore]
 fn paired_and_nested_brackets() {
-    assert!(Brackets::from("([{}({}[])])").are_balanced());
+    assert!(brackets_are_balanced("([{}({}[])])"));
 }
 
 #[test]
 #[ignore]
 fn unopened_closing_brackets() {
-    assert!(!Brackets::from("{[)][]}").are_balanced());
+    assert!(!brackets_are_balanced("{[)][]}"));
 }
 
 #[test]
 #[ignore]
 fn unpaired_and_nested_brackets() {
-    assert!(!Brackets::from("([{])").are_balanced());
+    assert!(!brackets_are_balanced("([{])"));
 }
 
 #[test]
 #[ignore]
 fn paired_and_wrong_nested_brackets() {
-    assert!(!Brackets::from("[({]})").are_balanced());
+    assert!(!brackets_are_balanced("[({]})"));
 }
 
 #[test]
 #[ignore]
 fn math_expression() {
-    assert!(Brackets::from("(((185 + 223.85) * 15) - 543)/2").are_balanced());
+    assert!(brackets_are_balanced("(((185 + 223.85) * 15) - 543)/2"));
 }
 
 #[test]
@@ -84,5 +84,5 @@ fn math_expression() {
 fn complex_latex_expression() {
     let input = "\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ \\mathrm{e}^{x} &... x^2 \
                  \\end{array}\\right)";
-    assert!(Brackets::from(input).are_balanced());
+    assert!(brackets_are_balanced(input));
 }


### PR DESCRIPTION
I'm just going to quote Peter Tillemans' post from the slack channel. He put it very nicely.

>Peter Tillemans [11 août à 23 h 35]
Regarding the Brackets exercise, the way the challenge is made, the student is forced to use an object-like interface where you have to initialise the 'object' before calling a method on it. This 'object' ends usually up with either the result of the brackets balance or the input text or some intermediate value of the data transformation pipeline. This challenge lends itself well to a purely functional solution. I also feel it pushes students to use stateful solutions where none are warranted. (Actually @mawis pointed this out originally).

The hint in the Readme points students towards using lifetimes, but most just accept the `impl From<&'a str> for Brackets` as is. They don't work with lifetimes themselves, they only conform to the interface.