### PR TITLE
rectangles: Added newline to the stub template message

### DIFF
--- a/exercises/rectangles/src/lib.rs
+++ b/exercises/rectangles/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn count(lines: &[&str]) -> u32 {
-    unimplemented!("Determine the count of rectangles in the ASCII diagram represented by the following lines:\n{:#?}\n.", lines);
+    unimplemented!("\nDetermine the count of rectangles in the ASCII diagram represented by the following lines:\n{:#?}\n.", lines);
 }


### PR DESCRIPTION
Makes the `unimplemented!` message to look like this: 

```text
---- test_two_rectangles_no_shared_parts stdout ----
thread 'test_two_rectangles_no_shared_parts' panicked at 'not yet implemented: 
Determine the count of rectangles in the ASCII diagram represented by the following lines:
[
    "  +-+",
    "  | |",
    "+-+-+",
    "| |  ",
    "+-+  "
]
.', src/lib.rs:2:5

```

Changes according to the following comment: https://github.com/exercism/rust/pull/609#discussion_r210719886