### PR TITLE
dot-dsl: Use zip instead of enumerate + map-with-indexing

### DIFF
--- a/exercises/dot-dsl/tests/dot-dsl.rs
+++ b/exercises/dot-dsl/tests/dot-dsl.rs
@@ -133,7 +133,7 @@ fn test_graph_stores_attributes() {
         &['a', 'b', 'c']
             .iter()
             .enumerate()
-            .map(|(i, n)| Node::new(&n.to_string()).with_attrs(&attributes[i..i + 1]))
+            .map(|(i, n)| Node::new(&n.to_string()).with_attrs(&attributes[i..=i]))
             .collect::<Vec<_>>(),
     );
 

--- a/exercises/dot-dsl/tests/dot-dsl.rs
+++ b/exercises/dot-dsl/tests/dot-dsl.rs
@@ -132,8 +132,8 @@ fn test_graph_stores_attributes() {
     let graph = Graph::new().with_nodes(
         &['a', 'b', 'c']
             .iter()
-            .enumerate()
-            .map(|(i, n)| Node::new(&n.to_string()).with_attrs(&attributes[i..=i]))
+            .zip(attributes.iter())
+            .map(|(name, &attr)| Node::new(&name.to_string()).with_attrs(&[attr]))
             .collect::<Vec<_>>(),
     );
 


### PR DESCRIPTION
Suggested by clippy:
https://travis-ci.org/exercism/rust/builds/517554492
warning: an inclusive range would be more readable
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#range_plus_one

Note that this `&attributes[i..=i]` is saying "one-element slice (the
ith element of `attributes`)". An equivalent construction would be
`&[attributes[i]]`. The latter would copy `attributes[i]`, so we'll
avoid by continuing to slice.

---

I ask reviewers to pay careful attention to the factual accuracy of the last paragraph and also judge whether this is a desirable thing to continue to do, as opposed to the alternative construction presented.