### PR TITLE
Fix link to installation section of the rust book.

### DIFF
--- a/exercises/hello-world/GETTING_STARTED.md
+++ b/exercises/hello-world/GETTING_STARTED.md
@@ -6,7 +6,7 @@ an exact match.
 The following steps assume that you are in the same directory as the exercise.
 
 You must have rust installed.
-Follow the [Installation chapter in the Rust book](https://doc.rust-lang.org/book/2018-edition/ch01-01-installation.html).
+Follow the [Installation chapter in the Rust book](https://doc.rust-lang.org/book/ch01-01-installation.html).
 The [Rust language section](http://exercism.io/languages/rust)
 section from exercism is also useful.
 


### PR DESCRIPTION
Trying out rust for the first time noted that this link was wrong. 

We site at that link says: 
>Installation
>The 2018 edition of the book is no longer distributed with Rust's documentation.
>If you came here via a link or web search, you may want to check out the current version of the book instead.
>If you have an internet connection, you can find a copy distributed with Rust 1.30.