### PR TITLE
two-bucket: declare compliance with 1.4.0 by changing descriptions

### DIFF
--- a/exercises/two-bucket/Cargo.toml
+++ b/exercises/two-bucket/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "two-bucket"
-version = "1.0.0"
+version = "1.4.0"

--- a/exercises/two-bucket/tests/two-bucket.rs
+++ b/exercises/two-bucket/tests/two-bucket.rs
@@ -55,7 +55,7 @@ fn test_case_4() {
 
 #[test]
 #[ignore]
-fn test_case_5() {
+fn goal_equal_to_start_bucket() {
     assert_eq!(
         solve(1, 3, 3, &Bucket::Two),
         BucketStats {
@@ -68,7 +68,7 @@ fn test_case_5() {
 
 #[test]
 #[ignore]
-fn test_case_6() {
+fn goal_equal_to_other_bucket() {
     assert_eq!(
         solve(2, 3, 3, &Bucket::One),
         BucketStats {


### PR DESCRIPTION
Note that two-bucket was added to the Rust track at
https://github.com/exercism/rust/pull/375
At the time it declared 1.0.0 compliance, but was actually compliant
with 1.2.0 already!

Further updates to 1.3.0 and 1.4.0 require no action on the Rust track's
part.

1.0.1: Fix exercise name
https://github.com/exercism/problem-specifications/pull/715

Unversioned(!): Change descriptions
https://github.com/exercism/problem-specifications/pull/716
(Our descriptions are no better or worse, so might as well keep them)

1.1.0: Add cases where goal equals one bucket's capacity
https://github.com/exercism/problem-specifications/pull/763
Rust already had these cases, so just update the descriptions

1.2.0: Fix a test case added in 1.1.0
https://github.com/exercism/problem-specifications/issues/911
https://github.com/exercism/problem-specifications/pull/941
Rust already had the correct values, so no action.

1.3.0: move inputs to `input` object
https://github.com/exercism/problem-specifications/pull/1084

1.4.0: rename JSON keys to camelCase
https://github.com/exercism/problem-specifications/pull/1136