### PR TITLE
binary-search 1.3.0: test for when left and right bounds cross

### DIFF
--- a/exercises/binary-search/Cargo.toml
+++ b/exercises/binary-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary-search"
-version = "1.2.0"
+version = "1.3.0"
 
 [dependencies]
 

--- a/exercises/binary-search/tests/binary-search.rs
+++ b/exercises/binary-search/tests/binary-search.rs
@@ -81,6 +81,12 @@ fn nothing_is_included_in_an_empty_array() {
 
 #[test]
 #[ignore]
+fn nothing_is_found_when_the_left_and_right_bounds_cross() {
+    assert_eq!(find(&[1, 2], 0), None);
+}
+
+#[test]
+#[ignore]
 #[cfg(feature = "generic")]
 fn works_for_arrays() {
     assert_eq!(find([6], 6), Some(0));


### PR DESCRIPTION
this test can catch a solution that explicitly checks for an empty array
but fails to check if the bounds cross

https://github.com/exercism/problem-specifications/pull/1399