### PR TITLE
Change template to point directly to exercism rust learning page

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -21,7 +21,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -52,7 +52,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -51,7 +51,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -82,7 +82,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -24,7 +24,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -55,7 +55,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -48,7 +48,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -79,7 +79,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -46,7 +46,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -77,7 +77,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -48,7 +48,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -79,7 +79,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -23,7 +23,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -54,7 +54,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -28,7 +28,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -59,7 +59,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -45,7 +45,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -76,7 +76,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -337,7 +337,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -368,7 +368,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -96,7 +96,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -127,7 +127,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -32,7 +32,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -63,7 +63,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -84,7 +84,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -115,7 +115,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -77,7 +77,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -108,7 +108,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -21,7 +21,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -52,7 +52,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -67,7 +67,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -98,7 +98,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -35,7 +35,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -66,7 +66,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -43,7 +43,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -74,7 +74,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -89,7 +89,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -120,7 +120,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -24,7 +24,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -55,7 +55,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/decimal/README.md
+++ b/exercises/decimal/README.md
@@ -37,7 +37,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -68,7 +68,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -69,7 +69,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -100,7 +100,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -29,7 +29,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -60,7 +60,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -58,7 +58,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -89,7 +89,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -31,7 +31,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -62,7 +62,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/dot-dsl/README.md
+++ b/exercises/dot-dsl/README.md
@@ -49,7 +49,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -80,7 +80,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -63,7 +63,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -94,7 +94,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -42,7 +42,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -73,7 +73,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -24,7 +24,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -55,7 +55,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -51,7 +51,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -82,7 +82,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -43,7 +43,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -74,7 +74,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -98,7 +98,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -129,7 +129,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -53,7 +53,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -84,7 +84,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -31,7 +31,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -62,7 +62,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -24,7 +24,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -55,7 +55,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -57,7 +57,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -88,7 +88,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -30,7 +30,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -61,7 +61,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -38,7 +38,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -69,7 +69,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -43,7 +43,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -74,7 +74,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/luhn-from/README.md
+++ b/exercises/luhn-from/README.md
@@ -29,7 +29,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -60,7 +60,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/luhn-trait/README.md
+++ b/exercises/luhn-trait/README.md
@@ -43,7 +43,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -74,7 +74,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -81,7 +81,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -112,7 +112,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/macros/README.md
+++ b/exercises/macros/README.md
@@ -47,7 +47,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -78,7 +78,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -43,7 +43,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -74,7 +74,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -25,7 +25,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -56,7 +56,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/nucleotide-codons/README.md
+++ b/exercises/nucleotide-codons/README.md
@@ -35,7 +35,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -66,7 +66,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -29,7 +29,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -60,7 +60,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -95,7 +95,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -126,7 +126,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -49,7 +49,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -80,7 +80,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -25,7 +25,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -56,7 +56,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -58,7 +58,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -89,7 +89,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -31,7 +31,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -62,7 +62,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -34,7 +34,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -65,7 +65,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -45,7 +45,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -76,7 +76,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -34,7 +34,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -65,7 +65,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -32,7 +32,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -63,7 +63,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -46,7 +46,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -77,7 +77,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -58,7 +58,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -89,7 +89,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -33,7 +33,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -64,7 +64,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -34,7 +34,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -65,7 +65,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -43,7 +43,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -74,7 +74,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -34,7 +34,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -65,7 +65,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -32,7 +32,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -63,7 +63,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -80,7 +80,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -111,7 +111,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -35,7 +35,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -66,7 +66,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -46,7 +46,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -77,7 +77,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -32,7 +32,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -63,7 +63,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -44,7 +44,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -75,7 +75,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -59,7 +59,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -90,7 +90,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -47,7 +47,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -78,7 +78,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -40,7 +40,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -71,7 +71,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -45,7 +45,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -76,7 +76,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -100,7 +100,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -131,7 +131,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -56,7 +56,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -87,7 +87,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -37,7 +37,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -68,7 +68,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -46,7 +46,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -77,7 +77,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -98,7 +98,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -129,7 +129,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -73,7 +73,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -104,7 +104,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -42,7 +42,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -73,7 +73,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -40,7 +40,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -71,7 +71,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -34,7 +34,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -65,7 +65,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -25,7 +25,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -56,7 +56,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -81,7 +81,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -112,7 +112,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -67,7 +67,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -98,7 +98,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -46,7 +46,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -77,7 +77,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -29,7 +29,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -60,7 +60,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -48,7 +48,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -79,7 +79,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -28,7 +28,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -59,7 +59,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -68,7 +68,7 @@ All but the first test have been ignored. After you get the first test to
 pass, open the tests source file which is located in the `tests` directory
 and remove the `#[ignore]` flag from the next test and get the tests to pass
 again. Each separate test is a function with `#[test]` flag above it.
-Continue, until you pass every test. 
+Continue, until you pass every test.
 
 If you wish to run all tests without editing the tests source file, use:
 
@@ -99,7 +99,7 @@ The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is th
 
 If you want to know more about Exercism, take a look at the [contribution guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md).
 
-[help-page]: http://exercism.io/languages/rust
+[help-page]: https://exercism.io/tracks/rust/learning
 [modules]: https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
 [cargo]: https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html


### PR DESCRIPTION
This means that students clicking that link end up somewhere
more useful than the generic page where they'd otherwise end
up after redirection.

Closes #599.

```sh
$ for url in $(rg -ioN 'http[^\s)]+' config/exercise_readme.go.tmpl); do
>   echo "$url"
>   curl -IL "$url" 2>/dev/null | rg HTTP
> done
Fri Aug 31 14:35:07 DST 2018
https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
HTTP/1.1 200 OK
https://github.com/exercism/rust
HTTP/1.1 200 OK
https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md
HTTP/1.1 200 OK
https://exercism.io/tracks/rust/learning
HTTP/1.1 200 OK
https://doc.rust-lang.org/book/2018-edition/ch07-00-modules.html
HTTP/1.1 200 OK
https://doc.rust-lang.org/book/2018-edition/ch14-00-more-about-cargo.html
HTTP/1.1 200 OK
https://doc.rust-lang.org/book/2018-edition/ch11-02-running-tests.html
HTTP/1.1 200 OK
```