### PR TITLE
exercise crate: Made configure subcommand handle null 'unlocked_by' field

### DIFF
--- a/util/exercise/Cargo.lock
+++ b/util/exercise/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "exercise"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/util/exercise/Cargo.toml
+++ b/util/exercise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exercise"
-version = "1.3.0"
+version = "1.3.1"
 description = "An utility for creating or updating the exercises on the Exercism Rust track"
 
 [dependencies]

--- a/util/exercise/src/cmd/configure.rs
+++ b/util/exercise/src/cmd/configure.rs
@@ -34,7 +34,7 @@ fn get_user_config(exercise_name: &str, config_content: &Value) -> Result<Value>
             if let Value::String(s) = get!(existing_config, "unlocked_by") {
                 s
             } else {
-                "none"
+                "null"
             }
         } else {
             "hello-world"

--- a/util/exercise/src/cmd/configure.rs
+++ b/util/exercise/src/cmd/configure.rs
@@ -29,8 +29,6 @@ fn get_user_config(exercise_name: &str, config_content: &Value) -> Result<Value>
         Uuid::new_v4().to_hyphenated().to_string()
     };
 
-    let core = false;
-
     let unlocked_by: Option<String> = loop {
         let default_value = if let Some(existing_config) = existing_config {
             get!(existing_config, "unlocked_by")
@@ -52,7 +50,7 @@ fn get_user_config(exercise_name: &str, config_content: &Value) -> Result<Value>
         if user_input.is_empty() {
             break default_value;
         } else if user_input == "null" {
-            break None::<String>
+            break None::<String>;
         } else if !get!(config_content, "exercises", as_array)
             .iter()
             .any(|exercise| exercise["slug"] == user_input)
@@ -64,6 +62,8 @@ fn get_user_config(exercise_name: &str, config_content: &Value) -> Result<Value>
             break Some(user_input);
         };
     };
+
+    let core = unlocked_by.is_none();
 
     let difficulty = loop {
         let unlocked_by_difficulty = match unlocked_by {

--- a/util/exercise/src/cmd/configure.rs
+++ b/util/exercise/src/cmd/configure.rs
@@ -31,32 +31,29 @@ fn get_user_config(exercise_name: &str, config_content: &Value) -> Result<Value>
 
     let unlocked_by: Option<String> = loop {
         let default_value = if let Some(existing_config) = existing_config {
-            get!(existing_config, "unlocked_by")
-                .as_str()
-                .map(|s| s.to_string())
+            if let Value::String(s) = get!(existing_config, "unlocked_by") {
+                s
+            } else {
+                "none"
+            }
         } else {
-            Some("hello-world".to_string())
+            "hello-world"
         };
 
         let user_input = get_user_input(&format!(
             "Exercise slug which unlocks this (blank for '{}'): ",
-            if let Some(ref value) = default_value {
-                value
-            } else {
-                "null"
-            }
+            default_value
         ))?;
 
         if user_input.is_empty() {
-            break default_value;
+            break Some(default_value.to_string());
         } else if user_input == "null" {
-            break None::<String>;
+            break None;
         } else if !get!(config_content, "exercises", as_array)
             .iter()
             .any(|exercise| exercise["slug"] == user_input)
         {
             println!("{} is not an existing exercise slug", user_input);
-
             continue;
         } else {
             break Some(user_input);


### PR DESCRIPTION
This PR adds the handling of the `null` field, read both from `config.json` and user input, by the `configure` subcommand.

Closes #719