### PR TITLE
wordy: Move `answer` to top level

### DIFF
--- a/exercises/wordy/example.rs
+++ b/exercises/wordy/example.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, PartialEq)]
-pub struct WordProblem {
+struct WordProblem {
     command: String,
 }
 
@@ -25,14 +25,18 @@ impl Token {
     }
 }
 
+pub fn answer(c: &str) -> Option<isize> {
+    WordProblem::new(c).answer()
+}
+
 impl WordProblem {
-    pub fn new(c: &str) -> Self {
+    fn new(c: &str) -> Self {
         WordProblem {
             command: String::from(c),
         }
     }
 
-    pub fn answer(&self) -> Option<isize> {
+    fn answer(&self) -> Option<isize> {
         let mut t = self.tokens();
         let mut result: isize = 0;
         let mut opr = "plus".to_string();

--- a/exercises/wordy/src/lib.rs
+++ b/exercises/wordy/src/lib.rs
@@ -1,16 +1,8 @@
 pub struct WordProblem;
 
-impl WordProblem {
-    pub fn new(command: &str) -> Self {
-        unimplemented!(
-            "From the '{}' command construct a new WordProblem struct.",
-            command
-        );
-    }
-
-    pub fn answer(&self) -> Option<i32> {
-        unimplemented!(
-            "Return the result of the transmitted command or None, if the command is invalid."
-        );
-    }
+pub fn answer(command: &str) -> Option<i32> {
+    unimplemented!(
+        "Return the result of the command '{}' or None, if the command is invalid.",
+        command
+    );
 }

--- a/exercises/wordy/tests/wordy.rs
+++ b/exercises/wordy/tests/wordy.rs
@@ -1,114 +1,114 @@
 extern crate wordy;
 
-use wordy::*;
+use wordy::answer;
 
 #[test]
 fn addition() {
     let command = "What is 1 plus 1?";
-    assert_eq!(Some(2), WordProblem::new(command).answer());
+    assert_eq!(Some(2), answer(command));
 }
 
 #[test]
 #[ignore]
 fn more_addition() {
     let command = "What is 53 plus 2?";
-    assert_eq!(Some(55), WordProblem::new(command).answer());
+    assert_eq!(Some(55), answer(command));
 }
 
 #[test]
 #[ignore]
 fn addition_with_negative_numbers() {
     let command = "What is -1 plus -10?";
-    assert_eq!(Some(-11), WordProblem::new(command).answer());
+    assert_eq!(Some(-11), answer(command));
 }
 
 #[test]
 #[ignore]
 fn large_addition() {
     let command = "What is 123 plus 45678?";
-    assert_eq!(Some(45801), WordProblem::new(command).answer());
+    assert_eq!(Some(45801), answer(command));
 }
 
 #[test]
 #[ignore]
 fn subtraction() {
     let command = "What is 4 minus -12?";
-    assert_eq!(Some(16), WordProblem::new(command).answer());
+    assert_eq!(Some(16), answer(command));
 }
 
 #[test]
 #[ignore]
 fn multiplication() {
     let command = "What is -3 multiplied by 25?";
-    assert_eq!(Some(-75), WordProblem::new(command).answer());
+    assert_eq!(Some(-75), answer(command));
 }
 
 #[test]
 #[ignore]
 fn division() {
     let command = "What is 33 divided by -3?";
-    assert_eq!(Some(-11), WordProblem::new(command).answer());
+    assert_eq!(Some(-11), answer(command));
 }
 
 #[test]
 #[ignore]
 fn multiple_additions() {
     let command = "What is 1 plus 1 plus 1?";
-    assert_eq!(Some(3), WordProblem::new(command).answer());
+    assert_eq!(Some(3), answer(command));
 }
 
 #[test]
 #[ignore]
 fn addition_and_subtraction() {
     let command = "What is 1 plus 5 minus -2?";
-    assert_eq!(Some(8), WordProblem::new(command).answer());
+    assert_eq!(Some(8), answer(command));
 }
 
 #[test]
 #[ignore]
 fn multiple_subtraction() {
     let command = "What is 20 minus 4 minus 13?";
-    assert_eq!(Some(3), WordProblem::new(command).answer());
+    assert_eq!(Some(3), answer(command));
 }
 
 #[test]
 #[ignore]
 fn subtraction_then_addition() {
     let command = "What is 17 minus 6 plus 3?";
-    assert_eq!(Some(14), WordProblem::new(command).answer());
+    assert_eq!(Some(14), answer(command));
 }
 
 #[test]
 #[ignore]
 fn multiple_multiplications() {
     let command = "What is 2 multiplied by -2 multiplied by 3?";
-    assert_eq!(Some(-12), WordProblem::new(command).answer());
+    assert_eq!(Some(-12), answer(command));
 }
 
 #[test]
 #[ignore]
 fn addition_and_multiplication() {
     let command = "What is -3 plus 7 multiplied by -2?";
-    assert_eq!(Some(-8), WordProblem::new(command).answer());
+    assert_eq!(Some(-8), answer(command));
 }
 
 #[test]
 #[ignore]
 fn multiple_divisions() {
     let command = "What is -12 divided by 2 divided by -3?";
-    assert_eq!(Some(2), WordProblem::new(command).answer());
+    assert_eq!(Some(2), answer(command));
 }
 
 #[test]
 #[ignore]
 fn unknown_operation() {
     let command = "What is 52 cubed?";
-    assert!(WordProblem::new(command).answer().is_none());
+    assert!(answer(command).is_none());
 }
 
 #[test]
 #[ignore]
 fn non_math_question() {
     let command = "Who is the President of the United States?";
-    assert!(WordProblem::new(command).answer().is_none());
+    assert!(answer(command).is_none());
 }


### PR DESCRIPTION
The previous API of `WordProblem::new(c).answer()` didn't lend itself
well to failing fast, because we should be able to know at the time of
`new` whether the command is erroneous, instead of having to wait for
`answer`.

Having the function that parses the command immediately return the
`Option` solves this problem.

Closes https://github.com/exercism/rust/issues/644