### PR TITLE
luhn trait: remove obsolete documentation

### DIFF
--- a/exercises/luhn-trait/.meta/description.md
+++ b/exercises/luhn-trait/.meta/description.md
@@ -21,5 +21,3 @@ In "Luhn: Using the From Trait" you implemented a From trait, which also require
 Instead of creating a Struct just to perform the validation, what if you validated the primitives (i.e, String, u8, etc.) themselves?
 
 In this exercise you'll create and implement a custom [trait](https://doc.rust-lang.org/book/2018-edition/ch10-02-traits.html) that performs the validation.
-
-Note: It is [not idiomatic Rust to implement traits on on primitives](https://doc.rust-lang.org/book/2018-edition/ch10-02-traits.html#implementing-a-trait-on-a-type). In this exercise we're showing something that you _can_ do, not something you _should_ do. If you find yourself implementing traits on primitives, perhaps you have a case of [Primitive Obsession](http://wiki.c2.com/?PrimitiveObsession).

--- a/exercises/luhn-trait/README.md
+++ b/exercises/luhn-trait/README.md
@@ -24,8 +24,6 @@ Instead of creating a Struct just to perform the validation, what if you validat
 
 In this exercise you'll create and implement a custom [trait](https://doc.rust-lang.org/book/2018-edition/ch10-02-traits.html) that performs the validation.
 
-Note: It is [not idiomatic Rust to implement traits on on primitives](https://doc.rust-lang.org/book/2018-edition/ch10-02-traits.html#implementing-a-trait-on-a-type). In this exercise we're showing something that you _can_ do, not something you _should_ do. If you find yourself implementing traits on primitives, perhaps you have a case of [Primitive Obsession](http://wiki.c2.com/?PrimitiveObsession).
-
 ## Rust Installation
 
 Refer to the [exercism help page][help-page] for Rust installation and learning


### PR DESCRIPTION
Closes https://github.com/exercism/rust/issues/845. Attn @bartmassey. 

Removes idiomaticity note which had become stale.