### PR TITLE
ensure-lib-src-rs-exist: Rephrased the missing stub file message

### DIFF
--- a/_test/ensure-lib-src-rs-exist.sh
+++ b/_test/ensure-lib-src-rs-exist.sh
@@ -18,8 +18,7 @@ for dir in $repo/exercises/*/; do
 	exercise=$(basename "$dir")
 
 	if [ ! -f "$dir/src/lib.rs" ]; then
-		# https://github.com/exercism/rust/pull/270
-		echo "$exercise is missing a src/lib.rs; please create one (an empty file is acceptable)"
+		echo "$exercise is missing a src/lib.rs stub file. Please create the missing file with the template, that is necessary for the exercise, present in it."
 		missing="$missing\n$exercise"
 	else
 		#Check if the stub file is empty


### PR DESCRIPTION
The original message suggests that it is OK to have an empty stub file, which contradicts the current track policy.