### PR TITLE
leap: Remove recommendation to DIY in description

### DIFF
--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -13,9 +13,6 @@ on every year that is evenly divisible by 4
 For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
 year, but 2000 is.
 
-If your language provides a method in the standard library that does
-this look-up, pretend it doesn't exist and implement it yourself.
-
 ## Notes
 
 Though our exercise adopts some very simple rules, there is more to


### PR DESCRIPTION
Leap-year functions don't generally occur in standard libraries.

Is there a single example of a language we have that does this?

If there is one, then that would be the right way to solve this exercise
in that language. Presumably this exercise is primarily placed at the
top of core tracks. We should not encourage to re-implement standard
library functions at that point. But this is a hypothetical argument.

https://github.com/exercism/problem-specifications/pull/1418