### PR TITLE
clock: update test suite to match canonical data

### DIFF
--- a/exercises/clock/Cargo.toml
+++ b/exercises/clock/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "clock"
-version = "1.0.0"
+version = "2.3.0"
 
 [dependencies]


### PR DESCRIPTION
Closes #642.

I performed a manual comparison of the [test suite][1] and the [canonical data][2],
and determined that the set of tests is identical in each. This PR is therefore
limited to updating the version string to match that of the canonical data.

[1]: https://github.com/exercism/rust/blob/master/exercises/clock/tests/clock.rs
[2]: https://github.com/exercism/problem-specifications/blob/master/exercises/clock/canonical-data.json