### PR TITLE
README: Added the 'Submitting the solution' section

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -62,6 +62,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -99,6 +99,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -65,6 +65,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -89,6 +89,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -87,6 +87,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -89,6 +89,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -64,6 +64,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -69,6 +69,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -86,6 +86,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -378,6 +378,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -137,6 +137,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -73,6 +73,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -125,6 +125,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -118,6 +118,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -62,6 +62,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -108,6 +108,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -76,6 +76,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -84,6 +84,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -130,6 +130,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -65,6 +65,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/decimal/README.md
+++ b/exercises/decimal/README.md
@@ -78,6 +78,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -110,6 +110,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -74,6 +74,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -99,6 +99,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -72,6 +72,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/dot-dsl/README.md
+++ b/exercises/dot-dsl/README.md
@@ -90,6 +90,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -104,6 +104,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -83,6 +83,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -66,6 +66,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -92,6 +92,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -84,6 +84,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -139,6 +139,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -81,6 +81,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -72,6 +72,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -65,6 +65,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -98,6 +98,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -71,6 +71,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -79,6 +79,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -84,6 +84,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/luhn-from/README.md
+++ b/exercises/luhn-from/README.md
@@ -70,6 +70,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/luhn-trait/README.md
+++ b/exercises/luhn-trait/README.md
@@ -84,6 +84,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -122,6 +122,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/macros/README.md
+++ b/exercises/macros/README.md
@@ -88,6 +88,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -84,6 +84,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -66,6 +66,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/nucleotide-codons/README.md
+++ b/exercises/nucleotide-codons/README.md
@@ -76,6 +76,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -70,6 +70,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -136,6 +136,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/paasio/README.md
+++ b/exercises/paasio/README.md
@@ -79,6 +79,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -90,6 +90,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -66,6 +66,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -99,6 +99,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -72,6 +72,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -75,6 +75,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -86,6 +86,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -75,6 +75,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -73,6 +73,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -87,6 +87,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -99,6 +99,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -74,6 +74,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -81,6 +81,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -84,6 +84,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -116,6 +116,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -75,6 +75,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -73,6 +73,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -121,6 +121,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -76,6 +76,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -87,6 +87,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -73,6 +73,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -85,6 +85,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -100,6 +100,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -88,6 +88,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -81,6 +81,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -101,6 +101,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -141,6 +141,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -106,6 +106,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -97,6 +97,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -78,6 +78,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -87,6 +87,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -136,6 +136,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -114,6 +114,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -83,6 +83,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -81,6 +81,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -75,6 +75,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -66,6 +66,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -122,6 +122,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -108,6 +108,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -87,6 +87,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -83,6 +83,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -89,6 +89,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -69,6 +69,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -125,6 +125,10 @@ To see, if your solution contains some common ineffective use cases, inside the 
 cargo clippy --all-targets
 ```
 
+## Submitting the solution
+
+Generally you should submit all files in which you implemented your solution (`src/lib.rs` in most cases). If you are using any external crates, please consider submitting the `Cargo.toml` file. This will make the review process faster and clearer.
+
 ## Feedback, Issues, Pull Requests
 
 The [exercism/rust](https://github.com/exercism/rust) repository on GitHub is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!


### PR DESCRIPTION
Very often, when using an external crate, the students do not submit the `Cargo.toml` file, which slows the review process. Plus some students try to submit the test suite file.

This PR adds a section to the exercise README, which explains what files need to be submitted.

The READMEs are not regenerated to not clutter the PR. The regeneration will be in the closing commit, in case the PR is approved.