### PR TITLE
Changed "Luhn From" And "Luhn Trait" To Be Unlocked By "Luhn".

### DIFF
--- a/config.json
+++ b/config.json
@@ -174,19 +174,6 @@
       ]
     },
     {
-      "slug": "luhn-from",
-      "uuid": "f9131b5d-91dd-4514-983d-4abc22bb5d5c",
-      "core": false,
-      "unlocked_by": "bob",
-      "difficulty": 4,
-      "topics": [
-        "from_trait",
-        "higher_order_functions",
-        "iterators",
-        "str_to_digits"
-      ]
-    },
-    {
       "slug": "clock",
       "uuid": "543a3ca2-fb9b-4f20-a873-ff23595d41df",
       "core": true,
@@ -739,19 +726,6 @@
       ]
     },
     {
-      "slug": "luhn-trait",
-      "uuid": "c32c0124-873d-45f4-9287-402aea29f129",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 4,
-      "topics": [
-        "custom_trait",
-        "higher_order_functions",
-        "iterators",
-        "str_to_digits"
-      ]
-    },
-    {
       "slug": "wordy",
       "uuid": "620b55bb-058e-4c6f-a966-ced3b41736db",
       "core": false,
@@ -828,6 +802,32 @@
       "unlocked_by": null,
       "difficulty": 7,
       "topics": [
+        "higher_order_functions",
+        "iterators",
+        "str_to_digits"
+      ]
+    },
+    {
+      "slug": "luhn-from",
+      "uuid": "f9131b5d-91dd-4514-983d-4abc22bb5d5c",
+      "core": false,
+      "unlocked_by": "luhn",
+      "difficulty": 4,
+      "topics": [
+        "from_trait",
+        "higher_order_functions",
+        "iterators",
+        "str_to_digits"
+      ]
+    },
+    {
+      "slug": "luhn-trait",
+      "uuid": "c32c0124-873d-45f4-9287-402aea29f129",
+      "core": false,
+      "unlocked_by": "luhn",
+      "difficulty": 4,
+      "topics": [
+        "custom_trait",
         "higher_order_functions",
         "iterators",
         "str_to_digits"


### PR DESCRIPTION
This pull request is part of the [Track Anatomy Project](https://exercism.io/blog/track-anatomy-project). For more on the background there, please see [issue #809](https://github.com/exercism/rust/issues/809) opened by @kytrinyx.

This remedies [issue #4779](https://github.com/exercism/exercism/issues/4779) and logically places the two side exercise, "Luhn From" and "Luhn Trait", to be unlocked by the core exercise, "Luhn".

Your feedback on the technical aspects of this pull request are very welcome here. For questions or discussions about the track anatomy project we have opened [issue #809](https://github.com/exercism/rust/issues/809).