### PR TITLE
Forego formerly deprecated exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,8 +4,11 @@
   "blurb": "Rust is a compiled programming language designed for speed, concurrency, and memory safety. Rust programs can run almost anywhere, from low-power embedded devices to web servers.",
   "foregone": [
     "binary",
+    "hexadecimal",
+    "nucleotide-codons",
     "octal",
-    "trinary"
+    "trinary",
+    "two-fer"
   ],
   "exercises": [
     {
@@ -1066,36 +1069,6 @@
       "topics": [
         "parser_reimplementation"
       ]
-    },
-    {
-      "slug": "two-fer",
-      "uuid": "c6631a2c-4632-11e8-842f-0ed5f89f718b",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "match",
-        "strings"
-      ],
-      "deprecated": true
-    },
-    {
-      "slug": "nucleotide-codons",
-      "uuid": "8dae8f4d-368d-477d-907e-bf746921bfbf",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 0,
-      "topics": null,
-      "deprecated": true
-    },
-    {
-      "slug": "hexadecimal",
-      "uuid": "496fd79f-1678-4aa2-8110-c32c6aaf545e",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 0,
-      "topics": null,
-      "deprecated": true
     }
   ]
 }


### PR DESCRIPTION
The rust track had several deprecated exercises. As they were removed
from the list of exercises available to students some time ago,
https://github.com/exercism/rust/pull/773 removed the actual exercises,
in order to clean things up. This produced a CI failure, but it was
overridden, because it was a configlet bug, not a real problem.

Overriding the CI failure was a mistake: I hadn't considered that
this would cause _every_ CI job to fail from that point forward.

I opened https://github.com/exercism/configlet/pull/160 fixing the
issue with configlet, but it has not yet been reviewed, and there
will be an unknowable amount of time before it is reviewed and
approved. In order to make configlet stop complaining and restore
CI functionality to the track, this PR moves the removed exercises
into the foregone list, which doesn't suffer the configlet bug.