### PR TITLE
macros: test macro without HashMap in scope

### DIFF
--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -60,3 +60,11 @@ fn test_nested() {
         expected
     );
 }
+
+mod test {
+    #[test]
+    #[ignore]
+    fn type_not_in_scope() {
+        let expected: ::std::collections::HashMap<(), ()> = hashmap!();
+    }
+}


### PR DESCRIPTION
fixes #600

I put a test fn in a new module that doesn't import HashMap, so that if a student uses `HashMap::new()` in the macro, the compiler will throw one and only one compile error.