### PR TITLE
Add test for pig latin rule 4

### DIFF
--- a/exercises/pig-latin/example.rs
+++ b/exercises/pig-latin/example.rs
@@ -13,7 +13,7 @@ pub fn translate_word(word: &str) -> String {
         // Detects if it starts with a vowel
         static ref VOWEL: Regex = Regex::new(r"^([aeiou]|y[^aeiou]|xr)[a-z]*").unwrap();
         // Detects splits for initial consonants
-        static ref CONSONANTS: Regex = Regex::new(r"^([^aeiou]?qu|[^aeiou]+)([a-z]*)").unwrap();
+        static ref CONSONANTS: Regex = Regex::new(r"^([^aeiou]?qu|[^aeiou][^aeiouy]*)([a-z]*)").unwrap();
     }
 
     if VOWEL.is_match(word) {

--- a/exercises/pig-latin/tests/pig-latin.rs
+++ b/exercises/pig-latin/tests/pig-latin.rs
@@ -115,6 +115,12 @@ fn test_word_beginning_with_xr() {
 
 #[test]
 #[ignore]
+fn test_y_is_treated_like_a_vowel_at_the_end_of_a_consonant_cluster() {
+    assert_eq!(pl::translate("rhythm"), "ythmrhay");
+}
+
+#[test]
+#[ignore]
 fn test_a_whole_phrase() {
     assert_eq!(pl::translate("quick fast run"), "ickquay astfay unray");
 }


### PR DESCRIPTION
There was no test for

```
**Rule 4**: If a word contains a "y" after a consonant cluster or as the
second letter if a two letter word it makes a vowel sound (e.g. "rhythm"
-> "ythmrhay", "my" -> "ymay").
```