### PR TITLE
Update link to macros chapter in Rust book

### DIFF
--- a/exercises/macros/.meta/description.md
+++ b/exercises/macros/.meta/description.md
@@ -8,7 +8,7 @@ What is a macro? [Wikipedia](https://en.wikipedia.org/wiki/Macro_(computer_scien
 
 Illuminating! But to be more concrete, macros are a special syntax which allows you to generate code at compile time. Macros can be used compile-time calculation, but more often they're just another way to abstract your code. For example, you've probably already used `println!()` and `vec![]`. These each take an arbitrary number of arguments, so you can't express them as simple functions. On the other hand, they always expand to some amount of absolutely standard Rust code. If you're interested, you can use the [cargo expand](https://github.com/dtolnay/cargo-expand) subcommand to view the results of macro expansion in your code.
 
-For further information about macros in Rust, The Rust Book has a [good chapter](https://doc.rust-lang.org/book/2018-edition/appendix-04-macros.html) on them.
+For further information about macros in Rust, The Rust Book has a [good chapter](https://doc.rust-lang.org/book/ch19-06-macros.html) on them.
 
 ## Problem Statement
 

--- a/exercises/macros/README.md
+++ b/exercises/macros/README.md
@@ -10,7 +10,7 @@ What is a macro? [Wikipedia](https://en.wikipedia.org/wiki/Macro_(computer_scien
 
 Illuminating! But to be more concrete, macros are a special syntax which allows you to generate code at compile time. Macros can be used compile-time calculation, but more often they're just another way to abstract your code. For example, you've probably already used `println!()` and `vec![]`. These each take an arbitrary number of arguments, so you can't express them as simple functions. On the other hand, they always expand to some amount of absolutely standard Rust code. If you're interested, you can use the [cargo expand](https://github.com/dtolnay/cargo-expand) subcommand to view the results of macro expansion in your code.
 
-For further information about macros in Rust, The Rust Book has a [good chapter](https://doc.rust-lang.org/book/2018-edition/appendix-04-macros.html) on them.
+For further information about macros in Rust, The Rust Book has a [good chapter](https://doc.rust-lang.org/book/ch19-06-macros.html) on them.
 
 ## Problem Statement
 


### PR DESCRIPTION
Thanks for this exercise!
The old link went to a 404 page. I believe this is the correct link — it's the link to the macros chapter of the current book. The old link looked like it was pointing at the appending of a previous version of the book; I think that the macro info must have been promoted to its own chapter in the new book.