### PR TITLE
Adhere to convention assert_eq!(expected, actual)

### DIFF
--- a/exercises/accumulate/tests/accumulate.rs
+++ b/exercises/accumulate/tests/accumulate.rs
@@ -10,7 +10,7 @@ fn square(x: i32) -> i32 {
 fn func_single() {
     let input = vec![2];
     let expected = vec![4];
-    assert_eq!(map(input, square), expected);
+    assert_eq!(expected, map(input, square));
 }
 
 #[test]
@@ -18,7 +18,7 @@ fn func_single() {
 fn func_multi() {
     let input = vec![2, 3, 4, 5];
     let expected = vec![4, 9, 16, 25];
-    assert_eq!(map(input, square), expected);
+    assert_eq!(expected, map(input, square));
 }
 
 #[test]
@@ -26,7 +26,7 @@ fn func_multi() {
 fn closure() {
     let input = vec![2, 3, 4, 5];
     let expected = vec![4, 9, 16, 25];
-    assert_eq!(map(input, |x| x * x), expected);
+    assert_eq!(expected, map(input, |x| x * x));
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn closure() {
 fn closure_floats() {
     let input = vec![2.0, 3.0, 4.0, 5.0];
     let expected = vec![4.0, 9.0, 16.0, 25.0];
-    assert_eq!(map(input, |x| x * x), expected);
+    assert_eq!(expected, map(input, |x| x * x));
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn closure_floats() {
 fn strings() {
     let input = vec!["1".to_string(), "2".into(), "3".into()];
     let expected = vec!["11".to_string(), "22".into(), "33".into()];
-    assert_eq!(map(input, |s| s.repeat(2)), expected);
+    assert_eq!(expected, map(input, |s| s.repeat(2)));
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn strings() {
 fn change_in_type() {
     let input: Vec<&str> = vec!["1", "2", "3"];
     let expected: Vec<String> = vec!["1".into(), "2".into(), "3".into()];
-    assert_eq!(map(input, |s| s.to_string()), expected);
+    assert_eq!(expected, map(input, |s| s.to_string()));
 }
 
 #[test]
@@ -63,8 +63,8 @@ fn mutating_closure() {
         counter += 1;
         x.abs()
     });
-    assert_eq!(result, expected);
-    assert_eq!(counter, 4);
+    assert_eq!(expected, result);
+    assert_eq!(4, counter);
 }
 
 #[test]

--- a/exercises/acronym/tests/acronym.rs
+++ b/exercises/acronym/tests/acronym.rs
@@ -1,54 +1,52 @@
 use acronym;
 
 #[test]
-fn empty() {
-    assert_eq!(acronym::abbreviate(""), "");
-}
+fn empty() { assert_eq!("", acronym::abbreviate("")); }
 
 #[test]
 #[ignore]
 fn basic() {
-    assert_eq!(acronym::abbreviate("Portable Network Graphics"), "PNG");
+    assert_eq!("PNG", acronym::abbreviate("Portable Network Graphics"));
 }
 
 #[test]
 #[ignore]
 fn lowercase_words() {
-    assert_eq!(acronym::abbreviate("Ruby on Rails"), "ROR");
+    assert_eq!("ROR", acronym::abbreviate("Ruby on Rails"));
 }
 
 #[test]
 #[ignore]
 fn camelcase() {
-    assert_eq!(acronym::abbreviate("HyperText Markup Language"), "HTML");
+    assert_eq!("HTML", acronym::abbreviate("HyperText Markup Language"));
 }
 
 #[test]
 #[ignore]
 fn punctuation() {
-    assert_eq!(acronym::abbreviate("First In, First Out"), "FIFO");
+    assert_eq!("FIFO", acronym::abbreviate("First In, First Out"));
 }
 
 #[test]
 #[ignore]
 fn all_caps_words() {
-    assert_eq!(acronym::abbreviate("PHP: Hypertext Preprocessor"), "PHP");
+    assert_eq!("PHP", acronym::abbreviate("PHP: Hypertext Preprocessor"));
 }
 
 #[test]
 #[ignore]
 fn non_acronym_all_caps_word() {
     assert_eq!(
-        acronym::abbreviate("GNU Image Manipulation Program"),
-        "GIMP"
-    );
+        "GIMP",
+        acronym::abbreviate("GNU Image Manipulation Program")
+    )
 }
 
 #[test]
 #[ignore]
 fn hyphenated() {
     assert_eq!(
-        acronym::abbreviate("Complementary metal-oxide semiconductor"),
-        "CMOS"
-    );
+        "CMOS",
+        acronym::abbreviate("Complementary metal-oxide semiconductor")
+    )
 }

--- a/exercises/all-your-base/tests/all-your-base.rs
+++ b/exercises/all-your-base/tests/all-your-base.rs
@@ -7,8 +7,8 @@ fn single_bit_one_to_decimal() {
     let output_base = 10;
     let output_digits = vec![1];
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Ok(output_digits)
+        Ok(output_digits),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -20,8 +20,8 @@ fn binary_to_single_decimal() {
     let output_base = 10;
     let output_digits = vec![5];
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Ok(output_digits)
+        Ok(output_digits),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -33,8 +33,8 @@ fn single_decimal_to_binary() {
     let output_base = 2;
     let output_digits = vec![1, 0, 1];
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Ok(output_digits)
+        Ok(output_digits),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -46,8 +46,8 @@ fn binary_to_multiple_decimal() {
     let output_base = 10;
     let output_digits = vec![4, 2];
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Ok(output_digits)
+        Ok(output_digits),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -59,8 +59,8 @@ fn decimal_to_binary() {
     let output_base = 2;
     let output_digits = vec![1, 0, 1, 0, 1, 0];
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Ok(output_digits)
+        Ok(output_digits),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -72,8 +72,8 @@ fn trinary_to_hexadecimal() {
     let output_base = 16;
     let output_digits = vec![2, 10];
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Ok(output_digits)
+        Ok(output_digits),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -85,8 +85,8 @@ fn hexadecimal_to_trinary() {
     let output_base = 3;
     let output_digits = vec![1, 1, 2, 0];
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Ok(output_digits)
+        Ok(output_digits),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -98,8 +98,8 @@ fn fifteen_bit_integer() {
     let output_base = 73;
     let output_digits = vec![6, 10, 45];
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Ok(output_digits)
+        Ok(output_digits),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -111,8 +111,8 @@ fn empty_list() {
     let output_base = 10;
     let output_digits = vec![];
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Ok(output_digits)
+        Ok(output_digits),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -124,8 +124,8 @@ fn single_zero() {
     let output_base = 2;
     let output_digits = vec![];
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Ok(output_digits)
+        Ok(output_digits),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -137,8 +137,8 @@ fn multiple_zeros() {
     let output_base = 2;
     let output_digits = vec![];
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Ok(output_digits)
+        Ok(output_digits),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -150,8 +150,8 @@ fn leading_zeros() {
     let output_base = 10;
     let output_digits = vec![4, 2];
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Ok(output_digits)
+        Ok(output_digits),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -163,7 +163,8 @@ fn invalid_positive_digit() {
     let output_base = 10;
     assert_eq!(
         ayb::convert(input_digits, input_base, output_base),
-        Err(ayb::Error::InvalidDigit(2))
+        Err(ayb::Error::InvalidDigit(2)
+        )
     );
 }
 
@@ -174,8 +175,8 @@ fn input_base_is_one() {
     let input_digits = &[];
     let output_base = 10;
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Err(ayb::Error::InvalidInputBase)
+        Err(ayb::Error::InvalidInputBase),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -186,8 +187,8 @@ fn output_base_is_one() {
     let input_digits = &[1, 0, 1, 0, 1, 0];
     let output_base = 1;
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Err(ayb::Error::InvalidOutputBase)
+        Err(ayb::Error::InvalidOutputBase),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -198,8 +199,8 @@ fn input_base_is_zero() {
     let input_digits = &[];
     let output_base = 10;
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Err(ayb::Error::InvalidInputBase)
+        Err(ayb::Error::InvalidInputBase),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }
 
@@ -210,7 +211,7 @@ fn output_base_is_zero() {
     let input_digits = &[7];
     let output_base = 0;
     assert_eq!(
-        ayb::convert(input_digits, input_base, output_base),
-        Err(ayb::Error::InvalidOutputBase)
+        Err(ayb::Error::InvalidOutputBase),
+        ayb::convert(input_digits, input_base, output_base)
     );
 }

--- a/exercises/alphametics/tests/alphametics.rs
+++ b/exercises/alphametics/tests/alphametics.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 fn assert_alphametic_solution_eq(puzzle: &str, solution: &[(char, u8)]) {
     let answer = alphametics::solve(puzzle);
     let solution: HashMap<char, u8> = solution.iter().cloned().collect();
-    assert_eq!(answer, Some(solution));
+    assert_eq!(Some(solution), answer)
 }
 
 #[test]
@@ -16,14 +16,14 @@ fn test_with_three_letters() {
 #[ignore]
 fn test_must_have_unique_value_for_each_letter() {
     let answer = alphametics::solve("A == B");
-    assert_eq!(answer, None);
+    assert_eq!(None, answer)
 }
 
 #[test]
 #[ignore]
 fn test_leading_zero_solution_is_invalid() {
     let answer = alphametics::solve("ACA + DD == BD");
-    assert_eq!(answer, None);
+    assert_eq!(None, answer)
 }
 
 #[test]

--- a/exercises/anagram/tests/anagram.rs
+++ b/exercises/anagram/tests/anagram.rs
@@ -8,7 +8,7 @@ fn process_anagram_case(word: &str, inputs: &[&str], expected: &[&str]) {
 
     let expected: HashSet<&str> = HashSet::from_iter(expected.iter().cloned());
 
-    assert_eq!(result, expected);
+    assert_eq!(expected, result);
 }
 
 #[test]

--- a/exercises/beer-song/tests/beer-song.rs
+++ b/exercises/beer-song/tests/beer-song.rs
@@ -2,35 +2,35 @@ use beer_song as beer;
 
 #[test]
 fn test_verse_0() {
-    assert_eq!(beer::verse(0), "No more bottles of beer on the wall, no more bottles of beer.\nGo to the store and buy some more, 99 bottles of beer on the wall.\n");
+    assert_eq!("No more bottles of beer on the wall, no more bottles of beer.\nGo to the store and buy some more, 99 bottles of beer on the wall.\n", beer::verse(0))
 }
 
 #[test]
 #[ignore]
 fn test_verse_1() {
-    assert_eq!(beer::verse(1), "1 bottle of beer on the wall, 1 bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n");
+    assert_eq!("1 bottle of beer on the wall, 1 bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n", beer::verse(1))
 }
 
 #[test]
 #[ignore]
 fn test_verse_2() {
-    assert_eq!(beer::verse(2), "2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n");
+    assert_eq!("2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n", beer::verse(2))
 }
 
 #[test]
 #[ignore]
 fn test_verse_8() {
-    assert_eq!(beer::verse(8), "8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n");
+    assert_eq!("8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n", beer::verse(8))
 }
 
 #[test]
 #[ignore]
 fn test_song_8_6() {
-    assert_eq!(beer::sing(8, 6), "8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n\n7 bottles of beer on the wall, 7 bottles of beer.\nTake one down and pass it around, 6 bottles of beer on the wall.\n\n6 bottles of beer on the wall, 6 bottles of beer.\nTake one down and pass it around, 5 bottles of beer on the wall.\n");
+    assert_eq!("8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n\n7 bottles of beer on the wall, 7 bottles of beer.\nTake one down and pass it around, 6 bottles of beer on the wall.\n\n6 bottles of beer on the wall, 6 bottles of beer.\nTake one down and pass it around, 5 bottles of beer on the wall.\n", beer::sing(8, 6))
 }
 
 #[test]
 #[ignore]
 fn test_song_3_0() {
-    assert_eq!(beer::sing(3, 0), "3 bottles of beer on the wall, 3 bottles of beer.\nTake one down and pass it around, 2 bottles of beer on the wall.\n\n2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n\n1 bottle of beer on the wall, 1 bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n\nNo more bottles of beer on the wall, no more bottles of beer.\nGo to the store and buy some more, 99 bottles of beer on the wall.\n");
+    assert_eq!("3 bottles of beer on the wall, 3 bottles of beer.\nTake one down and pass it around, 2 bottles of beer on the wall.\n\n2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n\n1 bottle of beer on the wall, 1 bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n\nNo more bottles of beer on the wall, no more bottles of beer.\nGo to the store and buy some more, 99 bottles of beer on the wall.\n", beer::sing(3, 0))
 }

--- a/exercises/binary-search/tests/binary-search.rs
+++ b/exercises/binary-search/tests/binary-search.rs
@@ -2,45 +2,45 @@ use binary_search::find;
 
 #[test]
 fn finds_a_value_in_an_array_with_one_element() {
-    assert_eq!(find(&[6], 6), Some(0));
+    assert_eq!(Some(0), find(&[6], 6));
 }
 
 #[test]
 #[ignore]
 fn finds_first_value_in_an_array_with_two_element() {
-    assert_eq!(find(&[1, 2], 1), Some(0));
+    assert_eq!(Some(0), find(&[1, 2], 1));
 }
 
 #[test]
 #[ignore]
 fn finds_second_value_in_an_array_with_two_element() {
-    assert_eq!(find(&[1, 2], 2), Some(1));
+    assert_eq!(Some(1), find(&[1, 2], 2));
 }
 
 #[test]
 #[ignore]
 fn finds_a_value_in_the_middle_of_an_array() {
-    assert_eq!(find(&[1, 3, 4, 6, 8, 9, 11], 6), Some(3));
+    assert_eq!(Some(3), find(&[1, 3, 4, 6, 8, 9, 11], 6));
 }
 
 #[test]
 #[ignore]
 fn finds_a_value_at_the_beginning_of_an_array() {
-    assert_eq!(find(&[1, 3, 4, 6, 8, 9, 11], 1), Some(0));
+    assert_eq!(Some(0), find(&[1, 3, 4, 6, 8, 9, 11], 1));
 }
 
 #[test]
 #[ignore]
 fn finds_a_value_at_the_end_of_an_array() {
-    assert_eq!(find(&[1, 3, 4, 6, 8, 9, 11], 11), Some(6));
+    assert_eq!(Some(6), find(&[1, 3, 4, 6, 8, 9, 11], 11));
 }
 
 #[test]
 #[ignore]
 fn finds_a_value_in_an_array_of_odd_length() {
     assert_eq!(
-        find(&[1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634], 144),
-        Some(9)
+        Some(9), 
+        find(&[1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634], 144)
     );
 }
 
@@ -48,46 +48,46 @@ fn finds_a_value_in_an_array_of_odd_length() {
 #[ignore]
 fn finds_a_value_in_an_array_of_even_length() {
     assert_eq!(
-        find(&[1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377], 21),
-        Some(5)
+        Some(5), 
+        find(&[1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377], 21)
     );
 }
 
 #[test]
 #[ignore]
 fn identifies_that_a_value_is_not_included_in_the_array() {
-    assert_eq!(find(&[1, 3, 4, 6, 8, 9, 11], 7), None);
+    assert_eq!(None, find(&[1, 3, 4, 6, 8, 9, 11], 7));
 }
 
 #[test]
 #[ignore]
 fn a_value_smaller_than_the_arrays_smallest_value_is_not_included() {
-    assert_eq!(find(&[1, 3, 4, 6, 8, 9, 11], 0), None);
+    assert_eq!(None, find(&[1, 3, 4, 6, 8, 9, 11], 0));
 }
 
 #[test]
 #[ignore]
 fn a_value_larger_than_the_arrays_largest_value_is_not_included() {
-    assert_eq!(find(&[1, 3, 4, 6, 8, 9, 11], 13), None);
+    assert_eq!(None, find(&[1, 3, 4, 6, 8, 9, 11], 13));
 }
 
 #[test]
 #[ignore]
 fn nothing_is_included_in_an_empty_array() {
-    assert_eq!(find(&[], 1), None);
+    assert_eq!(None, find(&[], 1));
 }
 
 #[test]
 #[ignore]
 fn nothing_is_found_when_the_left_and_right_bounds_cross() {
-    assert_eq!(find(&[1, 2], 0), None);
+    assert_eq!(None, find(&[1, 2], 0));
 }
 
 #[test]
 #[ignore]
 #[cfg(feature = "generic")]
 fn works_for_arrays() {
-    assert_eq!(find([6], 6), Some(0));
+    assert_eq!(Some(0), find([6], 6));
 }
 
 #[test]
@@ -95,14 +95,14 @@ fn works_for_arrays() {
 #[cfg(feature = "generic")]
 fn works_for_vec() {
     let vector = vec![6];
-    assert_eq!(find(&vector, 6), Some(0));
-    assert_eq!(find(vector, 6), Some(0));
+    assert_eq!(Some(0), find(&vector, 6));
+    assert_eq!(Some(0), find(vector, 6));
 }
 
 #[test]
 #[ignore]
 #[cfg(feature = "generic")]
 fn works_for_str_elements() {
-    assert_eq!(find(["a"], "a"), Some(0));
-    assert_eq!(find(["a", "b"], "b"), Some(1));
+    assert_eq!(Some(0), find(["a"], "a"));
+    assert_eq!(Some(1), find(["a", "b"], "b"));
 }

--- a/exercises/bob/tests/bob.rs
+++ b/exercises/bob/tests/bob.rs
@@ -1,7 +1,7 @@
 use bob;
 
 fn process_response_case(phrase: &str, expected_response: &str) {
-    assert_eq!(bob::reply(phrase), expected_response);
+    assert_eq!(expected_response, bob::reply(phrase));
 }
 
 #[test]

--- a/exercises/book-store/tests/book-store.rs
+++ b/exercises/book-store/tests/book-store.rs
@@ -14,7 +14,7 @@ use book_store::*;
 ///
 /// Expected input format: ('basket', 'targetgrouping')
 fn process_total_case(input: (Vec<u32>, Vec<Vec<u32>>), expected: u32) {
-    assert_eq!(lowest_price(&input.0), expected)
+    assert_eq!(expected, lowest_price(&input.0))
 }
 
 // Return the total basket price after applying the best discount.

--- a/exercises/bowling/tests/bowling.rs
+++ b/exercises/bowling/tests/bowling.rs
@@ -11,7 +11,7 @@ fn roll_returns_a_result() {
 fn you_cannot_roll_more_than_ten_pins_in_a_single_roll() {
     let mut game = BowlingGame::new();
 
-    assert_eq!(game.roll(11), Err(Error::NotEnoughPinsLeft));;
+    assert_eq!(Err(Error::NotEnoughPinsLeft), game.roll(11));
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn a_game_score_is_some_if_ten_frames_have_been_rolled() {
 fn you_cannot_score_a_game_with_no_rolls() {
     let game = BowlingGame::new();
 
-    assert_eq!(game.score(), None);
+    assert_eq!(None, game.score());
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn a_game_score_is_none_if_fewer_than_ten_frames_have_been_rolled() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score(), None);
+    assert_eq!(None, game.score());
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn a_roll_is_err_if_the_game_is_done() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.roll(0), Err(Error::GameComplete));;
+    assert_eq!(Err(Error::GameComplete), game.roll(0));;
 }
 
 #[test]
@@ -70,7 +70,7 @@ fn twenty_zero_pin_rolls_scores_zero() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score(), Some(0));
+    assert_eq!(Some(0), game.score());
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn ten_frames_without_a_strike_or_spare() {
         let _ = game.roll(6);
     }
 
-    assert_eq!(game.score(), Some(90));
+    assert_eq!(Some(90), game.score());
 }
 
 #[test]
@@ -98,7 +98,7 @@ fn spare_in_the_first_frame_followed_by_zeros() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score(), Some(10));
+    assert_eq!(Some(10), game.score());
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn points_scored_in_the_roll_after_a_spare_are_counted_twice_as_a_bonus() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score(), Some(16));
+    assert_eq!(Some(16), game.score());
 }
 
 #[test]
@@ -132,7 +132,7 @@ fn consecutive_spares_each_get_a_one_roll_bonus() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score(), Some(31));
+    assert_eq!(Some(31), game.score());
 }
 
 #[test]
@@ -148,7 +148,7 @@ fn if_the_last_frame_is_a_spare_you_get_one_extra_roll_that_is_scored_once() {
     let _ = game.roll(5);
     let _ = game.roll(7);
 
-    assert_eq!(game.score(), Some(17));
+    assert_eq!(Some(17), game.score());
 }
 
 #[test]
@@ -162,7 +162,7 @@ fn a_strike_earns_ten_points_in_a_frame_with_a_single_roll() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score(), Some(10));
+    assert_eq!(Some(10), game.score());
 }
 
 #[test]
@@ -178,7 +178,7 @@ fn points_scored_in_the_two_rolls_after_a_strike_are_counted_twice_as_a_bonus() 
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score(), Some(26));
+    assert_eq!(Some(26), game.score());
 }
 
 #[test]
@@ -196,7 +196,7 @@ fn consecutive_strikes_each_get_the_two_roll_bonus() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.score(), Some(81));
+    assert_eq!(Some(81), game.score());
 }
 
 #[test]
@@ -212,7 +212,7 @@ fn a_strike_in_the_last_frame_earns_a_two_roll_bonus_that_is_counted_once() {
     let _ = game.roll(7);
     let _ = game.roll(1);
 
-    assert_eq!(game.score(), Some(18));
+    assert_eq!(Some(18), game.score());
 }
 
 #[test]
@@ -228,7 +228,7 @@ fn a_spare_with_the_two_roll_bonus_does_not_get_a_bonus_roll() {
     let _ = game.roll(7);
     let _ = game.roll(3);
 
-    assert_eq!(game.score(), Some(20));
+    assert_eq!(Some(20), game.score());
 }
 
 #[test]
@@ -244,7 +244,7 @@ fn strikes_with_the_two_roll_bonus_do_not_get_a_bonus_roll() {
     let _ = game.roll(10);
     let _ = game.roll(10);
 
-    assert_eq!(game.score(), Some(30));
+    assert_eq!(Some(30), game.score());
 }
 
 #[test]
@@ -260,7 +260,7 @@ fn a_strike_with_the_one_roll_bonus_after_a_spare_in_the_last_frame_does_not_get
     let _ = game.roll(3);
     let _ = game.roll(10);
 
-    assert_eq!(game.score(), Some(20));
+    assert_eq!(Some(20), game.score());
 }
 
 #[test]
@@ -272,7 +272,7 @@ fn all_strikes_is_a_perfect_score_of_300() {
         let _ = game.roll(10);
     }
 
-    assert_eq!(game.score(), Some(300));
+    assert_eq!(Some(300), game.score());
 }
 
 #[test]
@@ -281,7 +281,7 @@ fn you_cannot_roll_more_than_ten_pins_in_a_single_frame() {
     let mut game = BowlingGame::new();
 
     assert!(game.roll(5).is_ok());
-    assert_eq!(game.roll(6), Err(Error::NotEnoughPinsLeft));;
+    assert_eq!(Err(Error::NotEnoughPinsLeft), game.roll(6));;
 }
 
 #[test]
@@ -295,7 +295,7 @@ fn first_bonus_ball_after_a_final_strike_cannot_score_an_invalid_number_of_pins(
 
     let _ = game.roll(10);
 
-    assert_eq!(game.roll(11), Err(Error::NotEnoughPinsLeft));;
+    assert_eq!(Err(Error::NotEnoughPinsLeft), game.roll(11));;
 }
 
 #[test]
@@ -310,7 +310,7 @@ fn the_two_balls_after_a_final_strike_cannot_score_an_invalid_number_of_pins() {
     let _ = game.roll(10);
 
     assert!(game.roll(5).is_ok());
-    assert_eq!(game.roll(6), Err(Error::NotEnoughPinsLeft));;
+    assert_eq!(Err(Error::NotEnoughPinsLeft), game.roll(6));;
 }
 
 #[test]
@@ -340,7 +340,7 @@ fn the_two_balls_after_a_final_strike_cannot_be_a_non_strike_followed_by_a_strik
     let _ = game.roll(10);
 
     assert!(game.roll(6).is_ok());
-    assert_eq!(game.roll(10), Err(Error::NotEnoughPinsLeft));;
+    assert_eq!(Err(Error::NotEnoughPinsLeft), game.roll(10));;
 }
 
 #[test]
@@ -356,7 +356,7 @@ fn second_bonus_ball_after_a_final_strike_cannot_score_an_invalid_number_of_pins
     let _ = game.roll(10);
 
     assert!(game.roll(10).is_ok());
-    assert_eq!(game.roll(11), Err(Error::NotEnoughPinsLeft));;
+    assert_eq!(Err(Error::NotEnoughPinsLeft), game.roll(11));;
 }
 
 #[test]
@@ -370,11 +370,11 @@ fn if_the_last_frame_is_a_strike_you_cannot_score_before_the_extra_rolls_are_tak
 
     let _ = game.roll(10);
 
-    assert_eq!(game.score(), None);
+    assert_eq!(None, game.score());
 
     let _ = game.roll(10);
 
-    assert_eq!(game.score(), None);
+    assert_eq!(None, game.score());
 
     let _ = game.roll(10);
 
@@ -393,7 +393,7 @@ fn if_the_last_frame_is_a_spare_you_cannot_create_a_score_before_extra_roll_is_t
     let _ = game.roll(5);
     let _ = game.roll(5);
 
-    assert_eq!(game.score(), None);
+    assert_eq!(None, game.score());
 
     let _ = game.roll(10);
 
@@ -413,7 +413,7 @@ fn cannot_roll_after_bonus_roll_for_spare() {
     let _ = game.roll(3);
     assert!(game.roll(2).is_ok());
 
-    assert_eq!(game.roll(2), Err(Error::GameComplete));
+    assert_eq!(Err(Error::GameComplete), game.roll(2));
 }
 
 #[test]
@@ -429,5 +429,5 @@ fn cannot_roll_after_bonus_roll_for_strike() {
     let _ = game.roll(3);
     assert!(game.roll(2).is_ok());
 
-    assert_eq!(game.roll(2), Err(Error::GameComplete));
+    assert_eq!(Err(Error::GameComplete), game.roll(2));
 }

--- a/exercises/clock/tests/clock.rs
+++ b/exercises/clock/tests/clock.rs
@@ -8,121 +8,121 @@ use clock::Clock;
 
 #[test]
 fn test_on_the_hour() {
-    assert_eq!(Clock::new(8, 0).to_string(), "08:00");
+    assert_eq!("08:00", Clock::new(8, 0).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_past_the_hour() {
-    assert_eq!(Clock::new(11, 9).to_string(), "11:09");
+    assert_eq!("11:09", Clock::new(11, 9).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_midnight_is_zero_hours() {
-    assert_eq!(Clock::new(24, 0).to_string(), "00:00");
+    assert_eq!("00:00", Clock::new(24, 0).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_hour_rolls_over() {
-    assert_eq!(Clock::new(25, 0).to_string(), "01:00");
+    assert_eq!("01:00", Clock::new(25, 0).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_hour_rolls_over_continuously() {
-    assert_eq!(Clock::new(100, 0).to_string(), "04:00");
+    assert_eq!("04:00", Clock::new(100, 0).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_sixty_minutes_is_next_hour() {
-    assert_eq!(Clock::new(1, 60).to_string(), "02:00");
+    assert_eq!("02:00", Clock::new(1, 60).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_minutes_roll_over() {
-    assert_eq!(Clock::new(0, 160).to_string(), "02:40");
+    assert_eq!("02:40", Clock::new(0, 160).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_minutes_roll_over_continuously() {
-    assert_eq!(Clock::new(0, 1723).to_string(), "04:43");
+    assert_eq!("04:43", Clock::new(0, 1723).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_hours_and_minutes_roll_over() {
-    assert_eq!(Clock::new(25, 160).to_string(), "03:40");
+    assert_eq!("03:40", Clock::new(25, 160).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_hours_and_minutes_roll_over_continuously() {
-    assert_eq!(Clock::new(201, 3001).to_string(), "11:01");
+    assert_eq!("11:01", Clock::new(201, 3001).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_hours_and_minutes_roll_over_to_exactly_midnight() {
-    assert_eq!(Clock::new(72, 8640).to_string(), "00:00");
+    assert_eq!("00:00", Clock::new(72, 8640).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_negative_hour() {
-    assert_eq!(Clock::new(-1, 15).to_string(), "23:15");
+    assert_eq!("23:15", Clock::new(-1, 15).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_negative_hour_roll_over() {
-    assert_eq!(Clock::new(-25, 00).to_string(), "23:00");
+    assert_eq!("23:00", Clock::new(-25, 00).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_negative_hour_roll_over_continuously() {
-    assert_eq!(Clock::new(-91, 00).to_string(), "05:00");
+    assert_eq!("05:00", Clock::new(-91, 00).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_negative_minutes() {
-    assert_eq!(Clock::new(1, -40).to_string(), "00:20");
+    assert_eq!("00:20", Clock::new(1, -40).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_negative_minutes_roll_over() {
-    assert_eq!(Clock::new(1, -160).to_string(), "22:20");
+    assert_eq!("22:20", Clock::new(1, -160).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_negative_minutes_roll_over_continuously() {
-    assert_eq!(Clock::new(1, -4820).to_string(), "16:40");
+    assert_eq!("16:40", Clock::new(1, -4820).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_negative_sixty_minutes_is_prev_hour() {
-    assert_eq!(Clock::new(2, -60).to_string(), "01:00");
+    assert_eq!("01:00", Clock::new(2, -60).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_negative_hour_and_minutes_both_roll_over() {
-    assert_eq!(Clock::new(-25, -160).to_string(), "20:20");
+    assert_eq!("20:20", Clock::new(-25, -160).to_string());;
 }
 
 #[test]
 #[ignore]
 fn test_negative_hour_and_minutes_both_roll_over_continuously() {
-    assert_eq!(Clock::new(-121, -5810).to_string(), "22:10");
+    assert_eq!("22:10", Clock::new(-121, -5810).to_string());;
 }
 
 //
@@ -133,112 +133,112 @@ fn test_negative_hour_and_minutes_both_roll_over_continuously() {
 #[ignore]
 fn test_add_minutes() {
     let clock = Clock::new(10, 0).add_minutes(3);
-    assert_eq!(clock.to_string(), "10:03");
+    assert_eq!("10:03", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_add_no_minutes() {
     let clock = Clock::new(6, 41).add_minutes(0);
-    assert_eq!(clock.to_string(), "06:41");
+    assert_eq!("06:41", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_add_to_next_hour() {
     let clock = Clock::new(0, 45).add_minutes(40);
-    assert_eq!(clock.to_string(), "01:25");
+    assert_eq!("01:25", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_add_more_than_one_hour() {
     let clock = Clock::new(10, 0).add_minutes(61);
-    assert_eq!(clock.to_string(), "11:01");
+    assert_eq!("11:01", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_add_more_than_two_hours_with_carry() {
     let clock = Clock::new(0, 45).add_minutes(160);
-    assert_eq!(clock.to_string(), "03:25");
+    assert_eq!("03:25", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_add_across_midnight() {
     let clock = Clock::new(23, 59).add_minutes(2);
-    assert_eq!(clock.to_string(), "00:01");
+    assert_eq!("00:01", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_add_more_than_one_day() {
     let clock = Clock::new(5, 32).add_minutes(1500);
-    assert_eq!(clock.to_string(), "06:32");
+    assert_eq!("06:32", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_add_more_than_two_days() {
     let clock = Clock::new(1, 1).add_minutes(3500);
-    assert_eq!(clock.to_string(), "11:21");
+    assert_eq!("11:21", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_subtract_minutes() {
     let clock = Clock::new(10, 3).add_minutes(-3);
-    assert_eq!(clock.to_string(), "10:00");
+    assert_eq!("10:00", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_subtract_to_previous_hour() {
     let clock = Clock::new(10, 3).add_minutes(-30);
-    assert_eq!(clock.to_string(), "09:33");
+    assert_eq!("09:33", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_subtract_more_than_an_hour() {
     let clock = Clock::new(10, 3).add_minutes(-70);
-    assert_eq!(clock.to_string(), "08:53");
+    assert_eq!("08:53", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_subtract_across_midnight() {
     let clock = Clock::new(0, 3).add_minutes(-4);
-    assert_eq!(clock.to_string(), "23:59");
+    assert_eq!("23:59", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_subtract_more_than_two_hours() {
     let clock = Clock::new(0, 0).add_minutes(-160);
-    assert_eq!(clock.to_string(), "21:20");
+    assert_eq!("21:20", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_subtract_more_than_two_hours_with_borrow() {
     let clock = Clock::new(6, 15).add_minutes(-160);
-    assert_eq!(clock.to_string(), "03:35");
+    assert_eq!("03:35", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_subtract_more_than_one_day() {
     let clock = Clock::new(5, 32).add_minutes(-1500);
-    assert_eq!(clock.to_string(), "04:32");
+    assert_eq!("04:32", clock.to_string());
 }
 
 #[test]
 #[ignore]
 fn test_subtract_mores_than_two_days() {
     let clock = Clock::new(2, 20).add_minutes(-3000);
-    assert_eq!(clock.to_string(), "00:20");
+    assert_eq!("00:20", clock.to_string());
 }
 
 //

--- a/exercises/crypto-square/tests/crypto-square.rs
+++ b/exercises/crypto-square/tests/crypto-square.rs
@@ -1,7 +1,7 @@
 use crypto_square::encrypt;
 
 fn test(input: &str, output: &str) {
-    assert_eq!(&encrypt(input), output);
+    assert_eq!(output, &encrypt(input));
 }
 
 #[test]

--- a/exercises/custom-set/tests/custom-set.rs
+++ b/exercises/custom-set/tests/custom-set.rs
@@ -174,7 +174,7 @@ fn sets_with_different_elements_are_not_equal() {
 fn add_to_empty_set() {
     let mut set = CustomSet::new(&[]);
     set.add(3);
-    assert_eq!(set, CustomSet::new(&[3]));
+    assert_eq!(CustomSet::new(&[3]), set);
 }
 
 #[test]
@@ -182,7 +182,7 @@ fn add_to_empty_set() {
 fn add_to_non_empty_set() {
     let mut set = CustomSet::new(&[1, 2, 4]);
     set.add(3);
-    assert_eq!(set, CustomSet::new(&[1, 2, 3, 4]));
+    assert_eq!(CustomSet::new(&[1, 2, 3, 4]), set);
 }
 
 #[test]
@@ -190,7 +190,7 @@ fn add_to_non_empty_set() {
 fn add_existing_element() {
     let mut set = CustomSet::new(&[1, 2, 3]);
     set.add(3);
-    assert_eq!(set, CustomSet::new(&[1, 2, 3]));
+    assert_eq!(CustomSet::new(&[1, 2, 3]), set);
 }
 
 #[test]
@@ -198,7 +198,7 @@ fn add_existing_element() {
 fn intersecting_empty_sets_return_empty_set() {
     let set1: CustomSet<()> = CustomSet::new(&[]);
     let set2: CustomSet<()> = CustomSet::new(&[]);
-    assert_eq!(set1.intersection(&set2), CustomSet::new(&[]));
+    assert_eq!(CustomSet::new(&[]), set1.intersection(&set2));
 }
 
 #[test]
@@ -206,7 +206,7 @@ fn intersecting_empty_sets_return_empty_set() {
 fn intersecting_empty_set_with_non_empty_returns_empty_set() {
     let set1 = CustomSet::new(&[]);
     let set2 = CustomSet::new(&[3, 2, 5]);
-    assert_eq!(set1.intersection(&set2), CustomSet::new(&[]));
+    assert_eq!(CustomSet::new(&[]), set1.intersection(&set2));
 }
 
 #[test]
@@ -214,7 +214,7 @@ fn intersecting_empty_set_with_non_empty_returns_empty_set() {
 fn intersecting_non_empty_set_with_empty_returns_empty_set() {
     let set1 = CustomSet::new(&[1, 2, 3, 4]);
     let set2 = CustomSet::new(&[]);
-    assert_eq!(set1.intersection(&set2), CustomSet::new(&[]));
+    assert_eq!(CustomSet::new(&[]), set1.intersection(&set2));
 }
 
 #[test]
@@ -222,8 +222,8 @@ fn intersecting_non_empty_set_with_empty_returns_empty_set() {
 fn intersection_of_two_sets_with_no_shared_elements_is_an_empty_set() {
     let set1 = CustomSet::new(&[1, 2, 3]);
     let set2 = CustomSet::new(&[4, 5, 6]);
-    assert_eq!(set1.intersection(&set2), CustomSet::new(&[]));
-    assert_eq!(set2.intersection(&set1), CustomSet::new(&[]));
+    assert_eq!(CustomSet::new(&[]), set1.intersection(&set2));
+    assert_eq!(CustomSet::new(&[]), set2.intersection(&set1));
 }
 
 #[test]
@@ -231,8 +231,8 @@ fn intersection_of_two_sets_with_no_shared_elements_is_an_empty_set() {
 fn intersection_of_two_sets_with_shared_elements_is_a_set_of_the_shared_elements() {
     let set1 = CustomSet::new(&[1, 2, 3, 4]);
     let set2 = CustomSet::new(&[3, 2, 5]);
-    assert_eq!(set1.intersection(&set2), CustomSet::new(&[2, 3]));
-    assert_eq!(set2.intersection(&set1), CustomSet::new(&[2, 3]));
+    assert_eq!(CustomSet::new(&[2, 3]), set1.intersection(&set2));
+    assert_eq!(CustomSet::new(&[2, 3]), set2.intersection(&set1));
 }
 
 #[test]
@@ -240,7 +240,7 @@ fn intersection_of_two_sets_with_shared_elements_is_a_set_of_the_shared_elements
 fn difference_of_two_empty_sets_is_empty_set() {
     let set1: CustomSet<()> = CustomSet::new(&[]);
     let set2: CustomSet<()> = CustomSet::new(&[]);
-    assert_eq!(set1.difference(&set2), CustomSet::new(&[]));
+    assert_eq!(CustomSet::new(&[]), set1.difference(&set2));
 }
 
 #[test]
@@ -248,7 +248,7 @@ fn difference_of_two_empty_sets_is_empty_set() {
 fn difference_of_an_empty_and_non_empty_set_is_an_empty_set() {
     let set1 = CustomSet::new(&[]);
     let set2 = CustomSet::new(&[3, 2, 5]);
-    assert_eq!(set1.difference(&set2), CustomSet::new(&[]));
+    assert_eq!(CustomSet::new(&[]), set1.difference(&set2));
 }
 
 #[test]
@@ -256,7 +256,7 @@ fn difference_of_an_empty_and_non_empty_set_is_an_empty_set() {
 fn difference_of_a_non_empty_set_and_empty_set_is_the_non_empty_set() {
     let set1 = CustomSet::new(&[1, 2, 3, 4]);
     let set2 = CustomSet::new(&[]);
-    assert_eq!(set1.difference(&set2), CustomSet::new(&[1, 2, 3, 4]));
+    assert_eq!(CustomSet::new(&[1, 2, 3, 4]), set1.difference(&set2));
 }
 
 #[test]
@@ -264,7 +264,7 @@ fn difference_of_a_non_empty_set_and_empty_set_is_the_non_empty_set() {
 fn difference_of_two_non_empty_sets_is_elements_only_in_first_set_one() {
     let set1 = CustomSet::new(&[3, 2, 1]);
     let set2 = CustomSet::new(&[2, 4]);
-    assert_eq!(set1.difference(&set2), CustomSet::new(&[1, 3]));
+    assert_eq!(CustomSet::new(&[1, 3]), set1.difference(&set2));
 }
 
 #[test]
@@ -272,7 +272,7 @@ fn difference_of_two_non_empty_sets_is_elements_only_in_first_set_one() {
 fn union_of_two_empty_sets_is_empty_set() {
     let set1: CustomSet<()> = CustomSet::new(&[]);
     let set2: CustomSet<()> = CustomSet::new(&[]);
-    assert_eq!(set1.union(&set2), CustomSet::new(&[]));
+    assert_eq!(CustomSet::new(&[]), set1.union(&set2));
 }
 
 #[test]
@@ -280,7 +280,7 @@ fn union_of_two_empty_sets_is_empty_set() {
 fn union_of_empty_set_and_non_empty_set_is_all_elements() {
     let set1 = CustomSet::new(&[]);
     let set2 = CustomSet::new(&[2]);
-    assert_eq!(set1.union(&set2), CustomSet::new(&[2]));
+    assert_eq!(CustomSet::new(&[2]), set1.union(&set2));
 }
 
 #[test]
@@ -288,7 +288,7 @@ fn union_of_empty_set_and_non_empty_set_is_all_elements() {
 fn union_of_non_empty_set_and_empty_set_is_the_non_empty_set() {
     let set1 = CustomSet::new(&[1, 3]);
     let set2 = CustomSet::new(&[]);
-    assert_eq!(set1.union(&set2), CustomSet::new(&[1, 3]));
+    assert_eq!(CustomSet::new(&[1, 3]), set1.union(&set2));
 }
 
 #[test]
@@ -296,5 +296,5 @@ fn union_of_non_empty_set_and_empty_set_is_the_non_empty_set() {
 fn union_of_non_empty_sets_contains_all_unique_elements() {
     let set1 = CustomSet::new(&[1, 3]);
     let set2 = CustomSet::new(&[2, 3]);
-    assert_eq!(set1.union(&set2), CustomSet::new(&[3, 2, 1]));
+    assert_eq!(CustomSet::new(&[3, 2, 1]), set1.union(&set2));
 }

--- a/exercises/decimal/tests/decimal.rs
+++ b/exercises/decimal/tests/decimal.rs
@@ -53,16 +53,16 @@ fn test_lt() {
 #[test]
 #[ignore]
 fn test_add() {
-    assert_eq!(decimal("0.1") + decimal("0.2"), decimal("0.3"));
-    assert_eq!(decimal(BIGS[0]) + decimal(BIGS[1]), decimal(BIGS[2]));
-    assert_eq!(decimal(BIGS[1]) + decimal(BIGS[0]), decimal(BIGS[2]));
+    assert_eq!(decimal("0.3"), decimal("0.1") + decimal("0.2"));
+    assert_eq!(decimal(BIGS[2]), decimal(BIGS[0]) + decimal(BIGS[1]));
+    assert_eq!(decimal(BIGS[2]), decimal(BIGS[1]) + decimal(BIGS[0]));
 }
 
 #[test]
 #[ignore]
 fn test_sub() {
-    assert_eq!(decimal(BIGS[2]) - decimal(BIGS[1]), decimal(BIGS[0]));
-    assert_eq!(decimal(BIGS[2]) - decimal(BIGS[0]), decimal(BIGS[1]));
+    assert_eq!(decimal(BIGS[0]), decimal(BIGS[2]) - decimal(BIGS[1]));
+    assert_eq!(decimal(BIGS[1]), decimal(BIGS[2]) - decimal(BIGS[0]));
 }
 
 #[test]
@@ -77,24 +77,24 @@ fn test_mul() {
 #[test]
 #[ignore]
 fn test_add_id() {
-    assert_eq!(decimal("1.0") + decimal("0.0"), decimal("1.0"));
-    assert_eq!(decimal("0.1") + decimal("0.0"), decimal("0.1"));
-    assert_eq!(decimal("0.0") + decimal("1.0"), decimal("1.0"));
-    assert_eq!(decimal("0.0") + decimal("0.1"), decimal("0.1"));
+    assert_eq!(decimal("1.0"), decimal("1.0") + decimal("0.0"));
+    assert_eq!(decimal("0.1"), decimal("0.1") + decimal("0.0"));
+    assert_eq!(decimal("1.0"), decimal("0.0") + decimal("1.0"));
+    assert_eq!(decimal("0.1"), decimal("0.0") + decimal("0.1"));
 }
 
 #[test]
 #[ignore]
 fn test_sub_id() {
-    assert_eq!(decimal("1.0") - decimal("0.0"), decimal("1.0"));
-    assert_eq!(decimal("0.1") - decimal("0.0"), decimal("0.1"));
+    assert_eq!(decimal("1.0"), decimal("1.0") - decimal("0.0"));
+    assert_eq!(decimal("0.1"), decimal("0.1") - decimal("0.0"));
 }
 
 #[test]
 #[ignore]
 fn test_mul_id() {
-    assert_eq!(decimal("2.1") * decimal("1.0"), decimal("2.1"));
-    assert_eq!(decimal("1.0") * decimal("2.1"), decimal("2.1"));
+    assert_eq!(decimal("2.1"), decimal("2.1") * decimal("1.0"));
+    assert_eq!(decimal("2.1"), decimal("1.0") * decimal("2.1"));
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn test_gt_negative_and_zero() {
 #[test]
 #[ignore]
 fn test_add_uneven_position() {
-    assert_eq!(decimal("0.1") + decimal("0.02"), decimal("0.12"));
+    assert_eq!(decimal("0.12"), decimal("0.1") + decimal("0.02"));
 }
 
 #[test]
@@ -129,22 +129,20 @@ fn test_eq_vary_sig_digits() {
 #[ignore]
 fn test_add_vary_precision() {
     assert_eq!(
+        decimal(BIGS[0]),
         decimal("100000000000000000000000000000000000000000000")
-            + decimal("0.00000000000000000000000000000000000000001"),
-        decimal(BIGS[0])
-    )
+            + decimal("0.00000000000000000000000000000000000000001")
+    );
 }
 
 #[test]
 #[ignore]
 fn test_cleanup_precision() {
     assert_eq!(
+        decimal("20000000000000000000000000000000000000000000001"),
         decimal("10000000000000000000000000000000000000000000000.999999999999999999999999998",)
-            + decimal(
-                "10000000000000000000000000000000000000000000000.000000000000000000000000002",
-            ),
-        decimal("20000000000000000000000000000000000000000000001")
-    )
+            + decimal("10000000000000000000000000000000000000000000000.000000000000000000000000002")
+    );
 }
 
 #[test]
@@ -178,22 +176,22 @@ fn test_gt_varying_negative_precisions() {
 #[ignore]
 fn test_negatives() {
     assert!(Decimal::try_from("-1").is_some());
-    assert_eq!(decimal("0") - decimal("1"), decimal("-1"));
-    assert_eq!(decimal("5.5") + decimal("-6.5"), decimal("-1"));
+    assert_eq!(decimal("-1"), decimal("0") - decimal("1"));
+    assert_eq!(decimal("-1"), decimal("5.5") + decimal("-6.5"));
 }
 
 #[test]
 #[ignore]
 fn test_explicit_positive() {
-    assert_eq!(decimal("+1"), decimal("1"));
-    assert_eq!(decimal("+2.0") - decimal("-0002.0"), decimal("4"));
+    assert_eq!(decimal("1"), decimal("+1"));
+    assert_eq!(decimal("4"), decimal("+2.0") - decimal("-0002.0"));
 }
 
 #[test]
 #[ignore]
 fn test_multiply_by_negative() {
-    assert_eq!(decimal("5") * decimal("-0.2"), decimal("-1"));
-    assert_eq!(decimal("-20") * decimal("-0.2"), decimal("4"));
+    assert_eq!(decimal("-1"), decimal("5") * decimal("-0.2"));
+    assert_eq!(decimal("4"), decimal("-20") * decimal("-0.2"));
 }
 
 #[test]
@@ -209,121 +207,121 @@ fn test_simple_partial_cmp() {
 #[test]
 #[ignore]
 fn test_carry_into_integer() {
-    assert_eq!(decimal("0.901") + decimal("0.1"), decimal("1.001"))
+    assert_eq!(decimal("1.001"), decimal("0.901") + decimal("0.1"));
 }
 
 #[test]
 #[ignore]
 fn test_carry_into_fractional_with_digits_to_right() {
-    assert_eq!(decimal("0.0901") + decimal("0.01"), decimal("0.1001"))
+    assert_eq!(decimal("0.1001"), decimal("0.0901") + decimal("0.01"));
 }
 
 #[test]
 #[ignore]
 fn test_add_carry_over_negative() {
-    assert_eq!(decimal("-1.99") + decimal("-0.01"), decimal("-2.0"))
+    assert_eq!(decimal("-2.0"), decimal("-1.99") + decimal("-0.01"));
 }
 
 #[test]
 #[ignore]
 fn test_sub_carry_over_negative() {
-    assert_eq!(decimal("-1.99") - decimal("0.01"), decimal("-2.0"))
+    assert_eq!(decimal("-2.0"), decimal("-1.99") - decimal("0.01"));
 }
 
 #[test]
 #[ignore]
 fn test_add_carry_over_negative_with_fractional() {
-    assert_eq!(decimal("-1.99") + decimal("-0.02"), decimal("-2.01"))
+    assert_eq!(decimal("-2.01"), decimal("-1.99") + decimal("-0.02"));
 }
 
 #[test]
 #[ignore]
 fn test_sub_carry_over_negative_with_fractional() {
-    assert_eq!(decimal("-1.99") - decimal("0.02"), decimal("-2.01"))
+    assert_eq!(decimal("-2.01"), decimal("-1.99") - decimal("0.02"));
 }
 
 #[test]
 #[ignore]
 fn test_carry_from_rightmost_one() {
-    assert_eq!(decimal("0.09") + decimal("0.01"), decimal("0.1"))
+    assert_eq!(decimal("0.1"), decimal("0.09") + decimal("0.01"));
 }
 
 #[test]
 #[ignore]
 fn test_carry_from_rightmost_more() {
-    assert_eq!(decimal("0.099") + decimal("0.001"), decimal("0.1"))
+    assert_eq!(decimal("0.1"), decimal("0.099") + decimal("0.001"));
 }
 
 #[test]
 #[ignore]
 fn test_carry_from_rightmost_into_integer() {
-    assert_eq!(decimal("0.999") + decimal("0.001"), decimal("1.0"))
+    assert_eq!(decimal("1.0"), decimal("0.999") + decimal("0.001"));
 }
 
 // test arithmetic borrow rules
 #[test]
 #[ignore]
 fn test_add_borrow() {
-    assert_eq!(decimal("0.01") + decimal("-0.0001"), decimal("0.0099"))
+    assert_eq!(decimal("0.0099"), decimal("0.01") + decimal("-0.0001"));
 }
 
 #[test]
 #[ignore]
 fn test_sub_borrow() {
-    assert_eq!(decimal("0.01") - decimal("0.0001"), decimal("0.0099"))
+    assert_eq!(decimal("0.0099"), decimal("0.01") - decimal("0.0001"));
 }
 
 #[test]
 #[ignore]
 fn test_add_borrow_integral() {
-    assert_eq!(decimal("1.0") + decimal("-0.01"), decimal("0.99"))
+    assert_eq!(decimal("0.99"), decimal("1.0") + decimal("-0.01"));
 }
 
 #[test]
 #[ignore]
 fn test_sub_borrow_integral() {
-    assert_eq!(decimal("1.0") - decimal("0.01"), decimal("0.99"))
+    assert_eq!(decimal("0.99"), decimal("1.0") - decimal("0.01"));
 }
 
 #[test]
 #[ignore]
 fn test_add_borrow_integral_zeroes() {
-    assert_eq!(decimal("1.0") + decimal("-0.99"), decimal("0.01"))
+    assert_eq!(decimal("0.01"), decimal("1.0") + decimal("-0.99"));
 }
 
 #[test]
 #[ignore]
 fn test_sub_borrow_integral_zeroes() {
-    assert_eq!(decimal("1.0") - decimal("0.99"), decimal("0.01"))
+    assert_eq!(decimal("0.01"), decimal("1.0") - decimal("0.99"));
 }
 
 #[test]
 #[ignore]
 fn test_borrow_from_negative() {
-    assert_eq!(decimal("-1.0") + decimal("0.01"), decimal("-0.99"))
+    assert_eq!(decimal("-0.99"), decimal("-1.0") + decimal("0.01"));
 }
 
 #[test]
 #[ignore]
 fn test_add_into_fewer_digits() {
-    assert_eq!(decimal("0.011") + decimal("-0.001"), decimal("0.01"))
+    assert_eq!(decimal("0.01"), decimal("0.011") + decimal("-0.001"));
 }
 
 // misc tests of arithmetic properties
 #[test]
 #[ignore]
 fn test_sub_into_fewer_digits() {
-    assert_eq!(decimal("0.011") - decimal("0.001"), decimal("0.01"))
+    assert_eq!(decimal("0.01"), decimal("0.011") - decimal("0.001"));
 }
 
 #[test]
 #[ignore]
 fn test_add_away_decimal() {
-    assert_eq!(decimal("1.1") + decimal("-0.1"), decimal("1.0"))
+    assert_eq!(decimal("1.0"), decimal("1.1") + decimal("-0.1"));
 }
 
 #[test]
 #[ignore]
 fn test_sub_away_decimal() {
-    assert_eq!(decimal("1.1") - decimal("0.1"), decimal("1.0"))
+    assert_eq!(decimal("1.0"), decimal("1.1") - decimal("0.1"));
 }

--- a/exercises/diamond/tests/diamond.rs
+++ b/exercises/diamond/tests/diamond.rs
@@ -3,29 +3,25 @@ use diamond::*;
 
 #[test]
 fn test_a() {
-    assert_eq!(get_diamond('A'), vec!["A"]);
+    assert_eq!(vec!["A"], get_diamond('A'));
 }
 
 #[test]
 #[ignore]
 fn test_b() {
-    assert_eq!(get_diamond('B'), vec![" A ", "B B", " A "]);
+    assert_eq!(vec![" A ", "B B", " A "], get_diamond('B'));
 }
 
 #[test]
 #[ignore]
 fn test_c() {
-    assert_eq!(
-        get_diamond('C'),
-        vec!["  A  ", " B B ", "C   C", " B B ", "  A  "]
-    );
+    assert_eq!(vec!["  A  ", " B B ", "C   C", " B B ", "  A  "], get_diamond('C'));
 }
 
 #[test]
 #[ignore]
 fn test_d() {
     assert_eq!(
-        get_diamond('D'),
         vec![
             "   A   ",
             "  B B  ",
@@ -34,7 +30,8 @@ fn test_d() {
             " C   C ",
             "  B B  ",
             "   A   ",
-        ]
+        ],
+        get_diamond('D')
     );
 }
 
@@ -42,7 +39,6 @@ fn test_d() {
 #[ignore]
 fn test_e() {
     assert_eq!(
-        get_diamond('Z'),
         vec![
             "                         A                         ",
             "                        B B                        ",
@@ -95,6 +91,7 @@ fn test_e() {
             "                       C   C                       ",
             "                        B B                        ",
             "                         A                         ",
-        ]
+        ],
+        get_diamond('Z')
     );
 }

--- a/exercises/diffie-hellman/tests/diffie-hellman.rs
+++ b/exercises/diffie-hellman/tests/diffie-hellman.rs
@@ -21,7 +21,7 @@ fn test_public_key_correct() {
     let private_key: u64 = 6;
     let expected: u64 = 8;
 
-    assert_eq!(public_key(p, g, private_key), expected);
+    assert_eq!(expected, public_key(p, g, private_key));
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn test_secret_key_correct() {
     let secret = secret(p, public_key_b, private_key_a);
     let expected = 2;
 
-    assert_eq!(secret, expected);
+    assert_eq!(expected, secret);
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn test_public_key_correct_big_numbers() {
 
     let expected: u64 = 4096;
 
-    assert_eq!(public_key(p, g, private_key), expected);
+    assert_eq!(expected, public_key(p, g, private_key));
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn test_secret_key_correct_big_numbers() {
 
     let expected = 1_389_354_282;
 
-    assert_eq!(secret, expected);
+    assert_eq!(expected, secret);
 }
 
 #[test]

--- a/exercises/dominoes/tests/dominoes.rs
+++ b/exercises/dominoes/tests/dominoes.rs
@@ -100,7 +100,7 @@ fn singleton_input_singleton_output() {
 #[ignore]
 fn singleton_that_cant_be_chained() {
     let input = &[(1, 2)];
-    assert_eq!(dominoes::chain(input), None);
+    assert_eq!(None, dominoes::chain(input));
 }
 
 #[test]
@@ -121,28 +121,28 @@ fn can_reverse_dominoes() {
 #[ignore]
 fn no_chains() {
     let input = &[(1, 2), (4, 1), (2, 3)];
-    assert_eq!(dominoes::chain(input), None);
+    assert_eq!(None, dominoes::chain(input));
 }
 
 #[test]
 #[ignore]
 fn disconnected_simple() {
     let input = &[(1, 1), (2, 2)];
-    assert_eq!(dominoes::chain(input), None);
+    assert_eq!(None, dominoes::chain(input));
 }
 
 #[test]
 #[ignore]
 fn disconnected_double_loop() {
     let input = &[(1, 2), (2, 1), (3, 4), (4, 3)];
-    assert_eq!(dominoes::chain(input), None);
+    assert_eq!(None, dominoes::chain(input));
 }
 
 #[test]
 #[ignore]
 fn disconnected_single_isolated() {
     let input = &[(1, 2), (2, 3), (3, 1), (4, 4)];
-    assert_eq!(dominoes::chain(input), None);
+    assert_eq!(None, dominoes::chain(input));
 }
 
 #[test]

--- a/exercises/dot-dsl/tests/dot-dsl.rs
+++ b/exercises/dot-dsl/tests/dot-dsl.rs
@@ -28,7 +28,7 @@ fn test_graph_with_one_node() {
 
     assert!(graph.attrs.is_empty());
 
-    assert_eq!(graph.nodes, vec![Node::new("a")]);
+    assert_eq!(vec![Node::new("a")], graph.nodes);
 }
 
 #[test]
@@ -43,8 +43,8 @@ fn test_graph_with_one_node_with_keywords() {
     assert!(graph.attrs.is_empty());
 
     assert_eq!(
-        graph.nodes,
-        vec![Node::new("a").with_attrs(&[("color", "green")])]
+        vec![Node::new("a").with_attrs(&[("color", "green")])],
+        graph.nodes
     );
 }
 
@@ -59,7 +59,7 @@ fn test_graph_with_one_edge() {
 
     assert!(graph.attrs.is_empty());
 
-    assert_eq!(graph.edges, vec![Edge::new("a", "b")]);
+    assert_eq!(vec![Edge::new("a", "b")], graph.edges);
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn test_graph_with_one_attribute() {
 
     assert!(graph.edges.is_empty());
 
-    assert_eq!(graph.attrs, expected_attrs);
+    assert_eq!(expected_attrs, graph.attrs);
 }
 
 #[test]
@@ -106,12 +106,12 @@ fn test_graph_with_attributes() {
         .with_attrs(&attrs);
 
     assert_eq!(
-        graph.nodes,
         vec![
             Node::new("a").with_attrs(&[("color", "green")]),
             Node::new("c"),
             Node::new("b").with_attrs(&[("label", "Beta!")]),
-        ]
+        ],
+        graph.nodes
     );
 
     assert_eq!(
@@ -122,7 +122,7 @@ fn test_graph_with_attributes() {
         ]
     );
 
-    assert_eq!(graph.attrs, expected_attrs);
+    assert_eq!(expected_attrs, graph.attrs);
 }
 
 #[test]
@@ -138,10 +138,10 @@ fn test_graph_stores_attributes() {
     );
 
     assert_eq!(
+        Some("bef"),
         graph
             .get_node("c")
             .expect("node must be stored")
-            .get_attr("bim"),
-        Some("bef")
+            .get_attr("bim")
     );
 }

--- a/exercises/gigasecond/tests/gigasecond.rs
+++ b/exercises/gigasecond/tests/gigasecond.rs
@@ -7,8 +7,8 @@ fn test_date() {
     let start_date = Utc.ymd(2011, 4, 25).and_hms(0, 0, 0);
 
     assert_eq!(
-        gigasecond::after(start_date),
         Utc.ymd(2043, 1, 1).and_hms(1, 46, 40)
+        gigasecond::after(start_date),
     );
 }
 
@@ -18,8 +18,8 @@ fn test_another_date() {
     let start_date = Utc.ymd(1977, 6, 13).and_hms(0, 0, 0);
 
     assert_eq!(
-        gigasecond::after(start_date),
         Utc.ymd(2009, 2, 19).and_hms(1, 46, 40)
+        gigasecond::after(start_date),
     );
 }
 
@@ -29,8 +29,8 @@ fn test_third_date() {
     let start_date = Utc.ymd(1959, 7, 19).and_hms(0, 0, 0);
 
     assert_eq!(
-        gigasecond::after(start_date),
         Utc.ymd(1991, 3, 27).and_hms(1, 46, 40)
+        gigasecond::after(start_date),
     );
 }
 
@@ -40,8 +40,8 @@ fn test_datetime() {
     let start_date = Utc.ymd(2015, 1, 24).and_hms(22, 0, 0);
 
     assert_eq!(
-        gigasecond::after(start_date),
         Utc.ymd(2046, 10, 2).and_hms(23, 46, 40)
+        gigasecond::after(start_date),
     );
 }
 
@@ -51,7 +51,7 @@ fn test_another_datetime() {
     let start_date = Utc.ymd(2015, 1, 24).and_hms(23, 59, 59);
 
     assert_eq!(
-        gigasecond::after(start_date),
         Utc.ymd(2046, 10, 3).and_hms(1, 46, 39)
+        gigasecond::after(start_date),
     );
 }

--- a/exercises/grade-school/tests/grade-school.rs
+++ b/exercises/grade-school/tests/grade-school.rs
@@ -7,7 +7,7 @@ fn some_strings(v: &[&str]) -> Option<Vec<String>> {
 #[test]
 fn test_grades_for_empty_school() {
     let s = school::School::new();
-    assert_eq!(s.grades(), vec![]);
+    assert_eq!(vec![], s.grades());
 }
 
 #[test]
@@ -15,7 +15,7 @@ fn test_grades_for_empty_school() {
 fn test_grades_for_one_student() {
     let mut s = school::School::new();
     s.add(2, "Aimee");
-    assert_eq!(s.grades(), vec![2]);
+    assert_eq!(vec![2], s.grades());
 }
 
 #[test]
@@ -25,7 +25,7 @@ fn test_grades_for_several_students_are_sorted() {
     s.add(2, "Aimee");
     s.add(7, "Logan");
     s.add(4, "Blair");
-    assert_eq!(s.grades(), vec![2, 4, 7]);
+    assert_eq!(vec![2, 4, 7], s.grades());
 }
 
 #[test]
@@ -35,14 +35,14 @@ fn test_grades_when_several_students_have_the_same_grade() {
     s.add(2, "Aimee");
     s.add(2, "Logan");
     s.add(2, "Blair");
-    assert_eq!(s.grades(), vec![2]);
+    assert_eq!(vec![2], s.grades());
 }
 
 #[test]
 #[ignore]
 fn test_grade_for_empty_school() {
     let s = school::School::new();
-    assert_eq!(s.grade(1), None);
+    assert_eq!(None, s.grade(1));
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn test_grade_for_empty_school() {
 fn test_grade_when_no_students_have_that_grade() {
     let mut s = school::School::new();
     s.add(7, "Logan");
-    assert_eq!(s.grade(1), None);
+    assert_eq!(None, s.grade(1));
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn test_grade_when_no_students_have_that_grade() {
 fn test_grade_for_one_student() {
     let mut s = school::School::new();
     s.add(2, "Aimee");
-    assert_eq!(s.grade(2), some_strings(&["Aimee"]));
+    assert_eq!(some_strings(&["Aimee"]), s.grade(2));
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn test_grade_returns_students_sorted_by_name() {
     s.add(2, "James");
     s.add(2, "Blair");
     s.add(2, "Paul");
-    assert_eq!(s.grade(2), some_strings(&["Blair", "James", "Paul"]));
+    assert_eq!(some_strings(&["Blair", "James", "Paul"]), s.grade(2));
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn test_add_students_to_different_grades() {
     let mut s = school::School::new();
     s.add(3, "Chelsea");
     s.add(7, "Logan");
-    assert_eq!(s.grades(), vec![3, 7]);
-    assert_eq!(s.grade(3), some_strings(&["Chelsea"]));
-    assert_eq!(s.grade(7), some_strings(&["Logan"]));
+    assert_eq!(vec![3, 7], s.grades());
+    assert_eq!(some_strings(&["Chelsea"]), s.grade(3));
+    assert_eq!(some_strings(&["Logan"]), s.grade(7));
 }

--- a/exercises/grains/tests/grains.rs
+++ b/exercises/grains/tests/grains.rs
@@ -1,7 +1,7 @@
 use grains;
 
 fn process_square_case(input: u32, expected: u64) {
-    assert_eq!(grains::square(input), expected);
+    assert_eq!(expected, grains::square(input));
 }
 
 #[test]
@@ -70,5 +70,5 @@ fn test_square_greater_than_64_raises_an_exception() {
 #[test]
 #[ignore]
 fn test_returns_the_total_number_of_grains_on_the_board() {
-    assert_eq!(grains::total(), 18_446_744_073_709_551_615);
+    assert_eq!(18_446_744_073_709_551_615, grains::total());
 }

--- a/exercises/grep/tests/grep.rs
+++ b/exercises/grep/tests/grep.rs
@@ -156,7 +156,7 @@ fn process_grep_case(pattern: &str, flags: &[&str], files: &[&str], expected: &[
 
     let grep_result = grep(pattern, &flags, files).unwrap();
 
-    assert_eq!(grep_result, expected);
+    assert_eq!(expected, grep_result);
 }
 
 // Test returning a Result

--- a/exercises/hamming/tests/hamming.rs
+++ b/exercises/hamming/tests/hamming.rs
@@ -2,8 +2,8 @@ use hamming;
 
 fn process_distance_case(strand_pair: [&str; 2], expected_distance: Option<usize>) {
     assert_eq!(
-        hamming::hamming_distance(strand_pair[0], strand_pair[1]),
-        expected_distance
+        expected_distance,
+        hamming::hamming_distance(strand_pair[0], strand_pair[1])
     );
 }
 

--- a/exercises/isogram/tests/isogram.rs
+++ b/exercises/isogram/tests/isogram.rs
@@ -2,21 +2,21 @@ use isogram::check;
 
 #[test]
 fn empty_string() {
-    assert_eq!(check(""), true, "An empty string should be an isogram.")
+    assert_eq!(true, check(""), "An empty string should be an isogram.");
 }
 
 #[test]
 #[ignore]
 fn only_lower_case_characters() {
-    assert_eq!(check("isogram"), true, "\"isogram\" should be an isogram.")
+    assert_eq!(true, check("isogram"), "\"isogram\" should be an isogram.");
 }
 
 #[test]
 #[ignore]
 fn one_duplicated_character() {
     assert_eq!(
-        check("eleven"),
         false,
+        check("eleven"),
         "\"eleven\" has more than one \'e\', therefore it is no isogram."
     )
 }
@@ -25,8 +25,8 @@ fn one_duplicated_character() {
 #[ignore]
 fn longest_reported_english_isogram() {
     assert_eq!(
-        check("subdermatoglyphic"),
         true,
+        check("subdermatoglyphic"),
         "\"subdermatoglyphic\" should be an isogram."
     )
 }
@@ -35,8 +35,8 @@ fn longest_reported_english_isogram() {
 #[ignore]
 fn one_duplicated_character_mixed_case() {
     assert_eq!(
-        check("Alphabet"),
         false,
+        check("Alphabet"),
         "\"Alphabet\" has more than one \'a\', therefore it is no isogram."
     )
 }
@@ -45,8 +45,8 @@ fn one_duplicated_character_mixed_case() {
 #[ignore]
 fn hypothetical_isogramic_word_with_hyphen() {
     assert_eq!(
-        check("thumbscrew-japingly"),
         true,
+        check("thumbscrew-japingly"),
         "\"thumbscrew-japingly\" should be an isogram."
     )
 }
@@ -55,8 +55,8 @@ fn hypothetical_isogramic_word_with_hyphen() {
 #[ignore]
 fn isogram_with_duplicated_hyphen() {
     assert_eq!(
-        check("six-year-old"),
         true,
+        check("six-year-old"),
         "\"six-year-old\" should be an isogram."
     )
 }
@@ -65,8 +65,8 @@ fn isogram_with_duplicated_hyphen() {
 #[ignore]
 fn made_up_name_that_is_an_isogram() {
     assert_eq!(
-        check("Emily Jung Schwartzkopf"),
         true,
+        check("Emily Jung Schwartzkopf"),
         "\"Emily Jung Schwartzkopf\" should be an isogram."
     )
 }
@@ -75,8 +75,8 @@ fn made_up_name_that_is_an_isogram() {
 #[ignore]
 fn duplicated_character_in_the_middle() {
     assert_eq!(
-        check("accentor"),
         false,
+        check("accentor"),
         "\"accentor\" has more than one \'c\', therefore it is no isogram."
     )
 }

--- a/exercises/leap/tests/leap.rs
+++ b/exercises/leap/tests/leap.rs
@@ -1,7 +1,7 @@
 use leap;
 
 fn process_leapyear_case(year: u64, expected: bool) {
-    assert_eq!(leap::is_leap_year(year), expected);
+    assert_eq!(expected, leap::is_leap_year(year));
 }
 
 #[test]
@@ -36,23 +36,23 @@ fn test_year_divisible_by_400_leap_year() {
 #[test]
 #[ignore]
 fn test_any_old_year() {
-    assert_eq!(leap::is_leap_year(1997), false);
+    assert_eq!(false, leap::is_leap_year(1997));
 }
 
 #[test]
 #[ignore]
 fn test_century() {
-    assert_eq!(leap::is_leap_year(1700), false);
-    assert_eq!(leap::is_leap_year(1800), false);
-    assert_eq!(leap::is_leap_year(1900), false);
+    assert_eq!(false, leap::is_leap_year(1700));
+    assert_eq!(false, leap::is_leap_year(1800));
+    assert_eq!(false, leap::is_leap_year(1900));
 }
 
 #[test]
 #[ignore]
 fn test_exceptional_centuries() {
-    assert_eq!(leap::is_leap_year(1600), true);
-    assert_eq!(leap::is_leap_year(2000), true);
-    assert_eq!(leap::is_leap_year(2400), true);
+    assert_eq!(true, leap::is_leap_year(1600));
+    assert_eq!(true, leap::is_leap_year(2000));
+    assert_eq!(true, leap::is_leap_year(2400));
 }
 
 #[test]

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 fn test_empty() {
     let expected: HashMap<u32, u32> = HashMap::new();
     let computed: HashMap<u32, u32> = hashmap!();
-    assert_eq!(computed, expected);
+    assert_eq!(expected, computed);
 }
 
 #[test]
@@ -16,7 +16,7 @@ fn test_no_trailing_comma() {
     let mut expected = HashMap::new();
     expected.insert(1, "one");
     expected.insert(2, "two");
-    assert_eq!(hashmap!(1 => "one", 2 => "two"), expected);
+    assert_eq!(expected, hashmap!(1 => "one", 2 => "two"));
 }
 
 #[test]
@@ -28,13 +28,13 @@ fn test_trailing_comma() {
     expected.insert('s', 19);
     expected.insert('h', 8);
     assert_eq!(
+        expected,
         hashmap!(
             'h' => 89,
             'a' => 1,
             's' => 19,
             'h' => 8,
-        ),
-        expected
+        )
     );
 }
 
@@ -50,14 +50,14 @@ fn test_nested() {
     });
     expected.insert("empty", HashMap::new());
     assert_eq!(
+        expected,
         hashmap!(
             "non-empty" => hashmap!(
                 23 => 623,
                 34 => 21
             ),
             "empty" => hashmap!()
-        ),
-        expected
+        )
     );
 }
 

--- a/exercises/nth-prime/tests/nth-prime.rs
+++ b/exercises/nth-prime/tests/nth-prime.rs
@@ -1,24 +1,16 @@
 use nth_prime as np;
 
 #[test]
-fn test_first_prime() {
-    assert_eq!(np::nth(0), 2);
-}
+fn test_first_prime() { assert_eq!(2, np::nth(0)); }
 
 #[test]
 #[ignore]
-fn test_second_prime() {
-    assert_eq!(np::nth(1), 3);
-}
+fn test_second_prime() { assert_eq!(3, np::nth(1)); }
 
 #[test]
 #[ignore]
-fn test_sixth_prime() {
-    assert_eq!(np::nth(5), 13);
-}
+fn test_sixth_prime() { assert_eq!(13, np::nth(5)); }
 
 #[test]
 #[ignore]
-fn test_big_prime() {
-    assert_eq!(np::nth(10000), 104743);
-}
+fn test_big_prime() { assert_eq!(104743, np::nth(10000)); }

--- a/exercises/nucleotide-count/tests/nucleotide-count.rs
+++ b/exercises/nucleotide-count/tests/nucleotide-count.rs
@@ -9,11 +9,11 @@ fn process_nucleotidecounts_case(s: &str, pairs: &[(char, usize)]) {
     // check for the presence and value of each key in the given pairs vector.
     let mut m: HashMap<char, usize> = dna::nucleotide_counts(s).unwrap();
     for &(k, v) in pairs.iter() {
-        assert_eq!((k, m.remove(&k)), (k, Some(v)));
+        assert_eq!((k, Some(v)), (k, m.remove(&k)));
     }
 
     // may fail with a message that clearly shows all extra pairs in the map
-    assert_eq!(m.iter().collect::<Vec<(&char, &usize)>>(), vec![]);
+    assert_eq!(vec![], m.iter().collect::<Vec<(&char, &usize)>>());
 }
 
 #[test]
@@ -24,31 +24,31 @@ fn count_returns_result() {
 #[test]
 #[ignore]
 fn test_count_empty() {
-    assert_eq!(dna::count('A', ""), Ok(0));
+    assert_eq!(Ok(0), dna::count('A', ""));
 }
 
 #[test]
 #[ignore]
 fn count_invalid_nucleotide() {
-    assert_eq!(dna::count('X', "A"), Err('X'));
+    assert_eq!(Err('X'), dna::count('X', "A"));
 }
 
 #[test]
 #[ignore]
 fn count_invalid_dna() {
-    assert_eq!(dna::count('A', "AX"), Err('X'));
+    assert_eq!(Err('X'), dna::count('A', "AX"));
 }
 
 #[test]
 #[ignore]
 fn test_count_repetitive_cytosine() {
-    assert_eq!(dna::count('C', "CCCCC"), Ok(5));
+    assert_eq!(Ok(5), dna::count('C', "CCCCC"));
 }
 
 #[test]
 #[ignore]
 fn test_count_only_thymine() {
-    assert_eq!(dna::count('T', "GGGGGTAACCCGG"), Ok(1));
+    assert_eq!(Ok(1), dna::count('T', "GGGGGTAACCCGG"));
 }
 
 #[test]
@@ -89,12 +89,12 @@ fn test_strand_with_multiple_nucleotides() {
 #[test]
 #[ignore]
 fn counts_invalid_nucleotide_results_in_err() {
-    assert_eq!(dna::nucleotide_counts("GGXXX"), Err('X'));
+    assert_eq!(Err('X'), dna::nucleotide_counts("GGXXX"));
 }
 
 #[test]
 #[ignore]
 /// strand with invalid nucleotides
 fn test_strand_with_invalid_nucleotides() {
-    assert_eq!(dna::nucleotide_counts("AGXXACT"), Err('X'),);
+    assert_eq!(Err('X'), dna::nucleotide_counts("AGXXACT"));
 }

--- a/exercises/paasio/tests/paasio.rs
+++ b/exercises/paasio/tests/paasio.rs
@@ -194,5 +194,5 @@ fn read_stats_by_ref_returns_wrapped_reader() {
     let input =
         "Why, sometimes I've believed as many as six impossible things before breakfast".as_bytes();
     let reader = ReadStats::new(input);
-    assert_eq!(reader.get_ref(), &input);
+    assert_eq!(&input, reader.get_ref());
 }

--- a/exercises/palindrome-products/tests/palindrome-products.rs
+++ b/exercises/palindrome-products/tests/palindrome-products.rs
@@ -3,54 +3,54 @@ use palindrome_products::*;
 #[test]
 fn single_digits() {
     let palindromes = get_palindrome_products(1, 9);
-    assert_eq!(min(&palindromes), Some(1));
-    assert_eq!(max(&palindromes), Some(9));
+    assert_eq!(Some(1), min(&palindromes));
+    assert_eq!(Some(9), max(&palindromes));
 }
 
 #[test]
 #[ignore]
 fn double_digits() {
     let palindromes = get_palindrome_products(10, 99);
-    assert_eq!(min(&palindromes), Some(121));
-    assert_eq!(max(&palindromes), Some(9009));
+    assert_eq!(Some(121), min(&palindromes));
+    assert_eq!(Some(9009), max(&palindromes));
 }
 
 #[test]
 #[ignore]
 fn triple_digits() {
     let palindromes = get_palindrome_products(100, 999);
-    assert_eq!(min(&palindromes), Some(10201));
-    assert_eq!(max(&palindromes), Some(906609));
+    assert_eq!(Some(10201), min(&palindromes));
+    assert_eq!(Some(906609), max(&palindromes));
 }
 
 #[test]
 #[ignore]
 fn four_digits() {
     let palindromes = get_palindrome_products(1000, 9999);
-    assert_eq!(min(&palindromes), Some(1002001));
-    assert_eq!(max(&palindromes), Some(99000099));
+    assert_eq!(Some(1002001), min(&palindromes));
+    assert_eq!(Some(99000099), max(&palindromes));
 }
 
 #[test]
 #[ignore]
 fn empty_result_for_smallest_palindrome() {
-    assert_eq!(min(&get_palindrome_products(1002, 1003)), None);
+    assert_eq!(None, min(&get_palindrome_products(1002, 1003)));
 }
 
 #[test]
 #[ignore]
 fn empty_result_for_largest_palindrome() {
-    assert_eq!(max(&get_palindrome_products(15, 15)), None);
+    assert_eq!(None, max(&get_palindrome_products(15, 15)));
 }
 
 #[test]
 #[ignore]
 fn error_smallest_palindrome_when_min_gt_max() {
-    assert_eq!(min(&get_palindrome_products(1000, 1)), None);
+    assert_eq!(None, min(&get_palindrome_products(1000, 1)));
 }
 
 #[test]
 #[ignore]
 fn error_largest_palindrome_when_min_st_max() {
-    assert_eq!(max(&get_palindrome_products(2, 1)), None);
+    assert_eq!(None, max(&get_palindrome_products(2, 1)));
 }

--- a/exercises/parallel-letter-frequency/tests/parallel-letter-frequency.rs
+++ b/exercises/parallel-letter-frequency/tests/parallel-letter-frequency.rs
@@ -40,7 +40,7 @@ const STAR_SPANGLED_BANNER: [&str; 8] = [
 
 #[test]
 fn test_no_texts() {
-    assert_eq!(frequency::frequency(&[], 4), HashMap::new());
+    assert_eq!(HashMap::new(), frequency::frequency(&[], 4));
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn test_no_texts() {
 fn test_one_letter() {
     let mut hm = HashMap::new();
     hm.insert('a', 1);
-    assert_eq!(frequency::frequency(&["a"], 4), hm);
+    assert_eq!(hm, frequency::frequency(&["a"], 4));
 }
 
 #[test]
@@ -56,7 +56,7 @@ fn test_one_letter() {
 fn test_case_insensitivity() {
     let mut hm = HashMap::new();
     hm.insert('a', 2);
-    assert_eq!(frequency::frequency(&["aA"], 4), hm);
+    assert_eq!(hm, frequency::frequency(&["aA"], 4));
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn test_many_empty_lines() {
     for _ in 0..1000 {
         v.push("");
     }
-    assert_eq!(frequency::frequency(&v[..], 4), HashMap::new());
+    assert_eq!(HashMap::new(), frequency::frequency(&v[..], 4));
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn test_many_times_same_text() {
     hm.insert('a', 1000);
     hm.insert('b', 1000);
     hm.insert('c', 1000);
-    assert_eq!(frequency::frequency(&v[..], 4), hm);
+    assert_eq!(hm, frequency::frequency(&v[..], 4));
 }
 
 #[test]
@@ -105,9 +105,9 @@ fn test_all_three_anthems_1_worker() {
         }
     }
     let freqs = frequency::frequency(&v[..], 1);
-    assert_eq!(freqs.get(&'a'), Some(&49));
-    assert_eq!(freqs.get(&'t'), Some(&56));
-    assert_eq!(freqs.get(&'ü'), Some(&2));
+    assert_eq!(Some(&49), freqs.get(&'a'));
+    assert_eq!(Some(&56), freqs.get(&'t'));
+    assert_eq!(Some(&2), freqs.get(&'ü'));
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn test_all_three_anthems_3_workers() {
         }
     }
     let freqs = frequency::frequency(&v[..], 3);
-    assert_eq!(freqs.get(&'a'), Some(&49));
-    assert_eq!(freqs.get(&'t'), Some(&56));
-    assert_eq!(freqs.get(&'ü'), Some(&2));
+    assert_eq!(Some(&49), freqs.get(&'a'));
+    assert_eq!(Some(&56), freqs.get(&'t'));
+    assert_eq!(Some(&2), freqs.get(&'ü'));
 }

--- a/exercises/perfect-numbers/tests/perfect-numbers.rs
+++ b/exercises/perfect-numbers/tests/perfect-numbers.rs
@@ -15,12 +15,12 @@ macro_rules! tests {
 }
 
 fn test_classification(num: u64, result: Classification) {
-    assert_eq!(classify(num), Some(result));
+    assert_eq!(Some(result), classify(num));
 }
 
 #[test]
 fn basic() {
-    assert_eq!(classify(0), None);
+    assert_eq!(None, classify(0));
 }
 
 tests! {

--- a/exercises/phone-number/tests/phone-number.rs
+++ b/exercises/phone-number/tests/phone-number.rs
@@ -1,7 +1,7 @@
 use phone_number as phone;
 
 fn process_clean_case(number: &str, expected: Option<&str>) {
-    assert_eq!(phone::number(number), expected.map(|x| x.to_string()));
+    assert_eq!(expected.map(|x| x.to_string()), phone::number(number));
 }
 
 #[test]

--- a/exercises/pig-latin/tests/pig-latin.rs
+++ b/exercises/pig-latin/tests/pig-latin.rs
@@ -2,125 +2,125 @@ use pig_latin as pl;
 
 #[test]
 fn test_word_beginning_with_a() {
-    assert_eq!(pl::translate("apple"), "appleay");
+    assert_eq!("appleay", pl::translate("apple"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_e() {
-    assert_eq!(pl::translate("ear"), "earay");
+    assert_eq!("earay", pl::translate("ear"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_i() {
-    assert_eq!(pl::translate("igloo"), "iglooay");
+    assert_eq!("iglooay", pl::translate("igloo"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_o() {
-    assert_eq!(pl::translate("object"), "objectay");
+    assert_eq!("objectay", pl::translate("object"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_u() {
-    assert_eq!(pl::translate("under"), "underay");
+    assert_eq!("underay", pl::translate("under"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_a_vowel_and_followed_by_a_qu() {
-    assert_eq!(pl::translate("equal"), "equalay");
+    assert_eq!("equalay", pl::translate("equal"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_p() {
-    assert_eq!(pl::translate("pig"), "igpay");
+    assert_eq!("igpay", pl::translate("pig"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_k() {
-    assert_eq!(pl::translate("koala"), "oalakay");
+    assert_eq!("oalakay", pl::translate("koala"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_y() {
-    assert_eq!(pl::translate("yellow"), "ellowyay");
+    assert_eq!("ellowyay", pl::translate("yellow"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_x() {
-    assert_eq!(pl::translate("xenon"), "enonxay");
+    assert_eq!("enonxay", pl::translate("xenon"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_q_without_a_following_u() {
-    assert_eq!(pl::translate("qat"), "atqay");
+    assert_eq!("atqay", pl::translate("qat"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_ch() {
-    assert_eq!(pl::translate("chair"), "airchay");
+    assert_eq!("airchay", pl::translate("chair"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_qu() {
-    assert_eq!(pl::translate("queen"), "eenquay");
+    assert_eq!("eenquay", pl::translate("queen"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_qu_and_a_preceding_consonant() {
-    assert_eq!(pl::translate("square"), "aresquay");
+    assert_eq!("aresquay", pl::translate("square"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_th() {
-    assert_eq!(pl::translate("therapy"), "erapythay");
+    assert_eq!("erapythay", pl::translate("therapy"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_thr() {
-    assert_eq!(pl::translate("thrush"), "ushthray");
+    assert_eq!("ushthray", pl::translate("thrush"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_sch() {
-    assert_eq!(pl::translate("school"), "oolschay");
+    assert_eq!("oolschay", pl::translate("school"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_yt() {
-    assert_eq!(pl::translate("yttria"), "yttriaay");
+    assert_eq!("yttriaay", pl::translate("yttria"));
 }
 
 #[test]
 #[ignore]
 fn test_word_beginning_with_xr() {
-    assert_eq!(pl::translate("xray"), "xrayay");
+    assert_eq!("xrayay", pl::translate("xray"));
 }
 
 #[test]
 #[ignore]
 fn test_y_is_treated_like_a_vowel_at_the_end_of_a_consonant_cluster() {
-    assert_eq!(pl::translate("rhythm"), "ythmrhay");
+    assert_eq!("ythmrhay", pl::translate("rhythm"));
 }
 
 #[test]
 #[ignore]
 fn test_a_whole_phrase() {
-    assert_eq!(pl::translate("quick fast run"), "ickquay astfay unray");
+    assert_eq!("ickquay astfay unray", pl::translate("quick fast run"));
 }

--- a/exercises/poker/tests/poker.rs
+++ b/exercises/poker/tests/poker.rs
@@ -16,8 +16,8 @@ fn hs_from<'a>(input: &[&'a str]) -> HashSet<&'a str> {
 /// abstract away the order of outputs.
 fn test<'a, 'b>(input: &[&'a str], expected: &[&'b str]) {
     assert_eq!(
-        hs_from(&winning_hands(input).expect("This test should produce Some value",)),
-        hs_from(expected)
+        hs_from(expected),
+        hs_from(&winning_hands(input).expect("This test should produce Some value",))
     )
 }
 

--- a/exercises/prime-factors/tests/prime-factors.rs
+++ b/exercises/prime-factors/tests/prime-factors.rs
@@ -1,42 +1,28 @@
 use prime_factors::factors;
 
 #[test]
-fn test_no_factors() {
-    assert_eq!(factors(1), vec![]);
-}
+fn test_no_factors() { assert_eq!(vec![], factors(1)); }
 
 #[test]
 #[ignore]
-fn test_prime_number() {
-    assert_eq!(factors(2), vec![2]);
-}
+fn test_prime_number() { assert_eq!(vec![2], factors(2)); }
 
 #[test]
 #[ignore]
-fn test_square_of_a_prime() {
-    assert_eq!(factors(9), vec![3, 3]);
-}
+fn test_square_of_a_prime() { assert_eq!(vec![3, 3], factors(9)); }
 
 #[test]
 #[ignore]
-fn test_cube_of_a_prime() {
-    assert_eq!(factors(8), vec![2, 2, 2]);
-}
+fn test_cube_of_a_prime() { assert_eq!(vec![2, 2, 2], factors(8)); }
 
 #[test]
 #[ignore]
-fn test_product_of_primes_and_non_primes() {
-    assert_eq!(factors(12), vec![2, 2, 3]);
-}
+fn test_product_of_primes_and_non_primes() { assert_eq!(vec![2, 2, 3], factors(12)); }
 
 #[test]
 #[ignore]
-fn test_product_of_primes() {
-    assert_eq!(factors(901255), vec![5, 17, 23, 461]);
-}
+fn test_product_of_primes() { assert_eq!(vec![5, 17, 23, 461], factors(901255)); }
 
 #[test]
 #[ignore]
-fn test_factors_include_large_prime() {
-    assert_eq!(factors(93819012551), vec![11, 9539, 894119]);
-}
+fn test_factors_include_large_prime() { assert_eq!(vec![11, 9539, 894119], factors(93819012551)); }

--- a/exercises/protein-translation/tests/proteins.rs
+++ b/exercises/protein-translation/tests/proteins.rs
@@ -3,44 +3,44 @@ use protein_translation as proteins;
 #[test]
 fn test_methionine() {
     let info = proteins::parse(make_pairs());
-    assert_eq!(info.name_for("AUG"), Some("methionine"));
+    assert_eq!(Some("methionine"), info.name_for("AUG"));
 }
 
 #[test]
 #[ignore]
 fn test_cysteine_tgt() {
     let info = proteins::parse(make_pairs());
-    assert_eq!(info.name_for("UGU"), Some("cysteine"));
+    assert_eq!(Some("cysteine"), info.name_for("UGU"));
 }
 
 #[test]
 #[ignore]
 fn test_stop() {
     let info = proteins::parse(make_pairs());
-    assert_eq!(info.name_for("UAA"), Some("stop codon"));
+    assert_eq!(Some("stop codon"), info.name_for("UAA"));
 }
 
 #[test]
 #[ignore]
 fn test_valine() {
     let info = proteins::parse(make_pairs());
-    assert_eq!(info.name_for("GUU"), Some("valine"));
+    assert_eq!(Some("valine"), info.name_for("GUU"));
 }
 
 #[test]
 #[ignore]
 fn test_isoleucine() {
     let info = proteins::parse(make_pairs());
-    assert_eq!(info.name_for("AUU"), Some("isoleucine"));
+    assert_eq!(Some("isoleucine"), info.name_for("AUU"));
 }
 
 #[test]
 #[ignore]
 fn test_arginine_name() {
     let info = proteins::parse(make_pairs());
-    assert_eq!(info.name_for("CGA"), Some("arginine"));
-    assert_eq!(info.name_for("AGA"), Some("arginine"));
-    assert_eq!(info.name_for("AGG"), Some("arginine"));
+    assert_eq!(Some("arginine"), info.name_for("CGA"));
+    assert_eq!(Some("arginine"), info.name_for("AGA"));
+    assert_eq!(Some("arginine"), info.name_for("AGG"));
 }
 
 #[test]
@@ -76,8 +76,8 @@ fn too_long_is_invalid() {
 fn test_translates_rna_strand_into_correct_protein() {
     let info = proteins::parse(make_pairs());
     assert_eq!(
-        info.of_rna("AUGUUUUGG"),
-        Some(vec!["methionine", "phenylalanine", "tryptophan"])
+        Some(vec!["methionine", "phenylalanine", "tryptophan"]),
+        info.of_rna("AUGUUUUGG")
     );
 }
 
@@ -86,8 +86,8 @@ fn test_translates_rna_strand_into_correct_protein() {
 fn test_stops_translation_if_stop_codon_present() {
     let info = proteins::parse(make_pairs());
     assert_eq!(
-        info.of_rna("AUGUUUUAA"),
-        Some(vec!["methionine", "phenylalanine"])
+        Some(vec!["methionine", "phenylalanine"]),
+        info.of_rna("AUGUUUUAA")
     );
 }
 
@@ -96,8 +96,8 @@ fn test_stops_translation_if_stop_codon_present() {
 fn test_stops_translation_of_longer_strand() {
     let info = proteins::parse(make_pairs());
     assert_eq!(
-        info.of_rna("UGGUGUUAUUAAUGGUUU"),
-        Some(vec!["tryptophan", "cysteine", "tyrosine"])
+        Some(vec!["tryptophan", "cysteine", "tyrosine"]),
+        info.of_rna("UGGUGUUAUUAAUGGUUU")
     );
 }
 

--- a/exercises/proverb/tests/proverb.rs
+++ b/exercises/proverb/tests/proverb.rs
@@ -8,7 +8,7 @@ fn test_two_pieces() {
         "And all for the want of a nail.",
     ]
     .join("\n");
-    assert_eq!(build_proverb(&input), expected);
+    assert_eq!(expected, build_proverb(&input));
 }
 
 // Notice the change in the last line at three pieces.
@@ -22,7 +22,7 @@ fn test_three_pieces() {
         "And all for the want of a nail.",
     ]
     .join("\n");
-    assert_eq!(build_proverb(&input), expected);
+    assert_eq!(expected, build_proverb(&input));
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn test_three_pieces() {
 fn test_one_piece() {
     let input = vec!["nail"];
     let expected = String::from("And all for the want of a nail.");
-    assert_eq!(build_proverb(&input), expected);
+    assert_eq!(expected, build_proverb(&input));
 }
 
 #[test]
@@ -38,7 +38,7 @@ fn test_one_piece() {
 fn test_zero_pieces() {
     let input: Vec<&str> = vec![];
     let expected = String::new();
-    assert_eq!(build_proverb(&input), expected);
+    assert_eq!(expected, build_proverb(&input));
 }
 
 #[test]
@@ -57,7 +57,7 @@ fn test_full() {
         "And all for the want of a nail.",
     ]
     .join("\n");
-    assert_eq!(build_proverb(&input), expected);
+    assert_eq!(expected, build_proverb(&input));
 }
 
 #[test]
@@ -71,5 +71,5 @@ fn test_three_pieces_modernized() {
         "And all for the want of a pin.",
     ]
     .join("\n");
-    assert_eq!(build_proverb(&input), expected);
+    assert_eq!(expected, build_proverb(&input));
 }

--- a/exercises/rail-fence-cipher/tests/rail-fence-cipher.rs
+++ b/exercises/rail-fence-cipher/tests/rail-fence-cipher.rs
@@ -16,7 +16,7 @@ use rail_fence_cipher::*;
 /// in terms of this function.
 fn process_encode_case(input: &str, rails: u32, expected: &str) {
     let rail_fence = RailFence::new(rails);
-    assert_eq!(rail_fence.encode(input), expected);
+    assert_eq!(expected, rail_fence.encode(input));
 }
 
 /// Process a single test case for the property `decode`
@@ -25,7 +25,7 @@ fn process_encode_case(input: &str, rails: u32, expected: &str) {
 /// in terms of this function.
 fn process_decode_case(input: &str, rails: u32, expected: &str) {
     let rail_fence = RailFence::new(rails);
-    assert_eq!(rail_fence.decode(input), expected);
+    assert_eq!(expected, rail_fence.decode(input));
 }
 
 // encode

--- a/exercises/react/tests/react.rs
+++ b/exercises/react/tests/react.rs
@@ -4,7 +4,7 @@ use react::*;
 fn input_cells_have_a_value() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(10);
-    assert_eq!(reactor.value(CellID::Input(input)), Some(10));
+    assert_eq!(Some(10), reactor.value(CellID::Input(input)));
 }
 
 #[test]
@@ -13,7 +13,7 @@ fn an_input_cells_value_can_be_set() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(4);
     assert!(reactor.set_value(input, 20));
-    assert_eq!(reactor.value(CellID::Input(input)), Some(20));
+    assert_eq!(Some(20), reactor.value(CellID::Input(input)));
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn compute_cells_calculate_initial_value() {
     let output = reactor
         .create_compute(&[CellID::Input(input)], |v| v[0] + 1)
         .unwrap();
-    assert_eq!(reactor.value(CellID::Compute(output)), Some(2));
+    assert_eq!(Some(2), reactor.value(CellID::Compute(output)));
 }
 
 #[test]
@@ -46,7 +46,7 @@ fn compute_cells_take_inputs_in_the_right_order() {
             v[0] + v[1] * 10
         })
         .unwrap();
-    assert_eq!(reactor.value(CellID::Compute(output)), Some(21));
+    assert_eq!(Some(21), reactor.value(CellID::Compute(output)));
 }
 
 #[test]
@@ -55,8 +55,8 @@ fn error_creating_compute_cell_if_input_doesnt_exist() {
     let mut dummy_reactor = Reactor::new();
     let input = dummy_reactor.create_input(1);
     assert_eq!(
-        Reactor::new().create_compute(&[CellID::Input(input)], |_| 0),
-        Err(CellID::Input(input))
+        Err(CellID::Input(input)),
+        Reactor::new().create_compute(&[CellID::Input(input)], |_| 0)
     );
 }
 
@@ -69,11 +69,11 @@ fn do_not_break_cell_if_creating_compute_cell_with_valid_and_invalid_input() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     assert_eq!(
-        reactor.create_compute(&[CellID::Input(input), CellID::Input(dummy_cell)], |_| 0),
-        Err(CellID::Input(dummy_cell))
+        Err(CellID::Input(dummy_cell)),
+        reactor.create_compute(&[CellID::Input(input), CellID::Input(dummy_cell)], |_| 0)
     );
     assert!(reactor.set_value(input, 5));
-    assert_eq!(reactor.value(CellID::Input(input)), Some(5));
+    assert_eq!(Some(5), reactor.value(CellID::Input(input)));
 }
 
 #[test]
@@ -84,9 +84,9 @@ fn compute_cells_update_value_when_dependencies_are_changed() {
     let output = reactor
         .create_compute(&[CellID::Input(input)], |v| v[0] + 1)
         .unwrap();
-    assert_eq!(reactor.value(CellID::Compute(output)), Some(2));
+    assert_eq!(Some(2), reactor.value(CellID::Compute(output)));
     assert!(reactor.set_value(input, 3));
-    assert_eq!(reactor.value(CellID::Compute(output)), Some(4));
+    assert_eq!(Some(4), reactor.value(CellID::Compute(output)));
 }
 
 #[test]
@@ -106,9 +106,9 @@ fn compute_cells_can_depend_on_other_compute_cells() {
             |v| v[0] + v[1],
         )
         .unwrap();
-    assert_eq!(reactor.value(CellID::Compute(output)), Some(32));
+    assert_eq!(Some(32), reactor.value(CellID::Compute(output)));
     assert!(reactor.set_value(input, 3));
-    assert_eq!(reactor.value(CellID::Compute(output)), Some(96));
+    assert_eq!(Some(96), reactor.value(CellID::Compute(output)));
 }
 
 /// A CallbackRecorder helps tests whether callbacks get called correctly.
@@ -137,24 +137,24 @@ impl CallbackRecorder {
             "Callback was not called, but should have been"
         );
         assert_eq!(
-            self.value.replace(None),
             Some(v),
+            self.value.replace(None),
             "Callback was called with incorrect value"
         );
     }
 
     fn expect_not_to_have_been_called(&self) {
         assert_eq!(
-            self.value.get(),
             None,
+            self.value.get(),
             "Callback was called, but should not have been"
         );
     }
 
     fn callback_called(&self, v: i32) {
         assert_eq!(
-            self.value.replace(Some(v)),
             None,
+            self.value.replace(Some(v)),
             "Callback was called too many times; can't be called with {}",
             v
         );
@@ -186,8 +186,8 @@ fn error_adding_callback_to_nonexistent_cell() {
         .create_compute(&[CellID::Input(input)], |_| 0)
         .unwrap();
     assert_eq!(
-        Reactor::new().add_callback(output, |_: u32| println!("hi")),
-        None
+        None,
+        Reactor::new().add_callback(output, |_: u32| println!("hi"))
     );
 }
 
@@ -313,8 +313,8 @@ fn removing_a_callback_multiple_times_doesnt_interfere_with_other_callbacks() {
     assert!(reactor.remove_callback(output, callback).is_ok());
     for _ in 1..5 {
         assert_eq!(
-            reactor.remove_callback(output, callback),
-            Err(RemoveCallbackError::NonexistentCallback)
+            Err(RemoveCallbackError::NonexistentCallback),
+            reactor.remove_callback(output, callback)
         );
     }
 
@@ -428,10 +428,10 @@ fn test_adder_with_boolean_values() {
         assert!(reactor.set_value(b, bval));
         assert!(reactor.set_value(carry_in, cinval));
 
-        assert_eq!(reactor.value(CellID::Compute(sum)), Some(expected_sum));
+        assert_eq!(Some(expected_sum), reactor.value(CellID::Compute(sum)));
         assert_eq!(
-            reactor.value(CellID::Compute(carry_out)),
-            Some(expected_cout)
+            Some(expected_cout),
+            reactor.value(CellID::Compute(carry_out))
         );
     }
 }

--- a/exercises/reverse-string/tests/reverse-string.rs
+++ b/exercises/reverse-string/tests/reverse-string.rs
@@ -9,7 +9,7 @@ use reverse_string::*;
 
 /// Process a single test case for the property `reverse`
 fn process_reverse_case(input: &str, expected: &str) {
-    assert_eq!(&reverse(input), expected)
+    assert_eq!(expected, &reverse(input))
 }
 
 #[test]

--- a/exercises/rna-transcription/tests/rna-transcription.rs
+++ b/exercises/rna-transcription/tests/rna-transcription.rs
@@ -15,11 +15,11 @@ fn test_valid_rna_input() {
 #[ignore]
 fn test_invalid_dna_input() {
     // Invalid character
-    assert_eq!(dna::DNA::new("X").err(), Some(0));
+    assert_eq!(Some(0), dna::DNA::new("X").err());
     // Valid nucleotide, but invalid in context
-    assert_eq!(dna::DNA::new("U").err(), Some(0));
+    assert_eq!(Some(0), dna::DNA::new("U").err());
     // Longer string with contained errors
-    assert_eq!(dna::DNA::new("ACGTUXXCTTAA").err(), Some(4));
+    assert_eq!(Some(4), dna::DNA::new("ACGTUXXCTTAA").err());
 }
 
 #[test]
@@ -84,5 +84,5 @@ fn test_transcribes_all_dna_to_rna() {
     assert_eq!(
         dna::RNA::new("UGCACCAGAAUU").unwrap(),
         dna::DNA::new("ACGTGGTCTTAA").unwrap().into_rna()
-    )
+    );
 }

--- a/exercises/say/tests/say.rs
+++ b/exercises/say/tests/say.rs
@@ -6,7 +6,7 @@ use say;
 
 #[test]
 fn test_zero() {
-    assert_eq!(say::encode(0), String::from("zero"));
+    assert_eq!(String::from("zero"), say::encode(0));
 }
 
 //
@@ -16,118 +16,110 @@ fn test_zero() {
 #[test]
 #[ignore]
 fn test_negative() {
-    assert_eq!(say::encode(-1), String::from("won't compile"));
+    assert_eq!(String::from("won't compile"), say::encode(-1));
 }
 */
 
 #[test]
 #[ignore]
 fn test_one() {
-    assert_eq!(say::encode(1), String::from("one"));
+    assert_eq!(String::from("one"), say::encode(1));
 }
 
 #[test]
 #[ignore]
 fn test_fourteen() {
-    assert_eq!(say::encode(14), String::from("fourteen"));
+    assert_eq!(String::from("fourteen"), say::encode(14));
 }
 
 #[test]
 #[ignore]
 fn test_twenty() {
-    assert_eq!(say::encode(20), String::from("twenty"));
+    assert_eq!(String::from("twenty"), say::encode(20));
 }
 
 #[test]
 #[ignore]
 fn test_twenty_two() {
-    assert_eq!(say::encode(22), String::from("twenty-two"));
+    assert_eq!(String::from("twenty-two"), say::encode(22));
 }
 
 #[test]
 #[ignore]
 fn test_one_hundred() {
-    assert_eq!(say::encode(100), String::from("one hundred"));
+    assert_eq!(String::from("one hundred"), say::encode(100));
 }
 
 // note, using American style with no and
 #[test]
 #[ignore]
 fn test_one_hundred_twenty() {
-    assert_eq!(say::encode(120), String::from("one hundred twenty"));
+    assert_eq!(String::from("one hundred twenty"), say::encode(120));
 }
 
 #[test]
 #[ignore]
 fn test_one_hundred_twenty_three() {
-    assert_eq!(say::encode(123), String::from("one hundred twenty-three"));
+    assert_eq!(String::from("one hundred twenty-three"), say::encode(123));
 }
 
 #[test]
 #[ignore]
 fn test_one_thousand() {
-    assert_eq!(say::encode(1000), String::from("one thousand"));
+    assert_eq!(String::from("one thousand"), say::encode(1000));
 }
 
 #[test]
 #[ignore]
 fn test_one_thousand_two_hundred_thirty_four() {
-    assert_eq!(
-        say::encode(1234),
-        String::from("one thousand two hundred thirty-four")
-    );
+    assert_eq!(String::from("one thousand two hundred thirty-four"), 
+        say::encode(1234));
 }
 
 // note, using American style with no and
 #[test]
 #[ignore]
 fn test_eight_hundred_and_ten_thousand() {
-    assert_eq!(
-        say::encode(810_000),
-        String::from("eight hundred ten thousand")
-    );
+    assert_eq!(String::from("eight hundred ten thousand"), 
+        say::encode(810_000));
 }
 
 #[test]
 #[ignore]
 fn test_one_million() {
-    assert_eq!(say::encode(1_000_000), String::from("one million"));
+    assert_eq!(String::from("one million"), say::encode(1_000_000));
 }
 
 // note, using American style with no and
 #[test]
 #[ignore]
 fn test_one_million_two() {
-    assert_eq!(say::encode(1_000_002), String::from("one million two"));
+    assert_eq!(String::from("one million two"), say::encode(1_000_002));
 }
 
 #[test]
 #[ignore]
 fn test_1002345() {
-    assert_eq!(
-        say::encode(1_002_345),
-        String::from("one million two thousand three hundred forty-five")
-    );
+    assert_eq!(String::from("one million two thousand three hundred forty-five"), 
+        say::encode(1_002_345));
 }
 
 #[test]
 #[ignore]
 fn test_one_billion() {
-    assert_eq!(say::encode(1_000_000_000), String::from("one billion"));
+    assert_eq!(String::from("one billion"), say::encode(1_000_000_000));
 }
 
 #[test]
 #[ignore]
 fn test_987654321123() {
-    assert_eq!(
-        say::encode(987_654_321_123),
-        String::from(
+    assert_eq!(String::from(
             "nine hundred eighty-seven billion \
              six hundred fifty-four million \
              three hundred twenty-one thousand \
              one hundred twenty-three"
-        )
-    );
+        ), 
+        say::encode(987_654_321_123));
 }
 
 /*
@@ -136,27 +128,23 @@ fn test_987654321123() {
 #[test]
 #[ignore]
 fn test_max_i64() {
-    assert_eq!(
-        say::encode(9_223_372_036_854_775_807),
-        String::from(
+    assert_eq!(String::from(
             "nine quintillion two hundred twenty-three \
              quadrillion three hundred seventy-two trillion \
              thirty-six billion eight hundred fifty-four million \
              seven hundred seventy-five thousand eight hundred seven"
-        )
-    );
+        ), 
+        say::encode(9_223_372_036_854_775_807));
 }
 
 #[test]
 #[ignore]
 fn test_max_u64() {
-    assert_eq!(
-        say::encode(18_446_744_073_709_551_615),
-        String::from(
+    assert_eq!(String::from(
             "eighteen quintillion four hundred forty-six \
              quadrillion seven hundred forty-four trillion \
              seventy-three billion seven hundred nine million \
              five hundred fifty-one thousand six hundred fifteen"
-        )
-    );
+        ), 
+        say::encode(18_446_744_073_709_551_615));
 }

--- a/exercises/scale-generator/tests/scale-generator.rs
+++ b/exercises/scale-generator/tests/scale-generator.rs
@@ -13,7 +13,7 @@ use scale_generator::*;
 /// in terms of this function.
 fn process_chromatic_case(tonic: &str, expected: &[&str]) {
     let s = Scale::chromatic(tonic).unwrap();
-    assert_eq!(s.enumerate(), expected);
+    assert_eq!(expected, s.enumerate());
 }
 
 /// Process a single test case for the property `interval`
@@ -22,7 +22,7 @@ fn process_chromatic_case(tonic: &str, expected: &[&str]) {
 /// in terms of this function.
 fn process_interval_case(tonic: &str, intervals: &str, expected: &[&str]) {
     let s = Scale::new(tonic, intervals).unwrap();
-    assert_eq!(s.enumerate(), expected);
+    assert_eq!(expected, s.enumerate());
 }
 
 // Chromatic scales

--- a/exercises/scrabble-score/tests/scrabble-score.rs
+++ b/exercises/scrabble-score/tests/scrabble-score.rs
@@ -2,73 +2,73 @@ use scrabble_score::*;
 
 #[test]
 fn a_is_worth_one_point() {
-    assert_eq!(score("a"), 1);
+    assert_eq!(1, score("a"));
 }
 
 #[test]
 #[ignore]
 fn scoring_is_case_insensitive() {
-    assert_eq!(score("A"), 1);
+    assert_eq!(1, score("A"));
 }
 
 #[test]
 #[ignore]
 fn f_is_worth_four() {
-    assert_eq!(score("f"), 4);
+    assert_eq!(4, score("f"));
 }
 
 #[test]
 #[ignore]
 fn two_one_point_letters_make_a_two_point_word() {
-    assert_eq!(score("at"), 2);
+    assert_eq!(2, score("at"));
 }
 
 #[test]
 #[ignore]
 fn three_letter_word() {
-    assert_eq!(score("zoo"), 12);
+    assert_eq!(12, score("zoo"));
 }
 
 #[test]
 #[ignore]
 fn medium_word() {
-    assert_eq!(score("street"), 6);
+    assert_eq!(6, score("street"));
 }
 
 #[test]
 #[ignore]
 fn longer_words_with_valuable_letters() {
-    assert_eq!(score("quirky"), 22);
+    assert_eq!(22, score("quirky"));
 }
 
 #[test]
 #[ignore]
 fn long_mixed_case_word() {
-    assert_eq!(score("OxyphenButazone"), 41);
+    assert_eq!(41, score("OxyphenButazone"));
 }
 
 #[test]
 #[ignore]
 fn non_english_scrabble_letters_do_not_score() {
-    assert_eq!(score("pinata"), 8, "'n' should score 1");
-    assert_eq!(score("piñata"), 7, "'ñ' should score 0");
+    assert_eq!(8, score("pinata"), "'n' should score 1");
+    assert_eq!(7, score("piñata"), "'ñ' should score 0");
 }
 
 #[test]
 #[ignore]
 fn empty_words_are_worth_zero() {
-    assert_eq!(score(""), 0);
+    assert_eq!(0, score(""));
 }
 
 #[test]
 #[ignore]
 fn all_letters_work() {
-    assert_eq!(score("abcdefghijklmnopqrstuvwxyz"), 87);
+    assert_eq!(87, score("abcdefghijklmnopqrstuvwxyz"));
 }
 
 #[test]
 #[ignore]
 fn german_letters_do_not_score() {
-    assert_eq!(score("STRASSE"), 7, "\"SS\" should score 2");
-    assert_eq!(score("STRAßE"), 5, "'ß' should score 0");
+    assert_eq!(7, "\"SS\" should score 2", score("STRASSE"));
+    assert_eq!(5, score("STRAßE"), "'ß' should score 0");
 }

--- a/exercises/series/tests/series.rs
+++ b/exercises/series/tests/series.rs
@@ -3,7 +3,7 @@ use series::*;
 #[test]
 fn test_with_zero_length() {
     let expected = vec!["".to_string(); 6];
-    assert_eq!(series("92017", 0), expected);
+    assert_eq!(expected, series("92017", 0));
 }
 
 #[test]
@@ -15,19 +15,19 @@ fn test_with_length_2() {
         "01".to_string(),
         "17".to_string(),
     ];
-    assert_eq!(series("92017", 2), expected);
+    assert_eq!(expected, series("92017", 2));
 }
 
 #[test]
 #[ignore]
 fn test_with_numbers_length() {
     let expected = vec!["92017".to_string()];
-    assert_eq!(series("92017", 5), expected);
+    assert_eq!(expected, series("92017", 5));
 }
 
 #[test]
 #[ignore]
 fn test_too_long() {
     let expected: Vec<String> = vec![];
-    assert_eq!(series("92017", 6), expected);
+    assert_eq!(expected, series("92017", 6));
 }

--- a/exercises/sieve/tests/sieve.rs
+++ b/exercises/sieve/tests/sieve.rs
@@ -2,25 +2,25 @@ use sieve;
 
 #[test]
 fn limit_lower_than_the_first_prime() {
-    assert_eq!(sieve::primes_up_to(1), []);
+    assert_eq!([], sieve::primes_up_to(1));
 }
 
 #[test]
 #[ignore]
 fn limit_is_the_first_prime() {
-    assert_eq!(sieve::primes_up_to(2), [2]);
+    assert_eq!([2], sieve::primes_up_to(2));
 }
 
 #[test]
 #[ignore]
 fn primes_up_to_10() {
-    assert_eq!(sieve::primes_up_to(10), [2, 3, 5, 7]);
+    assert_eq!([2, 3, 5, 7], sieve::primes_up_to(10));
 }
 
 #[test]
 #[ignore]
 fn limit_is_prime() {
-    assert_eq!(sieve::primes_up_to(13), [2, 3, 5, 7, 11, 13]);
+    assert_eq!([2, 3, 5, 7, 11, 13], sieve::primes_up_to(13));
 }
 
 #[test]
@@ -37,5 +37,5 @@ fn limit_of_1000() {
         751, 757, 761, 769, 773, 787, 797, 809, 811, 821, 823, 827, 829, 839, 853, 857, 859, 863,
         877, 881, 883, 887, 907, 911, 919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997,
     ];
-    assert_eq!(sieve::primes_up_to(1000), expected);
+    assert_eq!(expected, sieve::primes_up_to(1000));
 }

--- a/exercises/simple-cipher/tests/simple-cipher.rs
+++ b/exercises/simple-cipher/tests/simple-cipher.rs
@@ -6,13 +6,13 @@ const KEY: &str = "abcdefghij";
 
 #[test]
 fn cipher_can_encode_with_given_key() {
-    assert_eq!(encode(KEY, "aaaaaaaaaa"), Some(KEY.to_string()));
+    assert_eq!(Some(KEY.to_string(), encode(KEY, "aaaaaaaaaa")));
 }
 
 #[test]
 #[ignore]
 fn cipher_can_decode_with_given_key() {
-    assert_eq!(decode(KEY, "abcdefghij"), Some("aaaaaaaaaa".to_string()));
+    assert_eq!(Some("aaaaaaaaaa".to_string(), decode(KEY, "abcdefghij")));
 }
 
 #[test]
@@ -28,98 +28,97 @@ fn cipher_is_reversible_given_key() {
 #[ignore]
 fn cipher_can_double_shift_encode() {
     let plain_text = "iamapandabear";
-    assert_eq!(
-        encode(plain_text, plain_text),
-        Some("qayaeaagaciai".to_string())
+    assert_eq!(Some("qayaeaagaciai".to_string(), 
+        encode(plain_text, plain_text))
     );
 }
 
 #[test]
 #[ignore]
 fn cipher_can_wrap_encode() {
-    assert_eq!(encode(KEY, "zzzzzzzzzz"), Some("zabcdefghi".to_string()));
+    assert_eq!(Some("zabcdefghi".to_string(), encode(KEY, "zzzzzzzzzz")));
 }
 
 #[test]
 #[ignore]
 fn cipher_can_encode_a_message_that_is_shorter_than_the_key() {
-    assert_eq!(encode(KEY, "aaaaa"), Some("abcde".to_string()));
+    assert_eq!(Some("abcde".to_string(), encode(KEY, "aaaaa")));
 }
 
 #[test]
 #[ignore]
 fn cipher_can_decode_a_message_that_is_shorter_than_the_key() {
-    assert_eq!(decode(KEY, "abcde"), Some("aaaaa".to_string()));
+    assert_eq!(Some("aaaaa".to_string(), decode(KEY, "abcde")));
 }
 
 #[test]
 #[ignore]
 fn encode_returns_none_with_an_all_caps_key() {
     let key = "ABCDEF";
-    assert_eq!(encode(key, PLAIN_TEXT), None);
+    assert_eq!(None, encode(key, PLAIN_TEXT));
 }
 
 #[test]
 #[ignore]
 fn encode_returns_none_with_an_any_caps_key() {
     let key = "abcdEFg";
-    assert_eq!(encode(key, PLAIN_TEXT), None);
+    assert_eq!(None, encode(key, PLAIN_TEXT));
 }
 
 #[test]
 #[ignore]
 fn encode_returns_none_with_numeric_key() {
     let key = "12345";
-    assert_eq!(encode(key, PLAIN_TEXT), None);
+    assert_eq!(None, encode(key, PLAIN_TEXT));
 }
 
 #[test]
 #[ignore]
 fn encode_returns_none_with_any_numeric_key() {
     let key = "abcd345ef";
-    assert_eq!(encode(key, PLAIN_TEXT), None);
+    assert_eq!(None, encode(key, PLAIN_TEXT));
 }
 
 #[test]
 #[ignore]
 fn encode_returns_none_with_empty_key() {
     let key = "";
-    assert_eq!(encode(key, PLAIN_TEXT), None);
+    assert_eq!(None, encode(key, PLAIN_TEXT));
 }
 
 #[test]
 #[ignore]
 fn decode_returns_none_with_an_all_caps_key() {
     let key = "ABCDEF";
-    assert_eq!(decode(key, PLAIN_TEXT), None);
+    assert_eq!(None, decode(key, PLAIN_TEXT));
 }
 
 #[test]
 #[ignore]
 fn decode_returns_none_with_an_any_caps_key() {
     let key = "abcdEFg";
-    assert_eq!(decode(key, PLAIN_TEXT), None);
+    assert_eq!(None, decode(key, PLAIN_TEXT));
 }
 
 #[test]
 #[ignore]
 fn decode_returns_none_with_numeric_key() {
     let key = "12345";
-    assert_eq!(decode(key, PLAIN_TEXT), None);
+    assert_eq!(None, decode(key, PLAIN_TEXT));
 }
 
 #[test]
 #[ignore]
 fn decode_returns_none_with_any_numeric_key() {
     let key = "abcd345ef";
-    assert_eq!(decode(key, PLAIN_TEXT), None);
+    assert_eq!(None, decode(key, PLAIN_TEXT));
 }
 
 #[test]
 #[ignore]
 fn decode_returns_none_with_empty_key() {
     let key = "";
-    assert_eq!(decode(key, PLAIN_TEXT), None);
+    assert_eq!(None, decode(key, PLAIN_TEXT));
 }
 
 #[test]
@@ -144,26 +143,26 @@ fn encode_random_uses_randomly_generated_key() {
     for _ in 0..trials {
         keys.insert(encode_random(PLAIN_TEXT).0);
     }
-    assert_eq!(keys.len(), trials);
+    assert_eq!(trials, keys.len());
 }
 
 #[test]
 #[ignore]
 fn encode_random_can_encode() {
     let (k, encoded) = encode_random("aaaaaaaaaa");
-    assert_eq!(encoded, k.split_at(10).0);
+    assert_eq!(k.split_at(10).0, encoded);
 }
 
 #[test]
 #[ignore]
 fn encode_random_can_decode() {
     let (k, _) = encode_random("aaaaaaaaaa");
-    assert_eq!(decode(&k, k.split_at(10).0), Some("aaaaaaaaaa".to_string()));
+    assert_eq!(Some("aaaaaaaaaa".to_string()), decode(&k, k.split_at(10).0));
 }
 
 #[test]
 #[ignore]
 fn encode_random_is_reversible() {
     let (k, encoded) = encode_random(PLAIN_TEXT);
-    assert_eq!(decode(&k, &encoded), Some(PLAIN_TEXT.to_string()));
+    assert_eq!(Some(PLAIN_TEXT.to_string(), decode(&k, &encoded)));
 }

--- a/exercises/simple-linked-list/tests/simple-linked-list.rs
+++ b/exercises/simple-linked-list/tests/simple-linked-list.rs
@@ -3,7 +3,7 @@ use simple_linked_list::SimpleLinkedList;
 #[test]
 fn test_new_list_is_empty() {
     let list: SimpleLinkedList<u32> = SimpleLinkedList::new();
-    assert_eq!(list.len(), 0, "list's length must be 0");
+    assert_eq!(0, list.len(), "list's length must be 0");
 }
 
 #[test]
@@ -11,9 +11,9 @@ fn test_new_list_is_empty() {
 fn test_push_increments_length() {
     let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
     list.push(1);
-    assert_eq!(list.len(), 1, "list's length must be 1");
+    assert_eq!(1, list.len(), "list's length must be 1");
     list.push(2);
-    assert_eq!(list.len(), 2, "list's length must be 2");
+    assert_eq!(2, list.len(), "list's length must be 2");
 }
 
 #[test]
@@ -23,9 +23,9 @@ fn test_pop_decrements_length() {
     list.push(1);
     list.push(2);
     list.pop();
-    assert_eq!(list.len(), 1, "list's length must be 1");
+    assert_eq!(1, list.len(), "list's length must be 1");
     list.pop();
-    assert_eq!(list.len(), 0, "list's length must be 0");
+    assert_eq!(0, list.len(), "list's length must be 0");
 }
 
 #[test]
@@ -34,19 +34,19 @@ fn test_pop_returns_last_added_element() {
     let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
     list.push(1);
     list.push(2);
-    assert_eq!(list.pop(), Some(2), "Element must be 2");
-    assert_eq!(list.pop(), Some(1), "Element must be 1");
-    assert_eq!(list.pop(), None, "No element should be contained in list");
+    assert_eq!(Some(2), list.pop(), "Element must be 2");
+    assert_eq!(Some(1), list.pop(), "Element must be 1");
+    assert_eq!(None, list.pop(), "No element should be contained in list");
 }
 
 #[test]
 #[ignore]
 fn test_peek_returns_head_element() {
     let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
-    assert_eq!(list.peek(), None, "No element should be contained in list");
+    assert_eq!(None, list.peek(), "No element should be contained in list");
     list.push(2);
-    assert_eq!(list.peek(), Some(&2), "Element must be 2");
-    assert_eq!(list.peek(), Some(&2), "Element must be still 2");
+    assert_eq!(Some(&2), list.peek(), "Element must be 2");
+    assert_eq!(Some(&2), list.peek(), "Element must be still 2");
 }
 
 #[test]
@@ -54,10 +54,10 @@ fn test_peek_returns_head_element() {
 fn test_from_slice() {
     let array = ["1", "2", "3", "4"];
     let mut list = SimpleLinkedList::from(array.as_ref());
-    assert_eq!(list.pop(), Some("4"));
-    assert_eq!(list.pop(), Some("3"));
-    assert_eq!(list.pop(), Some("2"));
-    assert_eq!(list.pop(), Some("1"));
+    assert_eq!(Some("4"), list.pop());
+    assert_eq!(Some("3"), list.pop());
+    assert_eq!(Some("2"), list.pop());
+    assert_eq!(Some("1"), list.pop());
 }
 
 #[test]
@@ -68,10 +68,10 @@ fn test_reverse() {
     list.push(2);
     list.push(3);
     let mut rev_list = list.rev();
-    assert_eq!(rev_list.pop(), Some(1));
-    assert_eq!(rev_list.pop(), Some(2));
-    assert_eq!(rev_list.pop(), Some(3));
-    assert_eq!(rev_list.pop(), None);
+    assert_eq!(Some(1), rev_list.pop());
+    assert_eq!(Some(2), rev_list.pop());
+    assert_eq!(Some(3), rev_list.pop());
+    assert_eq!(None, rev_list.pop());
 }
 
 #[test]

--- a/exercises/spiral-matrix/tests/spiral-matrix.rs
+++ b/exercises/spiral-matrix/tests/spiral-matrix.rs
@@ -3,7 +3,7 @@ use spiral_matrix::*;
 #[test]
 fn empty_spiral() {
     let expected: Vec<Vec<u32>> = Vec::new();
-    assert_eq!(spiral_matrix(0), expected);
+    assert_eq!(expected, spiral_matrix(0));
 }
 
 #[test]
@@ -11,7 +11,7 @@ fn empty_spiral() {
 fn size_one_spiral() {
     let mut expected: Vec<Vec<u32>> = Vec::new();
     expected.push(vec![1]);
-    assert_eq!(spiral_matrix(1), expected);
+    assert_eq!(expected, spiral_matrix(1));
 }
 #[test]
 #[ignore]
@@ -19,7 +19,7 @@ fn size_two_spiral() {
     let mut expected: Vec<Vec<u32>> = Vec::new();
     expected.push(vec![1, 2]);
     expected.push(vec![4, 3]);
-    assert_eq!(spiral_matrix(2), expected);
+    assert_eq!(expected, spiral_matrix(2));
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn size_three_spiral() {
     expected.push(vec![1, 2, 3]);
     expected.push(vec![8, 9, 4]);
     expected.push(vec![7, 6, 5]);
-    assert_eq!(spiral_matrix(3), expected);
+    assert_eq!(expected, spiral_matrix(3));
 }
 #[test]
 #[ignore]
@@ -39,7 +39,7 @@ fn size_four_spiral() {
     expected.push(vec![12, 13, 14, 5]);
     expected.push(vec![11, 16, 15, 6]);
     expected.push(vec![10, 9, 8, 7]);
-    assert_eq!(spiral_matrix(4), expected);
+    assert_eq!(expected, spiral_matrix(4));
 }
 #[test]
 #[ignore]
@@ -50,5 +50,5 @@ fn size_five_spiral() {
     expected.push(vec![15, 24, 25, 20, 7]);
     expected.push(vec![14, 23, 22, 21, 8]);
     expected.push(vec![13, 12, 11, 10, 9]);
-    assert_eq!(spiral_matrix(5), expected);
+    assert_eq!(expected, spiral_matrix(5));
 }

--- a/exercises/tournament/tests/tournament.rs
+++ b/exercises/tournament/tests/tournament.rs
@@ -5,7 +5,7 @@ fn just_the_header_if_no_input() {
     let input = "";
     let expected = "Team                           | MP |  W |  D |  L |  P";
 
-    assert_eq!(tournament::tally(&input), expected);
+    assert_eq!(expected, tournament::tally(&input));
 }
 
 #[test]
@@ -17,7 +17,7 @@ fn a_win_is_three_points_a_loss_is_zero_points() {
         + "Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3\n"
         + "Blithering Badgers             |  1 |  0 |  0 |  1 |  0";
 
-    assert_eq!(tournament::tally(&input), expected);
+    assert_eq!(expected, tournament::tally(&input));
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn a_win_can_also_be_expressed_as_a_loss() {
         + "Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3\n"
         + "Blithering Badgers             |  1 |  0 |  0 |  1 |  0";
 
-    assert_eq!(tournament::tally(&input), expected);
+    assert_eq!(expected, tournament::tally(&input));
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn a_different_team_can_win() {
         + "Blithering Badgers             |  1 |  1 |  0 |  0 |  3\n"
         + "Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0";
 
-    assert_eq!(tournament::tally(&input), expected);
+    assert_eq!(expected, tournament::tally(&input));
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn there_can_be_more_than_one_match() {
         + "Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6\n"
         + "Blithering Badgers             |  2 |  0 |  0 |  2 |  0";
 
-    assert_eq!(tournament::tally(&input), expected);
+    assert_eq!(expected, tournament::tally(&input));
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn a_draw_is_one_point_each() {
         + "Allegoric Alaskans             |  2 |  1 |  1 |  0 |  4\n"
         + "Blithering Badgers             |  2 |  0 |  1 |  1 |  1";
 
-    assert_eq!(tournament::tally(&input), expected);
+    assert_eq!(expected, tournament::tally(&input));
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn there_can_be_more_than_one_winner() {
         + "Allegoric Alaskans             |  2 |  1 |  0 |  1 |  3\n"
         + "Blithering Badgers             |  2 |  1 |  0 |  1 |  3";
 
-    assert_eq!(tournament::tally(&input), expected);
+    assert_eq!(expected, tournament::tally(&input));
 }
 
 #[test]
@@ -95,7 +95,7 @@ fn there_can_be_more_than_two_teams() {
         + "Blithering Badgers             |  2 |  1 |  0 |  1 |  3\n"
         + "Courageous Californians        |  2 |  0 |  0 |  2 |  0";
 
-    assert_eq!(tournament::tally(&input), expected);
+    assert_eq!(expected, tournament::tally(&input));
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn typical_input() {
         + "Blithering Badgers             |  3 |  1 |  0 |  2 |  3\n"
         + "Courageous Californians        |  3 |  0 |  1 |  2 |  1";
 
-    assert_eq!(tournament::tally(&input), expected);
+    assert_eq!(expected, tournament::tally(&input));
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn incomplete_competition_not_all_pairs_have_played() {
         + "Courageous Californians        |  2 |  0 |  1 |  1 |  1\n"
         + "Devastating Donkeys            |  1 |  0 |  0 |  1 |  0";
 
-    assert_eq!(tournament::tally(&input), expected);
+    assert_eq!(expected, tournament::tally(&input));
 }
 
 #[test]
@@ -150,5 +150,5 @@ fn ties_broken_alphabetically() {
         + "Blithering Badgers             |  3 |  0 |  1 |  2 |  1\n"
         + "Devastating Donkeys            |  3 |  0 |  1 |  2 |  1";
 
-    assert_eq!(tournament::tally(&input), expected);
+    assert_eq!(expected, tournament::tally(&input));
 }

--- a/exercises/two-bucket/tests/two-bucket.rs
+++ b/exercises/two-bucket/tests/two-bucket.rs
@@ -3,12 +3,12 @@ use two_bucket::{solve, Bucket, BucketStats};
 #[test]
 fn test_case_1() {
     assert_eq!(
-        solve(3, 5, 1, &Bucket::One),
         BucketStats {
             moves: 4,
             goal_bucket: Bucket::One,
             other_bucket: 5,
-        }
+        },
+        solve(3, 5, 1, &Bucket::One)
     );
 }
 
@@ -16,12 +16,12 @@ fn test_case_1() {
 #[ignore]
 fn test_case_2() {
     assert_eq!(
-        solve(3, 5, 1, &Bucket::Two),
         BucketStats {
             moves: 8,
             goal_bucket: Bucket::Two,
             other_bucket: 3,
-        }
+        },
+        solve(3, 5, 1, &Bucket::Two)
     );
 }
 
@@ -29,12 +29,12 @@ fn test_case_2() {
 #[ignore]
 fn test_case_3() {
     assert_eq!(
-        solve(7, 11, 2, &Bucket::One),
         BucketStats {
             moves: 14,
             goal_bucket: Bucket::One,
             other_bucket: 11,
-        }
+        },
+        solve(7, 11, 2, &Bucket::One)
     );
 }
 
@@ -42,12 +42,12 @@ fn test_case_3() {
 #[ignore]
 fn test_case_4() {
     assert_eq!(
-        solve(7, 11, 2, &Bucket::Two),
         BucketStats {
             moves: 18,
             goal_bucket: Bucket::Two,
             other_bucket: 7,
-        }
+        },
+        solve(7, 11, 2, &Bucket::Two)
     );
 }
 
@@ -55,12 +55,12 @@ fn test_case_4() {
 #[ignore]
 fn goal_equal_to_start_bucket() {
     assert_eq!(
-        solve(1, 3, 3, &Bucket::Two),
         BucketStats {
             moves: 1,
             goal_bucket: Bucket::Two,
             other_bucket: 0,
-        }
+        },
+        solve(1, 3, 3, &Bucket::Two)
     );
 }
 
@@ -68,11 +68,11 @@ fn goal_equal_to_start_bucket() {
 #[ignore]
 fn goal_equal_to_other_bucket() {
     assert_eq!(
-        solve(2, 3, 3, &Bucket::One),
         BucketStats {
             moves: 2,
             goal_bucket: Bucket::Two,
             other_bucket: 2,
-        }
+        },
+        solve(2, 3, 3, &Bucket::One)
     );
 }

--- a/exercises/word-count/tests/word-count.rs
+++ b/exercises/word-count/tests/word-count.rs
@@ -9,10 +9,10 @@ fn check_word_count(s: &str, pairs: &[(&str, u32)]) {
     // check for the presence and value of each key in the given pairs vector.
     let mut m: HashMap<String, u32> = word_count::word_count(s);
     for &(k, v) in pairs.iter() {
-        assert_eq!((k, m.remove(&k.to_string()).unwrap_or(0)), (k, v));
+        assert_eq!((k, v), (k, m.remove(&k.to_string()).unwrap_or(0)));
     }
     // may fail with a message that clearly shows all extra pairs in the map
-    assert_eq!(m.iter().collect::<Vec<(&String, &u32)>>(), vec![]);
+    assert_eq!(vec![], m.iter().collect::<Vec<(&String, &u32)>>());
 }
 
 #[test]


### PR DESCRIPTION
First of all, thank you very much for your work on the Rust exercise track! I am finally productive with this language. I would be glad to contribute back, and I stumbled on a particular annoyance.

While the Rust documentation for assert_eq! does not mention this, it is common to consider the first argument the "expected" value (see [this thread on StackOverflow](https://stackoverflow.com/questions/26102865/assertequals-what-is-actual-and-what-is-expected)).

This convention is followed in some exercises but not in all of them. This can lead to very confusing results with IDEs that support the testing framework (e.g. CLion), and report the "expected" and the "actual" values to the user... reversed.

This pull request fixes this across all exercises.