### PR TITLE
circular-buffer 1.1.0

### DIFF
--- a/exercises/circular-buffer/Cargo.toml
+++ b/exercises/circular-buffer/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "circular-buffer"
-version = "0.0.0"
+version = "1.1.0"


### PR DESCRIPTION
The tests are the same as the initial unversioned version of canonical-data:
https://github.com/exercism/problem-specifications/pull/488

This is because all subsequent changes did not change test content:

1.0.0 (formatting change only):
https://github.com/exercism/problem-specifications/pull/681
1.0.1 (clarify overwrite):
https://github.com/exercism/problem-specifications/pull/892
1.1.0 (move inputs to `input` object):
https://github.com/exercism/problem-specifications/pull/1186

The Rust track already had most of the tests; these mostly add some
clarity around `clear` and addds a test for an `overwrite` following a
`read`.