### PR TITLE
 ensure-stubs-compile: Removed the redundant empty stub check

### DIFF
--- a/_test/ensure-stubs-compile.sh
+++ b/_test/ensure-stubs-compile.sh
@@ -21,9 +21,6 @@ broken=""
 for dir in $changed_exercises; do
   exercise=$(basename "$dir")
 
-  # If src/lib.rs contains any non-comment line that contains any non-spaces,
-  # it probably contains function signatures, and these should compile.
-  if grep -v '^//' $dir/src/lib.rs | grep '\S' > /dev/null; then
     allowed_file=$dir/.meta/ALLOWED_TO_NOT_COMPILE
 
     if [ -f $allowed_file ]; then
@@ -55,7 +52,6 @@ for dir in $changed_exercises; do
     mv $dir/lib.rs.orig $dir/src/lib.rs
     rm -r $dir/tests
     mv $dir/tests.orig $dir/tests
-  fi
 done
 
 if [ -n "$broken" ]; then

--- a/_test/ensure-stubs-compile.sh
+++ b/_test/ensure-stubs-compile.sh
@@ -19,39 +19,39 @@ fi
 broken=""
 
 for dir in $changed_exercises; do
-  exercise=$(basename "$dir")
+	exercise=$(basename "$dir")
 
-    allowed_file=$dir/.meta/ALLOWED_TO_NOT_COMPILE
+	allowed_file=$dir/.meta/ALLOWED_TO_NOT_COMPILE
 
-    if [ -f $allowed_file ]; then
-      echo "$exercise's stub is allowed to not compile"
-      continue
-    fi
+	if [ -f $allowed_file ]; then
+	  echo "$exercise's stub is allowed to not compile"
+	  continue
+	fi
 
-    # Backup tests and stub; this script will modify them.
-    cp -r $dir/tests $dir/tests.orig
-    cp $dir/src/lib.rs $dir/lib.rs.orig
+	# Backup tests and stub; this script will modify them.
+	cp -r $dir/tests $dir/tests.orig
+	cp $dir/src/lib.rs $dir/lib.rs.orig
 
-    # This sed serves two purposes:
-    # First, in Travis CI, we may have already compiled using the example solution.
-    # Edit the src/lib.rs file so that we surely recompile using the stub.
-    # Second, ensures that the stub compiles without warnings.
-    sed -i -e '1i #![deny(warnings)]' "$dir/src/lib.rs"
+	# This sed serves two purposes:
+	# First, in Travis CI, we may have already compiled using the example solution.
+	# Edit the src/lib.rs file so that we surely recompile using the stub.
+	# Second, ensures that the stub compiles without warnings.
+	sed -i -e '1i #![deny(warnings)]' "$dir/src/lib.rs"
 
-    # Deny warnings in the tests that may result from compiling the stubs.
-    # This helps avoid, for example, an overflowing literal warning
-    # that could be caused by a stub with a type that is too small.
-    sed -i -e '1i #![deny(warnings)]' $dir/tests/*.rs
+	# Deny warnings in the tests that may result from compiling the stubs.
+	# This helps avoid, for example, an overflowing literal warning
+	# that could be caused by a stub with a type that is too small.
+	sed -i -e '1i #![deny(warnings)]' $dir/tests/*.rs
 
-    if ! (cd $dir && cargo test --quiet --no-run); then
-      echo "$exercise's stub does not compile; please make it compile or remove all non-commented lines"
-      broken="$broken\n$exercise"
-    fi
+	if ! (cd $dir && cargo test --quiet --no-run); then
+	  echo "$exercise's stub does not compile; please make it compile or remove all non-commented lines"
+	  broken="$broken\n$exercise"
+	fi
 
-    # Restore tests and stub.
-    mv $dir/lib.rs.orig $dir/src/lib.rs
-    rm -r $dir/tests
-    mv $dir/tests.orig $dir/tests
+	# Restore tests and stub.
+	mv $dir/lib.rs.orig $dir/src/lib.rs
+	rm -r $dir/tests
+	mv $dir/tests.orig $dir/tests
 done
 
 if [ -n "$broken" ]; then


### PR DESCRIPTION
Since it is a track policy to not have empty stub files, the check is no longer needed