### PR TITLE
ocr-numbers: change `cfg_attr(rustfmt, rustfmt_skip)` to `rustfmt::skip`

### DIFF
--- a/exercises/ocr-numbers/tests/ocr-numbers.rs
+++ b/exercises/ocr-numbers/tests/ocr-numbers.rs
@@ -1,7 +1,7 @@
 use ocr_numbers as ocr;
 
 #[test]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn input_with_lines_not_multiple_of_four_is_error() {
     let input = " _ \n".to_string() +
                 "| |\n" +
@@ -12,7 +12,7 @@ fn input_with_lines_not_multiple_of_four_is_error() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn input_with_columns_not_multiple_of_three_is_error() {
     let input = "    \n".to_string() +
                 "   |\n" +
@@ -24,7 +24,7 @@ fn input_with_columns_not_multiple_of_three_is_error() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn unrecognized_characters_return_question_mark() {
     let input = "   \n".to_string() +
                 "  _\n" +
@@ -36,7 +36,7 @@ fn unrecognized_characters_return_question_mark() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn recognizes_0() {
     let input = " _ \n".to_string() +
                 "| |\n" +
@@ -48,7 +48,7 @@ fn recognizes_0() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn recognizes_1() {
     let input = "   \n".to_string() +
                 "  |\n" +
@@ -60,7 +60,7 @@ fn recognizes_1() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn recognizes_2() {
     let input = " _ \n".to_string() +
                 " _|\n" +
@@ -72,7 +72,7 @@ fn recognizes_2() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn recognizes_3() {
     let input = " _ \n".to_string() +
                 " _|\n" +
@@ -84,7 +84,7 @@ fn recognizes_3() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn recognizes_4() {
     let input = "   \n".to_string() +
                 "|_|\n" +
@@ -96,7 +96,7 @@ fn recognizes_4() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn recognizes_5() {
     let input = " _ \n".to_string() +
                 "|_ \n" +
@@ -108,7 +108,7 @@ fn recognizes_5() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn recognizes_6() {
     let input = " _ \n".to_string() +
                 "|_ \n" +
@@ -120,7 +120,7 @@ fn recognizes_6() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn recognizes_7() {
     let input = " _ \n".to_string() +
                 "  |\n" +
@@ -132,7 +132,7 @@ fn recognizes_7() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn recognizes_8() {
     let input = " _ \n".to_string() +
                 "|_|\n" +
@@ -144,7 +144,7 @@ fn recognizes_8() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn recognizes_9() {
     let input = " _ \n".to_string() +
                 "|_|\n" +
@@ -156,7 +156,7 @@ fn recognizes_9() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn recognizes_110101100() {
     let input = "       _     _        _  _ \n".to_string() +
                 "  |  || |  || |  |  || || |\n" +
@@ -168,7 +168,7 @@ fn recognizes_110101100() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn replaces_only_garbled_numbers_with_question_mark() {
     let input = "       _     _           _ \n".to_string() +
                 "  |  || |  || |     || || |\n" +
@@ -180,7 +180,7 @@ fn replaces_only_garbled_numbers_with_question_mark() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn recognizes_string_of_decimal_numbers() {
     let input = "    _  _     _  _  _  _  _  _ \n".to_string() +
                 "  | _| _||_||_ |_   ||_||_|| |\n" +
@@ -192,7 +192,7 @@ fn recognizes_string_of_decimal_numbers() {
 
 #[test]
 #[ignore]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn numbers_across_multiple_lines_are_joined_by_commas() {
     let input = "    _  _ \n".to_string() +
                 "  | _| _|\n" +


### PR DESCRIPTION
Clippy warning
https://travis-ci.org/exercism/rust/builds/456496870

warning: `cfg_attr` is deprecated for rustfmt and got replaced by tool_attributes
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/#deprecated_cfg_attr