### PR TITLE
Wordy: test for bonus condition

### DIFF
--- a/exercises/wordy/.meta/hints.md
+++ b/exercises/wordy/.meta/hints.md
@@ -1,0 +1,5 @@
+To get the bonus tests to run, execute the tests with:
+
+```bash
+$ cargo test --features exponentials
+```

--- a/exercises/wordy/Cargo.toml
+++ b/exercises/wordy/Cargo.toml
@@ -2,3 +2,6 @@
 edition = "2018"
 name = "wordy"
 version = "1.5.0"
+
+[features]
+exponentials = []

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -67,6 +67,12 @@ If you'd like, handle exponentials.
 
 32
 
+To get the bonus tests to run, execute the tests with:
+
+```bash
+$ cargo test --features exponentials
+```
+
 ## Rust Installation
 
 Refer to the [exercism help page][help-page] for Rust installation and learning

--- a/exercises/wordy/tests/wordy.rs
+++ b/exercises/wordy/tests/wordy.rs
@@ -108,54 +108,54 @@ fn multiple_divisions() {
 #[ignore]
 fn unknown_operation() {
     let command = "What is 52 cubed?";
-    assert!(answer(command).is_none());
+    assert_eq!(None, answer(command));
 }
 
 #[test]
 #[ignore]
 fn non_math_question() {
     let command = "Who is the President of the United States?";
-    assert!(answer(command).is_none());
+    assert_eq!(None, answer(command));
 }
 
 #[test]
 #[ignore]
 fn reject_problem_missing_an_operand() {
     let command = "What is 1 plus?";
-    assert!(answer(command).is_none());
+    assert_eq!(None, answer(command));
 }
 
 #[test]
 #[ignore]
 fn reject_problem_with_no_operands_or_operators() {
     let command = "What is?";
-    assert!(answer(command).is_none());
+    assert_eq!(None, answer(command));
 }
 
 #[test]
 #[ignore]
 fn reject_two_operations_in_a_row() {
     let command = "What is 1 plus plus 2?";
-    assert!(answer(command).is_none());
+    assert_eq!(None, answer(command));
 }
 
 #[test]
 #[ignore]
 fn reject_two_numbers_in_a_row() {
     let command = "What is 1 plus 2 1?";
-    assert!(answer(command).is_none());
+    assert_eq!(None, answer(command));
 }
 
 #[test]
 #[ignore]
 fn reject_postfix_notation() {
     let command = "What is 1 2 plus?";
-    assert!(answer(command).is_none());
+    assert_eq!(None, answer(command));
 }
 
 #[test]
 #[ignore]
 fn reject_prefix_notation() {
     let command = "What is plus 1 2?";
-    assert!(answer(command).is_none());
+    assert_eq!(None, answer(command));
 }

--- a/exercises/wordy/tests/wordy.rs
+++ b/exercises/wordy/tests/wordy.rs
@@ -159,3 +159,19 @@ fn reject_prefix_notation() {
     let command = "What is plus 1 2?";
     assert_eq!(None, answer(command));
 }
+
+#[test]
+#[ignore]
+#[cfg(feature="exponentials")]
+fn exponential() {
+    let command = "What is 2 raised to the 5th power?";
+    assert_eq!(Some(32), answer(command));
+}
+
+#[test]
+#[ignore]
+#[cfg(feature="exponentials")]
+fn addition_and_exponential() {
+    let command = "What is 1 plus 2 raised to the 2nd power?";
+    assert_eq!(Some(9), answer(command));
+}


### PR DESCRIPTION
The wordy Readme has the following:

> ## Bonus — Exponentials
> 
> If you'd like, handle exponentials.
> 
> > What is 2 raised to the 5th power?
> 
> 32

I've added tests for this, hidden behind the `exponentials` feature flag