### PR TITLE
Fix pythagorean-triplet readme, in accordance to the updated tests

### DIFF
--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -19,9 +19,9 @@ For example,
 3**2 + 4**2 = 9 + 16 = 25 = 5**2.
 ```
 
-There exists exactly one Pythagorean triplet for which a + b + c = 1000.
+Given an input integer N, find all Pythagorean triplets for which `a + b + c = N`.
 
-Find the product a * b * c.
+For example, with N = 1000, there is exactly one Pythagorean triplet for which `a + b + c = 1000`: `{200, 375, 425}`.
 
 ## Rust Installation
 


### PR DESCRIPTION
This is as described in https://github.com/exercism/problem-specifications/pull/1395

The current README will really confuse non math-savvy students, as it asked to find `a*b*c`, while the tests actually check for the triplets.

Change it to asks for the triplet explicitly. Give the answer for N = 1000 as it's also spoiled in the test file ;)