### PR TITLE
exercise crate: Added a check for a property during a recursive exercise update

### DIFF
--- a/util/exercise/Cargo.lock
+++ b/util/exercise/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "exercise"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/util/exercise/Cargo.toml
+++ b/util/exercise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exercise"
-version = "1.3.1"
+version = "1.3.2"
 description = "An utility for creating or updating the exercises on the Exercism Rust track"
 
 [dependencies]

--- a/util/exercise/src/cmd/update.rs
+++ b/util/exercise/src/cmd/update.rs
@@ -72,7 +72,9 @@ fn get_diffs(
         }
     }
 
-    generate_diffs(&case, &tests_content, diffs, use_maplit)?;
+    if case.get("property").is_some() {
+        generate_diffs(&case, &tests_content, diffs, use_maplit)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Adds a check for the `property` field during the traversal of the `canonical-data` for cases, which only have subcases, but no actual cases (for instance `grep` exercise)