### PR TITLE
proverb: Use `&[T]` instead of `Vec<T>`

### DIFF
--- a/exercises/proverb/example.rs
+++ b/exercises/proverb/example.rs
@@ -1,4 +1,4 @@
-pub fn build_proverb(items: Vec<&str>) -> String {
+pub fn build_proverb(items: &[&str]) -> String {
     let mut stanzas = Vec::with_capacity(items.len());
     for index in 0..items.len() {
         if index == items.len() - 1 {

--- a/exercises/proverb/src/lib.rs
+++ b/exercises/proverb/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn build_proverb(list: Vec<&str>) -> String {
+pub fn build_proverb(list: &[&str]) -> String {
     unimplemented!("build a proverb from this list of items: {:?}", list)
 }

--- a/exercises/proverb/tests/proverb.rs
+++ b/exercises/proverb/tests/proverb.rs
@@ -9,7 +9,7 @@ fn test_two_pieces() {
         "For want of a nail the shoe was lost.",
         "And all for the want of a nail.",
     ].join("\n");
-    assert_eq!(build_proverb(input), expected);
+    assert_eq!(build_proverb(&input), expected);
 }
 
 // Notice the change in the last line at three pieces.
@@ -22,7 +22,7 @@ fn test_three_pieces() {
         "For want of a shoe the horse was lost.",
         "And all for the want of a nail.",
     ].join("\n");
-    assert_eq!(build_proverb(input), expected);
+    assert_eq!(build_proverb(&input), expected);
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn test_three_pieces() {
 fn test_one_piece() {
     let input = vec!["nail"];
     let expected = String::from("And all for the want of a nail.");
-    assert_eq!(build_proverb(input), expected);
+    assert_eq!(build_proverb(&input), expected);
 }
 
 #[test]
@@ -38,7 +38,7 @@ fn test_one_piece() {
 fn test_zero_pieces() {
     let input: Vec<&str> = vec![];
     let expected = String::new();
-    assert_eq!(build_proverb(input), expected);
+    assert_eq!(build_proverb(&input), expected);
 }
 
 #[test]
@@ -56,7 +56,7 @@ fn test_full() {
         "For want of a battle the kingdom was lost.",
         "And all for the want of a nail.",
     ].join("\n");
-    assert_eq!(build_proverb(input), expected);
+    assert_eq!(build_proverb(&input), expected);
 }
 
 #[test]
@@ -69,5 +69,5 @@ fn test_three_pieces_modernized() {
         "For want of a soldier the battle was lost.",
         "And all for the want of a pin.",
     ].join("\n");
-    assert_eq!(build_proverb(input), expected);
+    assert_eq!(build_proverb(&input), expected);
 }


### PR DESCRIPTION
Clippy suggested
https://travis-ci.org/exercism/rust/builds/456432005
warning: this argument is passed by value, but not consumed in the function body
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#needless_pass_by_value

This gets its own PR simply because there's a student-facing change, though it is not terribly interesting. So I also don't really find this urgent. I originally thought there would be more student-facing changes, but I suppose that's unlikely if the files I was looking at were all the example solutions.