### PR TITLE
proverb: no-op declare compliance with 1.1.0

### DIFF
--- a/exercises/proverb/Cargo.toml
+++ b/exercises/proverb/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "proverb"
-version = "0.0.0"
+version = "1.1.0"
 
 [dependencies]


### PR DESCRIPTION
Actually, the canonical data was born from the Rust implementation.
https://github.com/exercism/problem-specifications/pull/994

1.1.0 moves inputs to the `input` object.
https://github.com/exercism/problem-specifications/pull/1157

The Rust track has all the canonical tests, although in a different
order. Reviewers should indicate whether an ordering change in the Rust
tests is desired.