### PR TITLE
nth-prime: tests do not match problem specifications

### DIFF
--- a/exercises/nth-prime/.meta/hints.md
+++ b/exercises/nth-prime/.meta/hints.md
@@ -1,0 +1,1 @@
+Remember that while people commonly count with 1-based indexing (i.e. "the 6th prime is 13"), many programming languages, including Rust, use 0-based indexing (i.e. `primes[5] == 13`). Use 0-based indexing for your implementation.

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -8,6 +8,9 @@ the 6th prime is 13.
 If your language provides methods in the standard library to deal with prime
 numbers, pretend they don't exist and implement them yourself.
 
+Remember that while people commonly count with 1-based indexing (i.e. "the 6th prime is 13"), many programming languages, including Rust, use 0-based indexing (i.e. `primes[5] == 13`). Use 0-based indexing for your implementation.
+
+
 ## Rust Installation
 
 Refer to the [exercism help page][help-page] for Rust installation and learning

--- a/exercises/nth-prime/tests/nth-prime.rs
+++ b/exercises/nth-prime/tests/nth-prime.rs
@@ -2,23 +2,23 @@ use nth_prime as np;
 
 #[test]
 fn test_first_prime() {
-    assert_eq!(np::nth(1), 2);
+    assert_eq!(np::nth(0), 2);
 }
 
 #[test]
 #[ignore]
 fn test_second_prime() {
-    assert_eq!(np::nth(2), 3);
+    assert_eq!(np::nth(1), 3);
 }
 
 #[test]
 #[ignore]
 fn test_sixth_prime() {
-    assert_eq!(np::nth(6), 13);
+    assert_eq!(np::nth(5), 13);
 }
 
 #[test]
 #[ignore]
 fn test_big_prime() {
-    assert_eq!(np::nth(10001), 104743);
+    assert_eq!(np::nth(10000), 104743);
 }

--- a/exercises/nth-prime/tests/nth-prime.rs
+++ b/exercises/nth-prime/tests/nth-prime.rs
@@ -2,23 +2,23 @@ use nth_prime as np;
 
 #[test]
 fn test_first_prime() {
-    assert_eq!(np::nth(0), 2);
+    assert_eq!(np::nth(1), 2);
 }
 
 #[test]
 #[ignore]
 fn test_second_prime() {
-    assert_eq!(np::nth(1), 3);
+    assert_eq!(np::nth(2), 3);
 }
 
 #[test]
 #[ignore]
 fn test_sixth_prime() {
-    assert_eq!(np::nth(5), 13);
+    assert_eq!(np::nth(6), 13);
 }
 
 #[test]
 #[ignore]
 fn test_big_prime() {
-    assert_eq!(np::nth(10000), 104743);
+    assert_eq!(np::nth(10001), 104743);
 }


### PR DESCRIPTION
In the exercise description 13 is 6th number while in tests it's 5th, I changed it to be consistent with python version