### PR TITLE
DO NOT MERGE: text check exercises

### DIFF
--- a/_test/check-exercises.sh
+++ b/_test/check-exercises.sh
@@ -20,15 +20,25 @@ fi
 # can't benchmark with a stable compiler; to bench, use
 # $ BENCHMARK=1 rustup run nightly _test/check-exercises.sh
 if [ -n "$BENCHMARK" ]; then
-    files=exercises/*/benches
+    target_dir=benches
 else
-    files=exercises/*/tests
+    target_dir=tests
+fi
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$current_branch" != "master" ]; then
+	files="$(git diff --name-only master | grep "exercises/" | cut -d '/' -f -2)"
+else
+	files=exercises/*
 fi
 
 return_code=0
 # An exercise worth testing is defined here as any top level directory with
 # a 'tests' directory
 for exercise in $files; do
+   exercise="$exercise/$target_dir"
+
    # This assumes that exercises are only one directory deep
    # and that the primary module is named the same as the directory
    directory=$(dirname "${exercise}")

--- a/exercises/bob/tests/bob.rs
+++ b/exercises/bob/tests/bob.rs
@@ -172,3 +172,7 @@ fn test_non_question_ending_with_whitespace() {
         bob::reply("This is a statement ending with whitespace      ")
     );
 }
+
+#[test]
+#[ignore]
+fn test_nothing() {}

--- a/exercises/clock/tests/clock.rs
+++ b/exercises/clock/tests/clock.rs
@@ -334,3 +334,9 @@ fn test_compare_clocks_with_negative_hours_and_minutes_that_wrap() {
 fn test_compare_full_clock_and_zeroed_clock() {
     assert_eq!(Clock::new(24, 0), Clock::new(0, 0))
 }
+
+#[test]
+#[ignore]
+fn test_nothing() {
+    unimplemented!()
+}


### PR DESCRIPTION
This PR builds on #688 and edits two exercises, to test for correct Travis behavior.

We should let Travis run on this PR. Correct behavior of #688 implies:

- check-exercises checks only `bob` and `clock`
- `bob` should succeed: added an empty test
- `clock` should fail: added an `unimplemented!()` test