### PR TITLE
nth-prime: use 0-based indexes instead of 1-based

### DIFF
--- a/exercises/nth-prime/example.rs
+++ b/exercises/nth-prime/example.rs
@@ -1,5 +1,5 @@
 fn is_prime(n: u32) -> bool {
-    let mut i: u32 = 3;
+    let mut i = 3;
     while (i * i) < (n + 1) {
         if n % i == 0 {
             return false;
@@ -9,20 +9,18 @@ fn is_prime(n: u32) -> bool {
     return true;
 }
 
-pub fn nth(n: u32) -> Option<u32> {
-    match n {
-        0 => None,
-        1 => Some(2),
-        _ => {
-            let mut count: u32 = 1;
-            let mut candidate: u32 = 1;
-            while count < n {
-                candidate += 2;
-                if is_prime(candidate) {
-                    count += 1;
-                }
+pub fn nth(n: u32) -> u32 {
+    if n == 0 {
+        2
+    } else {
+        let mut count = 0;
+        let mut candidate = 1;
+        while count < n {
+            candidate += 2;
+            if is_prime(candidate) {
+                count += 1;
             }
-            Some(candidate)
         }
+        candidate
     }
 }

--- a/exercises/nth-prime/src/lib.rs
+++ b/exercises/nth-prime/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn nth(n: u32) -> Option<u32> {
+pub fn nth(n: u32) -> u32 {
     unimplemented!("What is the {}th prime number?", n)
 }

--- a/exercises/nth-prime/src/lib.rs
+++ b/exercises/nth-prime/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn nth(n: u32) -> u32 {
-    unimplemented!("What is the {}th prime number?", n)
+    unimplemented!("What is the 0-indexed {}th prime number?", n)
 }

--- a/exercises/nth-prime/tests/nth-prime.rs
+++ b/exercises/nth-prime/tests/nth-prime.rs
@@ -2,29 +2,23 @@ extern crate nth_prime as np;
 
 #[test]
 fn test_first_prime() {
-    assert_eq!(np::nth(1), Some(2));
+    assert_eq!(np::nth(0), 2);
 }
 
 #[test]
 #[ignore]
 fn test_second_prime() {
-    assert_eq!(np::nth(2), Some(3));
+    assert_eq!(np::nth(1), 3);
 }
 
 #[test]
 #[ignore]
 fn test_sixth_prime() {
-    assert_eq!(np::nth(6), Some(13));
+    assert_eq!(np::nth(5), 13);
 }
 
 #[test]
 #[ignore]
 fn test_big_prime() {
-    assert_eq!(np::nth(10001), Some(104743));
-}
-
-#[test]
-#[ignore]
-fn test_zeroth_prime() {
-    assert_eq!(np::nth(0), None);
+    assert_eq!(np::nth(10000), 104743);
 }


### PR DESCRIPTION
As there is no longer any case which would return `None`, this also
imples returning a simple `u32` instead of an `Option<u32>`. Removing
the `Option` implied removing the test case testing for `None`.

In the past this may have served as a very gentle introdution to the
`Option` type, but that may have been accidental: it wasn't mentioned
in the "topics" section for this exercise in `config.json`. Therefore
it should be fine to let some other exercise serve as an introduction
to the `Option` type.

Closes #626. 