### PR TITLE
all-your-base: Fixing test: Empty slice corresponds to zero

### DIFF
--- a/exercises/all-your-base/tests/all-your-base.rs
+++ b/exercises/all-your-base/tests/all-your-base.rs
@@ -109,7 +109,7 @@ fn empty_list() {
     let input_base = 2;
     let input_digits = &[];
     let output_base = 10;
-    let output_digits = vec![];
+    let output_digits = vec![0];
     assert_eq!(
         ayb::convert(input_digits, input_base, output_base),
         Ok(output_digits)

--- a/exercises/all-your-base/tests/all-your-base.rs
+++ b/exercises/all-your-base/tests/all-your-base.rs
@@ -122,7 +122,7 @@ fn single_zero() {
     let input_base = 10;
     let input_digits = &[0];
     let output_base = 2;
-    let output_digits = vec![];
+    let output_digits = vec![0];
     assert_eq!(
         ayb::convert(input_digits, input_base, output_base),
         Ok(output_digits)
@@ -135,7 +135,7 @@ fn multiple_zeros() {
     let input_base = 10;
     let input_digits = &[0, 0, 0];
     let output_base = 2;
-    let output_digits = vec![];
+    let output_digits = vec![0];
     assert_eq!(
         ayb::convert(input_digits, input_base, output_base),
         Ok(output_digits)


### PR DESCRIPTION
In the template code, it says
```
> /// Notes:
> ///  * The empty slice ( "[]" ) is equal to the number 0.
```
But this test assumes that the empty slice should yield an empty slice, and not zero as noted here.