### PR TITLE
wordy 1.5.0: Test question `What is?` with no operands or operators

### DIFF
--- a/exercises/wordy/Cargo.toml
+++ b/exercises/wordy/Cargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "wordy"
-version = "1.4.0"
+version = "1.5.0"

--- a/exercises/wordy/tests/wordy.rs
+++ b/exercises/wordy/tests/wordy.rs
@@ -122,8 +122,15 @@ fn non_math_question() {
 
 #[test]
 #[ignore]
-fn reject_incomplete_problem() {
+fn reject_problem_missing_an_operand() {
     let command = "What is 1 plus?";
+    assert!(answer(command).is_none());
+}
+
+#[test]
+#[ignore]
+fn reject_problem_with_no_operands_or_operators() {
+    let command = "What is?";
     assert!(answer(command).is_none());
 }
 


### PR DESCRIPTION
In keeping with [1.3.0][], we want to test that this fails in an
expected way rather than an unexpected way.

[1.3.0]: https://github.com/exercism/problem-specifications/pull/1383

Specifically for Rust, we want to make sure that this results in `None`
rather than accessing an out-of-bounds index due to always assuming that
the inputs will have at least three space-separated elements (of the
form "What is X...?").

https://github.com/exercism/problem-specifications/pull/1401