### PR TITLE
macro: suppress unused_variable warning in test

### DIFF
--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -65,6 +65,6 @@ mod test {
     #[test]
     #[ignore]
     fn type_not_in_scope() {
-        let expected: ::std::collections::HashMap<(), ()> = hashmap!();
+        let _expected: ::std::collections::HashMap<(), ()> = hashmap!();
     }
 }


### PR DESCRIPTION
Oversight on the recent patch