### PR TITLE
docs: rm headings from INSTALLATION, LEARNING, and RESOURCES

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,1 @@
-## Installation
-
 Methods for installing Rust change as the language evolves. To get up-to-date installation instructions head to the [Rust homepage](https://www.rust-lang.org/) and click the "Install Rust" link.

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,5 +1,3 @@
-## Learning Rust
-
 * [The Rust Programming Language](https://doc.rust-lang.org/book/2018-edition/) is a great resource for getting started with Rust as well as diving deeper into specific features of Rust.
 * [Rust by Example](https://doc.rust-lang.org/stable/rust-by-example/) shows you examples of the most common things you will be writing in Rust.
 * [Into_rust()](http://intorust.com/) "Screencasts for learning Rust."

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,5 +1,3 @@
-## Recommended Learning Resources
-
 * [The Rust Programming Language](https://doc.rust-lang.org/book/2018-edition/) is a great resource for getting started with Rust as well as diving deeper into specific features of Rust.
 * [Rust by Example](https://doc.rust-lang.org/stable/rust-by-example/) shows you examples of the most common things you will be writing in Rust.
 * The [Rust API Documentation](http://doc.rust-lang.org/std/) can be used to discover new methods and how they work.


### PR DESCRIPTION
These are used in the following:
https://exercism.io/tracks/rust/installation
https://exercism.io/tracks/rust/learning
https://exercism.io/tracks/rust/resources

There is a nice page header on those pages that say "Installing Rust",
"Learning Rust", and "Useful Rust Resources" respectively.

Particularly useful because the previous header of RESOURCES was
"Recommended Learning Resources" which is against the purpose of
RESOURCES as stated in:

https://github.com/exercism/docs/blob/master/language-tracks/documentation/for-consumers.md#file-structure
https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md#improve-product-facing-copydocumentation