### PR TITLE
exercises: Removed the 'extern crate' from the test suites

### DIFF
--- a/exercises/accumulate/tests/accumulate.rs
+++ b/exercises/accumulate/tests/accumulate.rs
@@ -1,5 +1,3 @@
-extern crate accumulate;
-
 use accumulate::map;
 
 fn square(x: i32) -> i32 {

--- a/exercises/clock/tests/clock.rs
+++ b/exercises/clock/tests/clock.rs
@@ -1,5 +1,3 @@
-extern crate clock;
-
 use clock::Clock;
 
 //

--- a/exercises/custom-set/tests/custom-set.rs
+++ b/exercises/custom-set/tests/custom-set.rs
@@ -1,6 +1,4 @@
-extern crate custom_set as set;
-
-use set::*;
+use custom_set::*;
 
 #[test]
 fn sets_with_no_elements_are_empty() {

--- a/exercises/decimal/tests/decimal.rs
+++ b/exercises/decimal/tests/decimal.rs
@@ -1,4 +1,3 @@
-extern crate decimal;
 use decimal::Decimal;
 
 /// Create a Decimal from a string literal

--- a/exercises/dot-dsl/tests/dot-dsl.rs
+++ b/exercises/dot-dsl/tests/dot-dsl.rs
@@ -1,10 +1,7 @@
-#[macro_use]
-extern crate maplit;
-extern crate dot_dsl;
-
 use dot_dsl::graph::graph_items::edge::Edge;
 use dot_dsl::graph::graph_items::node::Node;
 use dot_dsl::graph::Graph;
+use maplit::hashmap;
 
 #[test]
 fn test_empty_graph() {

--- a/exercises/hexadecimal/tests/hexadecimal.rs
+++ b/exercises/hexadecimal/tests/hexadecimal.rs
@@ -1,5 +1,3 @@
-extern crate hexadecimal;
-
 #[test]
 fn test_hex_1_is_decimal_1() {
     assert_eq!(Some(1), hexadecimal::hex_to_int("1"));

--- a/exercises/luhn-from/tests/luhn-from.rs
+++ b/exercises/luhn-from/tests/luhn-from.rs
@@ -1,5 +1,3 @@
-extern crate luhn_from;
-
 use luhn_from::*;
 
 #[test]

--- a/exercises/luhn-trait/tests/luhn-trait.rs
+++ b/exercises/luhn-trait/tests/luhn-trait.rs
@@ -1,5 +1,3 @@
-extern crate luhn_trait;
-
 use luhn_trait::*;
 
 #[test]

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate macros;
-
+use macros::hashmap;
 use std::collections::HashMap;
 
 #[test]
@@ -62,6 +60,7 @@ fn test_nested() {
 }
 
 mod test {
+    use macros::hashmap;
     #[test]
     #[ignore]
     fn type_not_in_scope() {

--- a/exercises/nucleotide-codons/tests/codons.rs
+++ b/exercises/nucleotide-codons/tests/codons.rs
@@ -1,15 +1,13 @@
-extern crate nucleotide_codons as codons;
-
 #[test]
 fn test_methionine() {
-    let info = codons::parse(make_pairs());
+    let info = nucleotide_codons::parse(make_pairs());
     assert_eq!(info.name_for("ATG"), Ok("methionine"));
 }
 
 #[test]
 #[ignore]
 fn test_cysteine_tgt() {
-    let info = codons::parse(make_pairs());
+    let info = nucleotide_codons::parse(make_pairs());
     assert_eq!(info.name_for("TGT"), Ok("cysteine"));
 }
 
@@ -17,7 +15,7 @@ fn test_cysteine_tgt() {
 #[ignore]
 fn test_cysteine_tgy() {
     // "compressed" name for TGT and TGC
-    let info = codons::parse(make_pairs());
+    let info = nucleotide_codons::parse(make_pairs());
     assert_eq!(info.name_for("TGT"), info.name_for("TGY"));
     assert_eq!(info.name_for("TGC"), info.name_for("TGY"));
 }
@@ -25,21 +23,21 @@ fn test_cysteine_tgy() {
 #[test]
 #[ignore]
 fn test_stop() {
-    let info = codons::parse(make_pairs());
+    let info = nucleotide_codons::parse(make_pairs());
     assert_eq!(info.name_for("TAA"), Ok("stop codon"));
 }
 
 #[test]
 #[ignore]
 fn test_valine() {
-    let info = codons::parse(make_pairs());
+    let info = nucleotide_codons::parse(make_pairs());
     assert_eq!(info.name_for("GTN"), Ok("valine"));
 }
 
 #[test]
 #[ignore]
 fn test_isoleucine() {
-    let info = codons::parse(make_pairs());
+    let info = nucleotide_codons::parse(make_pairs());
     assert_eq!(info.name_for("ATH"), Ok("isoleucine"));
 }
 
@@ -47,7 +45,7 @@ fn test_isoleucine() {
 #[ignore]
 fn test_arginine_name() {
     // In arginine CGA can be "compressed" both as CGN and as MGR
-    let info = codons::parse(make_pairs());
+    let info = nucleotide_codons::parse(make_pairs());
     assert_eq!(info.name_for("CGA"), Ok("arginine"));
     assert_eq!(info.name_for("CGN"), Ok("arginine"));
     assert_eq!(info.name_for("MGR"), Ok("arginine"));
@@ -56,28 +54,28 @@ fn test_arginine_name() {
 #[test]
 #[ignore]
 fn empty_is_invalid() {
-    let info = codons::parse(make_pairs());
+    let info = nucleotide_codons::parse(make_pairs());
     assert!(info.name_for("").is_err());
 }
 
 #[test]
 #[ignore]
 fn x_is_not_shorthand_so_is_invalid() {
-    let info = codons::parse(make_pairs());
+    let info = nucleotide_codons::parse(make_pairs());
     assert!(info.name_for("VWX").is_err());
 }
 
 #[test]
 #[ignore]
 fn too_short_is_invalid() {
-    let info = codons::parse(make_pairs());
+    let info = nucleotide_codons::parse(make_pairs());
     assert!(info.name_for("AT").is_err());
 }
 
 #[test]
 #[ignore]
 fn too_long_is_invalid() {
-    let info = codons::parse(make_pairs());
+    let info = nucleotide_codons::parse(make_pairs());
     assert!(info.name_for("ATTA").is_err());
 }
 

--- a/exercises/two-fer/Cargo.toml
+++ b/exercises/two-fer/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "twofer"
 version = "1.2.0"
 

--- a/exercises/two-fer/tests/two-fer.rs
+++ b/exercises/two-fer/tests/two-fer.rs
@@ -1,4 +1,3 @@
-extern crate twofer;
 use twofer::twofer;
 
 #[test]


### PR DESCRIPTION
Some `extern crate` lines were left in the exercise test suites after the `2018 edition` migration.
This PR removes them.