### PR TITLE
INSTALLATION.md: Replaced the Rust homepage link with the direct link to the installation instructions

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,1 +1,1 @@
-Methods for installing Rust change as the language evolves. To get up-to-date installation instructions head to the [Rust homepage](https://www.rust-lang.org/) and click the "Install Rust" link.
+Methods for installing Rust change as the language evolves. To get up-to-date installation instructions head to the [Rust install page](https://www.rust-lang.org/tools/install).


### PR DESCRIPTION
After the 2018 Edition the Rust site has been redesigned with the "Install Rust" link removed.
To avoid confusion this PR includes a direct link to the installation instructions.