### PR TITLE
saddle-points: Added efficiency notice about vector of vectors

### DIFF
--- a/exercises/saddle-points/.meta/hints.md
+++ b/exercises/saddle-points/.meta/hints.md
@@ -1,0 +1,13 @@
+## Efficiency Notice
+
+This exercise uses a _vector of vectors_ to store the content of matrices. While
+this exercise is designed to help students understand basic concepts about
+vectors, such as indexing, and that nested data types are legal, _vector of
+vectors_ is a suboptimal choice for high-performance matrix algebra and any
+similar efficient processing of larger amounts of data.
+
+The detailed explanation of this inefficiency is beyond the scope of this
+exercise and this learning track in general. This aspect is known as
+[cache locality](https://stackoverflow.com/questions/12065774/why-does-cache-locality-matter-for-array-performance)
+and you can find a good introduction to it by clicking that link if you'd like
+to learn more about details of a modern computer architecture.

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -8,11 +8,11 @@ So say you have a matrix like so:
     0  1  2
   |---------
 0 | 9  8  7
-1 | 5  3  2     <--- saddle point at (1,0)
+1 | 5  3  2     <--- saddle point at column 0, row 1, with value 5
 2 | 6  6  7
 ```
 
-It has a saddle point at (1, 0).
+It has a saddle point at column 0, row 1.
 
 It's called a "saddle point" because it is greater than or equal to
 every element in its row and less than or equal to every element in

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -5,14 +5,14 @@ Detect saddle points in a matrix.
 So say you have a matrix like so:
 
 ```text
-    0  1  2
+    1  2  3
   |---------
-0 | 9  8  7
-1 | 5  3  2     <--- saddle point at column 0, row 1, with value 5
-2 | 6  6  7
+1 | 9  8  7
+2 | 5  3  2     <--- saddle point at column 1, row 2, with value 5
+3 | 6  6  7
 ```
 
-It has a saddle point at column 0, row 1.
+It has a saddle point at column 1, row 2.
 
 It's called a "saddle point" because it is greater than or equal to
 every element in its row and less than or equal to every element in

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -28,6 +28,21 @@ The matrix can have a different number of rows and columns (Non square).
 Note that you may find other definitions of matrix saddle points online,
 but the tests for this exercise follow the above unambiguous definition.
 
+## Efficiency Notice
+
+This exercise uses a _vector of vectors_ to store the content of matrices. While
+this exercise is designed to help students understand basic concepts about
+vectors, such as indexing, and that nested data types are legal, _vector of
+vectors_ is a suboptimal choice for high-performance matrix algebra and any
+similar efficient processing of larger amounts of data.
+
+The detailed explanation of this inefficiency is beyond the scope of this
+exercise and this learning track in general. This aspect is known as
+[cache locality](https://stackoverflow.com/questions/12065774/why-does-cache-locality-matter-for-array-performance)
+and you can find a good introduction to it by clicking that link if you'd like
+to learn more about details of a modern computer architecture.
+
+
 ## Rust Installation
 
 Refer to the [exercism help page][help-page] for Rust installation and learning


### PR DESCRIPTION
In reference to my issue #787 this is proposed notice in the exercise description about inefficiency of _vector of vectors_ and cache locality aspect.

Update to `README.md` seem to pick up some changes from master exercise repository.

I'm open to any suggestions about wording.