### PR TITLE
tournament: line up the expected table header with the rest of the table

### DIFF
--- a/exercises/tournament/tests/tournament.rs
+++ b/exercises/tournament/tests/tournament.rs
@@ -12,7 +12,8 @@ fn just_the_header_if_no_input() {
 #[ignore]
 fn a_win_is_three_points_a_loss_is_zero_points() {
     let input = "Allegoric Alaskans;Blithering Badgers;win";
-    let expected = "Team                           | MP |  W |  D |  L |  P\n".to_string()
+    let expected = "".to_string()
+        + "Team                           | MP |  W |  D |  L |  P\n"
         + "Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3\n"
         + "Blithering Badgers             |  1 |  0 |  0 |  1 |  0";
 
@@ -23,7 +24,8 @@ fn a_win_is_three_points_a_loss_is_zero_points() {
 #[ignore]
 fn a_win_can_also_be_expressed_as_a_loss() {
     let input = "Blithering Badgers;Allegoric Alaskans;loss";
-    let expected = "Team                           | MP |  W |  D |  L |  P\n".to_string()
+    let expected = "".to_string()
+        + "Team                           | MP |  W |  D |  L |  P\n"
         + "Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3\n"
         + "Blithering Badgers             |  1 |  0 |  0 |  1 |  0";
 
@@ -34,7 +36,8 @@ fn a_win_can_also_be_expressed_as_a_loss() {
 #[ignore]
 fn a_different_team_can_win() {
     let input = "Blithering Badgers;Allegoric Alaskans;win";
-    let expected = "Team                           | MP |  W |  D |  L |  P\n".to_string()
+    let expected = "".to_string()
+        + "Team                           | MP |  W |  D |  L |  P\n"
         + "Blithering Badgers             |  1 |  1 |  0 |  0 |  3\n"
         + "Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0";
 
@@ -45,7 +48,8 @@ fn a_different_team_can_win() {
 #[ignore]
 fn a_draw_is_one_point_each() {
     let input = "Allegoric Alaskans;Blithering Badgers;draw";
-    let expected = "Team                           | MP |  W |  D |  L |  P\n".to_string()
+    let expected = "".to_string()
+        + "Team                           | MP |  W |  D |  L |  P\n"
         + "Allegoric Alaskans             |  1 |  0 |  1 |  0 |  1\n"
         + "Blithering Badgers             |  1 |  0 |  1 |  0 |  1";
 
@@ -57,7 +61,8 @@ fn a_draw_is_one_point_each() {
 fn there_can_be_more_than_one_match() {
     let input = "Allegoric Alaskans;Blithering Badgers;win\n".to_string()
         + "Allegoric Alaskans;Blithering Badgers;win";
-    let expected = "Team                           | MP |  W |  D |  L |  P\n".to_string()
+    let expected = "".to_string()
+        + "Team                           | MP |  W |  D |  L |  P\n"
         + "Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6\n"
         + "Blithering Badgers             |  2 |  0 |  0 |  2 |  0";
 
@@ -69,7 +74,8 @@ fn there_can_be_more_than_one_match() {
 fn there_can_be_more_than_one_winner() {
     let input = "Allegoric Alaskans;Blithering Badgers;loss\n".to_string()
         + "Allegoric Alaskans;Blithering Badgers;win";
-    let expected = "Team                           | MP |  W |  D |  L |  P\n".to_string()
+    let expected = "".to_string()
+        + "Team                           | MP |  W |  D |  L |  P\n"
         + "Allegoric Alaskans             |  2 |  1 |  0 |  1 |  3\n"
         + "Blithering Badgers             |  2 |  1 |  0 |  1 |  3";
 
@@ -82,7 +88,8 @@ fn there_can_be_more_than_two_teams() {
     let input = "Allegoric Alaskans;Blithering Badgers;win\n".to_string()
         + "Blithering Badgers;Courageous Californians;win\n"
         + "Courageous Californians;Allegoric Alaskans;loss";
-    let expected = "Team                           | MP |  W |  D |  L |  P\n".to_string()
+    let expected = "".to_string()
+        + "Team                           | MP |  W |  D |  L |  P\n"
         + "Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6\n"
         + "Blithering Badgers             |  2 |  1 |  0 |  1 |  3\n"
         + "Courageous Californians        |  2 |  0 |  0 |  2 |  0";
@@ -99,7 +106,8 @@ fn typical_input() {
         + "Courageous Californians;Blithering Badgers;loss\n"
         + "Blithering Badgers;Devastating Donkeys;loss\n"
         + "Allegoric Alaskans;Courageous Californians;win";
-    let expected = "Team                           | MP |  W |  D |  L |  P\n".to_string()
+    let expected = "".to_string()
+        + "Team                           | MP |  W |  D |  L |  P\n"
         + "Devastating Donkeys            |  3 |  2 |  1 |  0 |  7\n"
         + "Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6\n"
         + "Blithering Badgers             |  3 |  1 |  0 |  2 |  3\n"
@@ -115,7 +123,8 @@ fn incomplete_competition_not_all_pairs_have_played() {
         + "Devastating Donkeys;Allegoric Alaskans;loss\n"
         + "Courageous Californians;Blithering Badgers;draw\n"
         + "Allegoric Alaskans;Courageous Californians;win";
-    let expected = "Team                           | MP |  W |  D |  L |  P\n".to_string()
+    let expected = "".to_string()
+        + "Team                           | MP |  W |  D |  L |  P\n"
         + "Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6\n"
         + "Blithering Badgers             |  2 |  1 |  1 |  0 |  4\n"
         + "Courageous Californians        |  2 |  0 |  1 |  1 |  1\n"
@@ -133,7 +142,8 @@ fn ties_broken_alphabetically() {
         + "Courageous Californians;Blithering Badgers;win\n"
         + "Blithering Badgers;Devastating Donkeys;draw\n"
         + "Allegoric Alaskans;Courageous Californians;draw";
-    let expected = "Team                           | MP |  W |  D |  L |  P\n".to_string()
+    let expected = "".to_string()
+        + "Team                           | MP |  W |  D |  L |  P\n"
         + "Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7\n"
         + "Courageous Californians        |  3 |  2 |  1 |  0 |  7\n"
         + "Blithering Badgers             |  3 |  0 |  1 |  2 |  1\n"


### PR DESCRIPTION
Call this one a little pedantic, but as soon as I opened this test file I couldn't bear to look at the expected outputs without lining up the headers properly. Just thought I'd save other obsessive people like myself the hassle in future! ;)