### PR TITLE
hexadecimal, nucleotide-codons: Add stubs indicating deprecation

### DIFF
--- a/exercises/hexadecimal/src/lib.rs
+++ b/exercises/hexadecimal/src/lib.rs
@@ -1,1 +1,6 @@
+// This exercise is deprecated.
+// Consider working on all-your-base instead.
 
+pub fn hex_to_int(string: &str) -> Option<i64> {
+    unimplemented!("what integer is represented by the base-16 digits {}?", string);
+}

--- a/exercises/nucleotide-codons/src/lib.rs
+++ b/exercises/nucleotide-codons/src/lib.rs
@@ -1,1 +1,32 @@
+// This exercise is deprecated.
+// Consider working on protein-translation instead.
 
+use std::marker::PhantomData;
+
+pub struct CodonsInfo<'a> {
+    // This field is here to make the template compile and not to
+    // complain about unused type lifetime parameter "'a". Once you start
+    // solving the exercise, delete this field and the 'std::marker::PhantomData'
+    // import.
+    phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> CodonsInfo<'a> {
+    pub fn name_for(&self, codon: &str) -> Result<&'a str, ()> {
+        unimplemented!(
+            "Return the protein name for a '{}' codon or Err, if codon string is invalid",
+            codon
+        );
+    }
+
+    pub fn of_rna(&self, rna: &str) -> Result<Vec<&'a str>, ()> {
+        unimplemented!("Return a list of protein names that correspond to the '{}' RNA string or Err if the RNA string is invalid", rna);
+    }
+}
+
+pub fn parse<'a>(pairs: Vec<(&'a str, &'a str)>) -> CodonsInfo<'a> {
+    unimplemented!(
+        "Construct a new CodonsInfo struct from given pairs: {:?}",
+        pairs
+    );
+}


### PR DESCRIPTION
Needed because https://github.com/exercism/rust/pull/707, and the track
has a policy to not have empty stub files.

hexadecimal: Copied from the example.
nucleotide-codons: Copied from protein-translation.

Since the build on master is broken without this, I regret to inform
that this will be merged as soon as Travis CI passes, but post-merge
review is of course welcome.