### PR TITLE
clock: Add test for exactly -60 minutes.

### DIFF
--- a/exercises/clock/Cargo.toml
+++ b/exercises/clock/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "clock"
-version = "2.3.0"
+version = "2.4.0"
 
 [dependencies]

--- a/exercises/clock/tests/clock.rs
+++ b/exercises/clock/tests/clock.rs
@@ -109,6 +109,12 @@ fn test_negative_minutes_roll_over_continuously() {
 
 #[test]
 #[ignore]
+fn test_negative_sixty_minutes_is_prev_hour() {
+    assert_eq!(Clock::new(2, -60).to_string(), "01:00");
+}
+
+#[test]
+#[ignore]
 fn test_negative_hour_and_minutes_both_roll_over() {
     assert_eq!(Clock::new(-25, -160).to_string(), "20:20");
 }


### PR DESCRIPTION
I ran into a solution that would give the wrong solution if the minutes were exactly a multiple of 60 and negative.