### PR TITLE
clippy: Use field init shorthand

### DIFF
--- a/exercises/crypto-square/example.rs
+++ b/exercises/crypto-square/example.rs
@@ -89,8 +89,8 @@ struct SquareIndexer {
 impl SquareIndexer {
     fn new(rows: usize, cols: usize) -> SquareIndexer {
         SquareIndexer {
-            rows: rows,
-            cols: cols,
+            rows,
+            cols,
             cur_row: 0,
             cur_col: 0,
             max_value: rows * cols,

--- a/exercises/decimal/example.rs
+++ b/exercises/decimal/example.rs
@@ -20,8 +20,8 @@ pub struct Decimal {
 impl Decimal {
     fn new(digits: BigInt, decimal_index: usize) -> Decimal {
         let mut value = Decimal {
-            digits: digits,
-            decimal_index: decimal_index,
+            digits,
+            decimal_index,
         };
         value.reduce();
         value

--- a/exercises/pascals-triangle/example.rs
+++ b/exercises/pascals-triangle/example.rs
@@ -5,7 +5,7 @@ pub struct PascalsTriangle {
 impl PascalsTriangle {
     pub fn new(row_count: u32) -> Self {
         PascalsTriangle {
-            row_count: row_count,
+            row_count,
         }
     }
 

--- a/exercises/poker/example.rs
+++ b/exercises/poker/example.rs
@@ -259,7 +259,7 @@ impl<'a> Hand<'a> {
         cards.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Less));
         if cards.len() == 5 {
             Some(Hand {
-                source: source,
+                source,
                 cards: [cards[0], cards[1], cards[2], cards[3], cards[4]],
                 hand_type: try_opt!(PokerHand::analyze(&cards)),
             })

--- a/exercises/queen-attack/example.rs
+++ b/exercises/queen-attack/example.rs
@@ -22,7 +22,7 @@ impl ChessPiece for Queen {
 
 impl Queen {
     pub fn new(position: ChessPosition) -> Queen {
-        Queen { position: position }
+        Queen { position }
     }
 }
 
@@ -35,8 +35,8 @@ pub struct ChessPosition {
 impl ChessPosition {
     pub fn new(rank: i8, file: i8) -> Option<Self> {
         let position = ChessPosition {
-            rank: rank,
-            file: file,
+            rank,
+            file,
         };
 
         if position.is_valid() {

--- a/exercises/rectangles/example.rs
+++ b/exercises/rectangles/example.rs
@@ -149,10 +149,10 @@ fn scan_connected(area: &Area) -> Connections {
                     conns.lines.insert(Line{x1: prev.clone(), y1: y, x2: x, y2: y});
                 }
                 if let Some(last) = connected.last() {
-                    let cf = conns.points.get_mut(&Point{x: last.clone(), y: y}).unwrap();
+                    let cf = conns.points.get_mut(&Point{x: last.clone(), y}).unwrap();
                     *cf = *cf | CONN_RIGHT;
                 }
-                let cf = conns.points.entry(Point{x: x, y: y}).or_insert(0);
+                let cf = conns.points.entry(Point{x, y}).or_insert(0);
                 if !connected.is_empty() {
                     *cf = *cf | CONN_LEFT;
                 }

--- a/exercises/robot-simulator/example.rs
+++ b/exercises/robot-simulator/example.rs
@@ -34,7 +34,7 @@ struct Position {
 
 impl Position {
     fn new(x: i32, y: i32) -> Self {
-        Position { x: x, y: y }
+        Position { x, y }
     }
 
     fn advance(&self, direction: &Direction) -> Self {
@@ -60,8 +60,8 @@ impl Robot {
 
     fn build(position: Position, direction: Direction) -> Self {
         Robot {
-            position: position,
-            direction: direction,
+            position,
+            direction,
         }
     }
 

--- a/exercises/roman-numerals/example.rs
+++ b/exercises/roman-numerals/example.rs
@@ -42,6 +42,6 @@ impl fmt::Display for Roman {
 
 impl Roman {
     fn new(num: usize) -> Roman {
-        Roman { num: num }
+        Roman { num }
     }
 }

--- a/exercises/triangle/example.rs
+++ b/exercises/triangle/example.rs
@@ -23,7 +23,7 @@ where
     }
 
     pub fn build(sides: [T; 3]) -> Option<Triangle<T>> {
-        let t = Triangle { sides: sides };
+        let t = Triangle { sides };
 
         if t.valid_sides() {
             Some(t)

--- a/exercises/two-bucket/example.rs
+++ b/exercises/two-bucket/example.rs
@@ -57,13 +57,13 @@ pub fn solve(capacity_1: u8, capacity_2: u8, goal: u8, start_bucket: &Bucket) ->
 
             if bucket_1 == goal {
                 return BucketStats {
-                    moves: moves,
+                    moves,
                     goal_bucket: Bucket::One,
                     other_bucket: bucket_2,
                 };
             } else if bucket_2 == goal {
                 return BucketStats {
-                    moves: moves,
+                    moves,
                     goal_bucket: Bucket::Two,
                     other_bucket: bucket_1,
                 };


### PR DESCRIPTION
Appears that this has been available since Rust 1.17:
https://rust-lang-nursery.github.io/edition-guide/rust-2018/data-types/field-init-shorthand.html

Although I didn't check, surely it's the case that many examples were
written before Rust 1.17 so they didn't get a chance to take advantage.
Since we are long past Rust 1.17, let's take the chance now.

Clippy suggested:
warning: redundant field names in struct initialization
https://travis-ci.org/exercism/rust/builds/456356560
for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#redundant_field_names