### PR TITLE
 pythagorean-triplet: Updated the test suite to the version 1.0.0

### DIFF
--- a/config.json
+++ b/config.json
@@ -150,8 +150,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "math",
-        "option"
+        "math"
       ]
     },
     {

--- a/exercises/pythagorean-triplet/Cargo.toml
+++ b/exercises/pythagorean-triplet/Cargo.toml
@@ -1,5 +1,5 @@
+[dependencies]
+
 [package]
 name = "pythagorean_triplet"
-version = "0.0.0"
-
-[dependencies]
+version = "1.0.0"

--- a/exercises/pythagorean-triplet/example.rs
+++ b/exercises/pythagorean-triplet/example.rs
@@ -1,11 +1,19 @@
-pub fn find() -> Option<u32> {
-    for a in 1..1000 {
-        for b in (a + 1)..(1000 - a) {
-            let c = 1000 - (a + b);
+pub fn find(sum: u32) -> Option<Vec<[u32; 3]>> {
+    let mut triplets = vec![];
+
+    for a in 1..sum {
+        for b in (a + 1)..(sum - a) {
+            let c = sum - (a + b);
+
             if a * a + b * b == c * c {
-                return Some(a * b * c);
+                triplets.push([a, b, c]);
             }
         }
     }
-    None
+
+    if triplets.is_empty() {
+        None
+    } else {
+        Some(triplets)
+    }
 }

--- a/exercises/pythagorean-triplet/example.rs
+++ b/exercises/pythagorean-triplet/example.rs
@@ -1,12 +1,14 @@
-pub fn find(sum: u32) -> Vec<[u32; 3]> {
-    let mut triplets = vec![];
+use std::collections::HashSet;
+
+pub fn find(sum: u32) -> HashSet<[u32; 3]> {
+    let mut triplets = HashSet::new();
 
     for a in 1..sum {
         for b in (a + 1)..(sum - a) {
             let c = sum - (a + b);
 
             if a * a + b * b == c * c {
-                triplets.push([a, b, c]);
+                triplets.insert([a, b, c]);
             }
         }
     }

--- a/exercises/pythagorean-triplet/example.rs
+++ b/exercises/pythagorean-triplet/example.rs
@@ -1,4 +1,4 @@
-pub fn find(sum: u32) -> Option<Vec<[u32; 3]>> {
+pub fn find(sum: u32) -> Vec<[u32; 3]> {
     let mut triplets = vec![];
 
     for a in 1..sum {
@@ -11,9 +11,5 @@ pub fn find(sum: u32) -> Option<Vec<[u32; 3]>> {
         }
     }
 
-    if triplets.is_empty() {
-        None
-    } else {
-        Some(triplets)
-    }
+    triplets
 }

--- a/exercises/pythagorean-triplet/src/lib.rs
+++ b/exercises/pythagorean-triplet/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn find(sum: u32) -> Option<Vec<[u32; 3]>> {
-    unimplemented!("Given the sum {}, return all possible Pythagorean triplets, which produce the said sum, or None if there are no such triplets. Note that you are expected to return triplets in [a, b, c] order, where a < b < c", sum);
+pub fn find(sum: u32) -> Vec<[u32; 3]> {
+    unimplemented!("Given the sum {}, return all possible Pythagorean triplets, which produce the said sum, or an empty Vec if there are no such triplets. Note that you are expected to return triplets in [a, b, c] order, where a < b < c", sum);
 }

--- a/exercises/pythagorean-triplet/src/lib.rs
+++ b/exercises/pythagorean-triplet/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn find() -> Option<u32> {
+pub fn find(sum: u32) -> Option<Vec<[u32; 3]>> {
     unimplemented!();
 }

--- a/exercises/pythagorean-triplet/src/lib.rs
+++ b/exercises/pythagorean-triplet/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn find(sum: u32) -> Option<Vec<[u32; 3]>> {
-    unimplemented!();
+    unimplemented!("Given the sum {}, return all possible Pythagorean triplets, which produce the said sum, or None if there are no such triplets. Note that you are expected to return triplets in [a, b, c] order, where a < b < c", sum);
 }

--- a/exercises/pythagorean-triplet/src/lib.rs
+++ b/exercises/pythagorean-triplet/src/lib.rs
@@ -1,3 +1,5 @@
-pub fn find(sum: u32) -> Vec<[u32; 3]> {
-    unimplemented!("Given the sum {}, return all possible Pythagorean triplets, which produce the said sum, or an empty Vec if there are no such triplets. Note that you are expected to return triplets in [a, b, c] order, where a < b < c", sum);
+use std::collections::HashSet;
+
+pub fn find(sum: u32) -> HashSet<[u32; 3]> {
+    unimplemented!("Given the sum {}, return all possible Pythagorean triplets, which produce the said sum, or an empty HashSet if there are no such triplets. Note that you are expected to return triplets in [a, b, c] order, where a < b < c", sum);
 }

--- a/exercises/pythagorean-triplet/tests/pythagorean-triplet.rs
+++ b/exercises/pythagorean-triplet/tests/pythagorean-triplet.rs
@@ -2,47 +2,47 @@ extern crate pythagorean_triplet;
 
 use pythagorean_triplet::find;
 
-fn process_tripletswithsum_case(sum: u32, expected: Option<Vec<[u32; 3]>>) {
-    if let Some(expected_triplets) = expected {
-        let triplets = find(sum).unwrap();
+fn process_tripletswithsum_case(sum: u32, expected: Vec<[u32; 3]>) {
+    if !expected.is_empty() {
+        let triplets = find(sum);
 
         assert!(
-            expected_triplets
+            expected
                 .iter()
                 .all(|expected_triplet| triplets.contains(expected_triplet))
         );
     } else {
-        assert!(find(sum).is_none());
+        assert!(find(sum).is_empty());
     }
 }
 
 #[test]
 fn test_triplets_whose_sum_is_12() {
-    process_tripletswithsum_case(12, Some(vec![[3, 4, 5]]));
+    process_tripletswithsum_case(12, vec![[3, 4, 5]]);
 }
 
 #[test]
 #[ignore]
 fn test_triplets_whose_sum_is_108() {
-    process_tripletswithsum_case(108, Some(vec![[27, 36, 45]]));
+    process_tripletswithsum_case(108, vec![[27, 36, 45]]);
 }
 
 #[test]
 #[ignore]
 fn test_triplets_whose_sum_is_1000() {
-    process_tripletswithsum_case(1000, Some(vec![[200, 375, 425]]));
+    process_tripletswithsum_case(1000, vec![[200, 375, 425]]);
 }
 
 #[test]
 #[ignore]
 fn test_no_matching_triplets_for_1001() {
-    process_tripletswithsum_case(1001, None);
+    process_tripletswithsum_case(1001, vec![]);
 }
 
 #[test]
 #[ignore]
 fn test_returns_all_matching_triplets() {
-    process_tripletswithsum_case(90, Some(vec![[9, 40, 41], [15, 36, 39]]));
+    process_tripletswithsum_case(90, vec![[9, 40, 41], [15, 36, 39]]);
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn test_returns_all_matching_triplets() {
 fn test_several_matching_triplets() {
     process_tripletswithsum_case(
         840,
-        Some(vec![
+        vec![
             [40, 399, 401],
             [56, 390, 394],
             [105, 360, 375],
@@ -59,7 +59,7 @@ fn test_several_matching_triplets() {
             [168, 315, 357],
             [210, 280, 350],
             [240, 252, 348],
-        ]),
+        ],
     );
 }
 
@@ -68,12 +68,12 @@ fn test_several_matching_triplets() {
 fn test_triplets_for_large_number() {
     process_tripletswithsum_case(
         30000,
-        Some(vec![
+        vec![
             [1200, 14375, 14425],
             [1875, 14000, 14125],
             [5000, 12000, 13000],
             [6000, 11250, 12750],
             [7500, 10000, 12500],
-        ]),
+        ],
     );
 }

--- a/exercises/pythagorean-triplet/tests/pythagorean-triplet.rs
+++ b/exercises/pythagorean-triplet/tests/pythagorean-triplet.rs
@@ -1,18 +1,17 @@
 extern crate pythagorean_triplet;
 
 use pythagorean_triplet::find;
+use std::{collections::HashSet, iter::FromIterator};
 
 fn process_tripletswithsum_case(sum: u32, expected: Vec<[u32; 3]>) {
-    if !expected.is_empty() {
-        let triplets = find(sum);
+    let triplets = find(sum);
 
-        assert!(
-            expected
-                .iter()
-                .all(|expected_triplet| triplets.contains(expected_triplet))
-        );
+    if !expected.is_empty() {
+        let expected = HashSet::from_iter(expected.iter().cloned());
+
+        assert_eq!(expected, triplets);
     } else {
-        assert!(find(sum).is_empty());
+        assert!(triplets.is_empty());
     }
 }
 

--- a/exercises/pythagorean-triplet/tests/pythagorean-triplet.rs
+++ b/exercises/pythagorean-triplet/tests/pythagorean-triplet.rs
@@ -1,6 +1,79 @@
 extern crate pythagorean_triplet;
 
+use pythagorean_triplet::find;
+
+fn process_tripletswithsum_case(sum: u32, expected: Option<Vec<[u32; 3]>>) {
+    if let Some(expected_triplets) = expected {
+        let triplets = find(sum).unwrap();
+
+        assert!(
+            expected_triplets
+                .iter()
+                .all(|expected_triplet| triplets.contains(expected_triplet))
+        );
+    } else {
+        assert!(find(sum).is_none());
+    }
+}
+
 #[test]
-fn test_answer() {
-    assert_eq!(pythagorean_triplet::find(), Some(31875000));
+fn test_several_matching_triplets() {
+    process_tripletswithsum_case(
+        840,
+        Some(vec![
+            [40, 399, 401],
+            [56, 390, 394],
+            [105, 360, 375],
+            [120, 350, 370],
+            [140, 336, 364],
+            [168, 315, 357],
+            [210, 280, 350],
+            [240, 252, 348],
+        ]),
+    );
+}
+
+#[test]
+#[ignore]
+fn test_returns_all_matching_triplets() {
+    process_tripletswithsum_case(90, Some(vec![[9, 40, 41], [15, 36, 39]]));
+}
+
+#[test]
+#[ignore]
+fn test_triplets_whose_sum_is_108() {
+    process_tripletswithsum_case(108, Some(vec![[27, 36, 45]]));
+}
+
+#[test]
+#[ignore]
+fn test_triplets_for_large_number() {
+    process_tripletswithsum_case(
+        30000,
+        Some(vec![
+            [1200, 14375, 14425],
+            [1875, 14000, 14125],
+            [5000, 12000, 13000],
+            [6000, 11250, 12750],
+            [7500, 10000, 12500],
+        ]),
+    );
+}
+
+#[test]
+#[ignore]
+fn test_no_matching_triplets_for_1001() {
+    process_tripletswithsum_case(1001, None);
+}
+
+#[test]
+#[ignore]
+fn test_triplets_whose_sum_is_1000() {
+    process_tripletswithsum_case(1000, Some(vec![[200, 375, 425]]));
+}
+
+#[test]
+#[ignore]
+fn test_triplets_whose_sum_is_12() {
+    process_tripletswithsum_case(12, Some(vec![[3, 4, 5]]));
 }

--- a/exercises/pythagorean-triplet/tests/pythagorean-triplet.rs
+++ b/exercises/pythagorean-triplet/tests/pythagorean-triplet.rs
@@ -17,6 +17,36 @@ fn process_tripletswithsum_case(sum: u32, expected: Option<Vec<[u32; 3]>>) {
 }
 
 #[test]
+fn test_triplets_whose_sum_is_12() {
+    process_tripletswithsum_case(12, Some(vec![[3, 4, 5]]));
+}
+
+#[test]
+#[ignore]
+fn test_triplets_whose_sum_is_108() {
+    process_tripletswithsum_case(108, Some(vec![[27, 36, 45]]));
+}
+
+#[test]
+#[ignore]
+fn test_triplets_whose_sum_is_1000() {
+    process_tripletswithsum_case(1000, Some(vec![[200, 375, 425]]));
+}
+
+#[test]
+#[ignore]
+fn test_no_matching_triplets_for_1001() {
+    process_tripletswithsum_case(1001, None);
+}
+
+#[test]
+#[ignore]
+fn test_returns_all_matching_triplets() {
+    process_tripletswithsum_case(90, Some(vec![[9, 40, 41], [15, 36, 39]]));
+}
+
+#[test]
+#[ignore]
 fn test_several_matching_triplets() {
     process_tripletswithsum_case(
         840,
@@ -35,18 +65,6 @@ fn test_several_matching_triplets() {
 
 #[test]
 #[ignore]
-fn test_returns_all_matching_triplets() {
-    process_tripletswithsum_case(90, Some(vec![[9, 40, 41], [15, 36, 39]]));
-}
-
-#[test]
-#[ignore]
-fn test_triplets_whose_sum_is_108() {
-    process_tripletswithsum_case(108, Some(vec![[27, 36, 45]]));
-}
-
-#[test]
-#[ignore]
 fn test_triplets_for_large_number() {
     process_tripletswithsum_case(
         30000,
@@ -58,22 +76,4 @@ fn test_triplets_for_large_number() {
             [7500, 10000, 12500],
         ]),
     );
-}
-
-#[test]
-#[ignore]
-fn test_no_matching_triplets_for_1001() {
-    process_tripletswithsum_case(1001, None);
-}
-
-#[test]
-#[ignore]
-fn test_triplets_whose_sum_is_1000() {
-    process_tripletswithsum_case(1000, Some(vec![[200, 375, 425]]));
-}
-
-#[test]
-#[ignore]
-fn test_triplets_whose_sum_is_12() {
-    process_tripletswithsum_case(12, Some(vec![[3, 4, 5]]));
 }


### PR DESCRIPTION
Updates the ` pythagorean-triplet` according to the latest canonical-data.

The canonical-data introduced the `sum` input parameter, therefore the stub template is updated alongside with the test suite and the example solution.

Closes #712 