### PR TITLE
saddle-points: Ignore order of results

### DIFF
--- a/exercises/saddle-points/tests/saddle-points.rs
+++ b/exercises/saddle-points/tests/saddle-points.rs
@@ -110,7 +110,7 @@ fn single_column_matrix() {
         vec![4],
         vec![1],
     ];
-    assert_eq!(vec![(1, 0), (3, 0)], find_saddle_points(&input));
+    assert_eq!(vec![(1, 0), (3, 0)], find_sorted_saddle_points(&input));
 }
 
 #[test]
@@ -119,6 +119,6 @@ fn single_row_matrix() {
     let input = vec![
         vec![2, 5, 3, 5],
     ];
-    assert_eq!(vec![(0, 1), (0, 3)], find_saddle_points(&input));
+    assert_eq!(vec![(0, 1), (0, 3)], find_sorted_saddle_points(&input));
 }
 


### PR DESCRIPTION
Some test cases could still reject results if the order was different
than expected. These are now using the helper function
find_sorted_saddle_points.