### PR TITLE
clock: Add test case for comparing 24:00 and 00:00

### DIFF
--- a/exercises/clock/tests/clock.rs
+++ b/exercises/clock/tests/clock.rs
@@ -328,3 +328,9 @@ fn test_compare_clocks_with_negative_hours_and_minutes() {
 fn test_compare_clocks_with_negative_hours_and_minutes_that_wrap() {
     assert_eq!(Clock::new(18, 7), Clock::new(-54, -11513))
 }
+
+#[test]
+#[ignore]
+fn test_compare_full_clock_and_zeroed_clock() {
+    assert_eq!(Clock::new(24, 0), Clock::new(0, 0))
+}


### PR DESCRIPTION
This test helped me find a bug in my solution, specifically where I did the modulo operation.

I had this:

```rust
    fn mod_n(a: i32, n: i32) -> i32 {
        if n <= 0 {
            panic!("Tried mod with negative base: {:?}", n);
        }

        if a > 0 {
            a % n
        }
        else {
            a % n + n
        }
    }
```

And it should've been this:

```rust
    fn mod_n(a: i32, n: i32) -> i32 {
        if n <= 0 {
            panic!("Tried mod with negative base: {:?}", n);
        }

        if a >= 0 {
            a % n
        }
        else {
            a % n + n
        }
    }
```

"0 hours" was treated like a negative amount, but the solution still passed all the tests. Anyway, I hope this helps, and lemme know if I should change something!