### PR TITLE
gigasecond:change chrono crate link

### DIFF
--- a/exercises/gigasecond/.meta/hints.md
+++ b/exercises/gigasecond/.meta/hints.md
@@ -1,1 +1,1 @@
-If you're unsure what operations you can perform on `DateTime<Utc>` take a look at the [chrono crate](https://docs.rs/chrono/0.4.0/chrono/) which is listed as a dependency in the `Cargo.toml` file for this exercise.
+If you're unsure what operations you can perform on `DateTime<Utc>` take a look at the [chrono crate](https://docs.rs/chrono) which is listed as a dependency in the `Cargo.toml` file for this exercise.

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -4,7 +4,7 @@ Calculate the moment when someone has lived for 10^9 seconds.
 
 A gigasecond is 10^9 (1,000,000,000) seconds.
 
-If you're unsure what operations you can perform on `DateTime<Utc>` take a look at the [chrono crate](https://crates.io/crates/chrono) which is listed as a dependency in the `Cargo.toml` file for this exercise.
+If you're unsure what operations you can perform on `DateTime<Utc>` take a look at the [chrono crate](https://docs.rs/chrono) which is listed as a dependency in the `Cargo.toml` file for this exercise.
 
 
 ## Rust Installation

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -4,7 +4,7 @@ Calculate the moment when someone has lived for 10^9 seconds.
 
 A gigasecond is 10^9 (1,000,000,000) seconds.
 
-If you're unsure what operations you can perform on `DateTime<Utc>` take a look at the [chrono crate](https://docs.rs/chrono/0.4.0/chrono/) which is listed as a dependency in the `Cargo.toml` file for this exercise.
+If you're unsure what operations you can perform on `DateTime<Utc>` take a look at the [chrono crate](https://crates.io/crates/chrono) which is listed as a dependency in the `Cargo.toml` file for this exercise.
 
 
 ## Rust Installation


### PR DESCRIPTION
When I used https://docs.rs/chrono/0.4.0/chrono/, the paragraph under
Duration has 3 dead links. Suggest changing this link to
https://crates.io/crates/chrono where the links under the Duration
section work.