### PR TITLE
 leap: Updated exercise to 1.4.0 version

### DIFF
--- a/exercises/leap/Cargo.toml
+++ b/exercises/leap/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "leap"
-version = "1.0.0"
+version = "1.4.0"

--- a/exercises/leap/example.rs
+++ b/exercises/leap/example.rs
@@ -1,4 +1,4 @@
-pub fn is_leap_year(year: i32) -> bool {
+pub fn is_leap_year(year: u64) -> bool {
     let has_factor = |n| year % n == 0;
     has_factor(4) && (!has_factor(100) || has_factor(400))
 }

--- a/exercises/leap/src/lib.rs
+++ b/exercises/leap/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn is_leap_year(year: i32) -> bool {
+pub fn is_leap_year(year: u64) -> bool {
     unimplemented!("true if {} is a leap year", year)
 }

--- a/exercises/leap/tests/leap.rs
+++ b/exercises/leap/tests/leap.rs
@@ -1,6 +1,6 @@
 extern crate leap;
 
-fn process_leapyear_case(year: i32, expected: bool) {
+fn process_leapyear_case(year: u64, expected: bool) {
     assert_eq!(leap::is_leap_year(year), expected);
 }
 

--- a/exercises/leap/tests/leap.rs
+++ b/exercises/leap/tests/leap.rs
@@ -1,8 +1,36 @@
 extern crate leap;
 
+fn process_leapyear_case(year: i32, expected: bool) {
+    assert_eq!(leap::is_leap_year(year), expected);
+}
+
 #[test]
-fn test_vanilla_leap_year() {
-    assert_eq!(leap::is_leap_year(1996), true);
+fn test_year_divisible_by_4_not_divisible_by_100_leap_year() {
+    process_leapyear_case(1996, true);
+}
+
+#[test]
+#[ignore]
+fn test_year_not_divisible_by_4_common_year() {
+    process_leapyear_case(2015, false);
+}
+
+#[test]
+#[ignore]
+fn test_year_divisible_by_200_not_divisible_by_400_common_year() {
+    process_leapyear_case(1800, false);
+}
+
+#[test]
+#[ignore]
+fn test_year_divisible_by_100_not_divisible_by_400_common_year() {
+    process_leapyear_case(2100, false);
+}
+
+#[test]
+#[ignore]
+fn test_year_divisible_by_400_leap_year() {
+    process_leapyear_case(2000, true);
 }
 
 #[test]


### PR DESCRIPTION
This PR syncs the `leap` exercise with the `problem-specifications` repo.

It introduces the following changes:

- Adds all the cases from canonical data. The cases that were present in the suite were not present in the canonical version, so I added new cases in a `test_description_in_lowercase` format. The old cases were not touched (except the one that checked the 1996 year - it was present in canonical data, so I replaced it with the formatted case). Perhaps some old test cases could be deleted?

- Replaced `i32` argument type with `u64` - no negative years are expected, so I thought it would make sense

Relevent PR: https://github.com/exercism/problem-specifications/pull/1359