### PR TITLE
accumulate: correct README function links

### DIFF
--- a/exercises/accumulate/.meta/hints.md
+++ b/exercises/accumulate/.meta/hints.md
@@ -2,8 +2,8 @@
 
 It may help to look at the Fn\* traits:
 [Fn](https://doc.rust-lang.org/std/ops/trait.Fn.html),
-[FnMut](https://doc.rust-lang.org/std/ops/trait.Fn.html) and
-[FnOnce](https://doc.rust-lang.org/std/ops/trait.Fn.html).
+[FnMut](https://doc.rust-lang.org/std/ops/trait.FnMut.html) and
+[FnOnce](https://doc.rust-lang.org/std/ops/trait.FnOnce.html).
 
 Help with passing a closure into a function may be found in
 the ["closures as input parameters" section](https://doc.rust-lang.org/stable/rust-by-example/fn/closures/input_parameters.html) of

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -29,8 +29,8 @@ Solve this one yourself using other basic tools instead.
 
 It may help to look at the Fn\* traits:
 [Fn](https://doc.rust-lang.org/std/ops/trait.Fn.html),
-[FnMut](https://doc.rust-lang.org/std/ops/trait.Fn.html) and
-[FnOnce](https://doc.rust-lang.org/std/ops/trait.Fn.html).
+[FnMut](https://doc.rust-lang.org/std/ops/trait.FnMut.html) and
+[FnOnce](https://doc.rust-lang.org/std/ops/trait.FnOnce.html).
 
 Help with passing a closure into a function may be found in
 the ["closures as input parameters" section](https://doc.rust-lang.org/stable/rust-by-example/fn/closures/input_parameters.html) of


### PR DESCRIPTION
Correct the links to `FnMut` and `FnOnce` to be their documentation
pages rather than the generic `Fn` documentation page.