### PR TITLE
saddle-points: Updated the identify_all_saddle_points test to be sort-independent

### DIFF
--- a/exercises/saddle-points/tests/saddle-points.rs
+++ b/exercises/saddle-points/tests/saddle-points.rs
@@ -103,6 +103,6 @@ fn identify_all_saddle_points() {
             (2, 1),
             (2, 2)
         ],
-        find_saddle_points(&input)
+        find_sorted_saddle_points(&input)
     );
 }


### PR DESCRIPTION
**saddle-points**: Updated the `identify_all_saddle_points` test to be sort-independent by using the `find_sorted_saddle_points` function.