### PR TITLE
leap: add more test cases

### DIFF
--- a/exercises/leap/tests/leap.rs
+++ b/exercises/leap/tests/leap.rs
@@ -14,12 +14,27 @@ fn test_any_old_year() {
 #[test]
 #[ignore]
 fn test_century() {
+    assert_eq!(leap::is_leap_year(1700), false);
+    assert_eq!(leap::is_leap_year(1800), false);
     assert_eq!(leap::is_leap_year(1900), false);
 }
 
 #[test]
 #[ignore]
 fn test_exceptional_centuries() {
+    assert_eq!(leap::is_leap_year(1600), true);
     assert_eq!(leap::is_leap_year(2000), true);
     assert_eq!(leap::is_leap_year(2400), true);
+}
+
+#[test]
+#[ignore]
+fn test_years_1600_to_1699() {
+    let incorrect_years = (1600..1700)
+        .filter(|&year| leap::is_leap_year(year) != (year % 4 == 0))
+        .collect::<Vec<_>>();
+
+    if !incorrect_years.is_empty() {
+        panic!("incorrect result for years: {:?}", incorrect_years);
+    }
 }


### PR DESCRIPTION
The exercise has just 5 test cases. This can easily let some bugs slip through.
This adds a check for a range of years (1600 to 1699) and a few additional centuries. The range is kept short so the user isn't spammed with a huge list of incorrect years with wrong code. It also avoids having the full solution in the tests where students could stumble upon it.

I got this faulty code from a student which passes all the old tests:  
```rust
year % 4 == 0 && !year % 100 == 0 || year % 400 == 0
```