### PR TITLE
passio: test fix when reading odd number of bytes

### DIFF
--- a/exercises/paasio/tests/paasio.rs
+++ b/exercises/paasio/tests/paasio.rs
@@ -42,7 +42,7 @@ macro_rules! test_read {
                     chunks_read += 1;
                 }
 
-                assert_eq!(size / CHUNK_SIZE, chunks_read);
+                assert_eq!(size / CHUNK_SIZE + std::cmp::min(1, size % CHUNK_SIZE), chunks_read);
                 // we read once more than the number of chunks, because the final
                 // read returns 0 new bytes
                 assert_eq!(1+chunks_read, reader.reads());
@@ -62,7 +62,7 @@ macro_rules! test_read {
                     chunks_read += 1;
                 }
 
-                assert_eq!(size / CHUNK_SIZE, chunks_read);
+                assert_eq!(size / CHUNK_SIZE + std::cmp::min(1, size % CHUNK_SIZE), chunks_read);
                 // the BufReader should smooth out the reads, collecting into
                 // a buffer and performing only two read operations:
                 // the first collects everything into the buffer,


### PR DESCRIPTION
The error becomes visible when README.md (which is read during the test) has odd number of bytes.

This situation occured with last README.md update 5f23d6af5a2fa3898cd46e2d3c85b5c72d355f6e