### PR TITLE
dot-dsl: Add get_node and get_attr methods to required signatures

### DIFF
--- a/exercises/dot-dsl/example.rs
+++ b/exercises/dot-dsl/example.rs
@@ -38,6 +38,10 @@ pub mod graph {
 
             self
         }
+
+        pub fn get_node(&self, name: &str) -> Option<&Node> {
+            self.nodes.iter().filter(|n| n.name == name).nth(0)
+        }
     }
 
     pub mod graph_items {
@@ -75,7 +79,7 @@ pub mod graph {
 
             #[derive(Clone, PartialEq, Debug)]
             pub struct Node {
-                name: String,
+                pub name: String,
 
                 attrs: HashMap<String, String>,
             }
@@ -94,6 +98,10 @@ pub mod graph {
                     });
 
                     self
+                }
+
+                pub fn get_attr(&self, name: &str) -> Option<&str> {
+                    self.attrs.get(name).map(|v| v.as_ref())
                 }
             }
 

--- a/exercises/dot-dsl/tests/dot-dsl.rs
+++ b/exercises/dot-dsl/tests/dot-dsl.rs
@@ -124,3 +124,22 @@ fn test_graph_with_attributes() {
 
     assert_eq!(graph.attrs, expected_attrs);
 }
+
+#[test]
+#[ignore]
+fn test_graph_stores_attributes() {
+    let attributes = [("foo", "bar"), ("bat", "baz"), ("bim", "bef")];
+    let graph = Graph::new().with_nodes(&['a', 'b', 'c']
+        .iter()
+        .enumerate()
+        .map(|(i, n)| Node::new(&n.to_string()).with_attrs(&attributes[i..i + 1]))
+        .collect::<Vec<_>>());
+
+    assert_eq!(
+        graph
+            .get_node("c")
+            .expect("node must be stored")
+            .get_attr("bim"),
+        Some("bef")
+    );
+}

--- a/exercises/dot-dsl/tests/dot-dsl.rs
+++ b/exercises/dot-dsl/tests/dot-dsl.rs
@@ -2,9 +2,9 @@
 extern crate maplit;
 extern crate dot_dsl;
 
+use dot_dsl::graph::Graph;
 use dot_dsl::graph::graph_items::edge::Edge;
 use dot_dsl::graph::graph_items::node::Node;
-use dot_dsl::graph::Graph;
 
 #[test]
 fn test_empty_graph() {


### PR DESCRIPTION
Closes #640. Doesn't test edges or edge attributes, but hopefully
once students have implemented enough to pass this test, they'll
implement edges properly also.