### PR TITLE
clock: Modified the add_minutes stub function to take self by reference

### DIFF
--- a/exercises/clock/src/lib.rs
+++ b/exercises/clock/src/lib.rs
@@ -9,7 +9,7 @@ impl Clock {
         );
     }
 
-    pub fn add_minutes(self, minutes: i32) -> Self {
+    pub fn add_minutes(&self, minutes: i32) -> Self {
         unimplemented!("Add {} minutes to existing Clock time", minutes);
     }
 }


### PR DESCRIPTION
There is no need to consume the original value of Clock, when making a new Clock via the `add_minutes` method.