### PR TITLE
 rna-transcription: rename method to_rna() to into_rna(), fixes clippy::wrong_self_convention

### DIFF
--- a/exercises/rna-transcription/.meta/hints.md
+++ b/exercises/rna-transcription/.meta/hints.md
@@ -4,6 +4,6 @@ By using private fields in structs with public `new` functions returning
 `Option` or `Result` (as here with `DNA::new` & `RNA::new`), we can guarantee
 that the internal representation of `DNA` is correct. Because every valid DNA
 string has a valid RNA string, we don't need to return a `Result`/`Option` from
-`to_rna`.
+`into_rna`.
 
 This explains the type signatures you will see in the tests.

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -24,7 +24,7 @@ By using private fields in structs with public `new` functions returning
 `Option` or `Result` (as here with `DNA::new` & `RNA::new`), we can guarantee
 that the internal representation of `DNA` is correct. Because every valid DNA
 string has a valid RNA string, we don't need to return a `Result`/`Option` from
-`to_rna`.
+`into_rna`.
 
 This explains the type signatures you will see in the tests.
 

--- a/exercises/rna-transcription/example.rs
+++ b/exercises/rna-transcription/example.rs
@@ -49,7 +49,7 @@ impl DNA {
         Ok(DNA(out))
     }
 
-    pub fn to_rna(mut self) -> RNA {
+    pub fn into_rna(mut self) -> RNA {
         for nuc in self.0.iter_mut() {
             *nuc = match *nuc {
                 Nucleotide::Adenine => Nucleotide::Uracil,

--- a/exercises/rna-transcription/src/lib.rs
+++ b/exercises/rna-transcription/src/lib.rs
@@ -9,7 +9,7 @@ impl DNA {
         unimplemented!("Construct new DNA from '{}' string. If string contains invalid nucleotides return index of first invalid nucleotide", dna);
     }
 
-    pub fn to_rna(self) -> RNA {
+    pub fn into_rna(self) -> RNA {
         unimplemented!("Transform DNA {:?} into corresponding RNA", self);
     }
 }

--- a/exercises/rna-transcription/tests/rna-transcription.rs
+++ b/exercises/rna-transcription/tests/rna-transcription.rs
@@ -47,7 +47,7 @@ fn test_acid_equals_acid() {
 fn test_transcribes_cytosine_guanine() {
     assert_eq!(
         dna::RNA::new("G").unwrap(),
-        dna::DNA::new("C").unwrap().to_rna()
+        dna::DNA::new("C").unwrap().into_rna()
     );
 }
 
@@ -56,7 +56,7 @@ fn test_transcribes_cytosine_guanine() {
 fn test_transcribes_guanine_cytosine() {
     assert_eq!(
         dna::RNA::new("C").unwrap(),
-        dna::DNA::new("G").unwrap().to_rna()
+        dna::DNA::new("G").unwrap().into_rna()
     );
 }
 
@@ -65,7 +65,7 @@ fn test_transcribes_guanine_cytosine() {
 fn test_transcribes_adenine_uracil() {
     assert_eq!(
         dna::RNA::new("U").unwrap(),
-        dna::DNA::new("A").unwrap().to_rna()
+        dna::DNA::new("A").unwrap().into_rna()
     );
 }
 
@@ -74,7 +74,7 @@ fn test_transcribes_adenine_uracil() {
 fn test_transcribes_thymine_to_adenine() {
     assert_eq!(
         dna::RNA::new("A").unwrap(),
-        dna::DNA::new("T").unwrap().to_rna()
+        dna::DNA::new("T").unwrap().into_rna()
     );
 }
 
@@ -83,6 +83,6 @@ fn test_transcribes_thymine_to_adenine() {
 fn test_transcribes_all_dna_to_rna() {
     assert_eq!(
         dna::RNA::new("UGCACCAGAAUU").unwrap(),
-        dna::DNA::new("ACGTGGTCTTAA").unwrap().to_rna()
+        dna::DNA::new("ACGTGGTCTTAA").unwrap().into_rna()
     )
 }


### PR DESCRIPTION
`clippy::wrong_self_convention` is being violated at present.