### PR TITLE
Reverse string hint

### DIFF
--- a/exercises/reverse-string/.meta/hints.md
+++ b/exercises/reverse-string/.meta/hints.md
@@ -8,3 +8,7 @@ last test, and execute the tests with:
 ```bash
 $ cargo test --features grapheme
 ```
+
+You will need to use external libraries (a `crate` in rust lingo) for the bonus task. A good place to look for those is [crates.io](https://crates.io/), the official repository of crates.
+
+[Check the documentation](https://doc.rust-lang.org/cargo/guide/dependencies.html) for instructions on how to use external crates in your projects.

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -17,6 +17,10 @@ last test, and execute the tests with:
 $ cargo test --features grapheme
 ```
 
+You will need to use external libraries (a `crate` in rust lingo) for the bonus task. A good place to look for those is [crates.io](https://crates.io/), the official repository of crates.
+
+[Check the documentation](https://doc.rust-lang.org/cargo/guide/dependencies.html) for instructions on how to use external crates in your projects.
+
 
 ## Rust Installation
 


### PR DESCRIPTION
I thought the exercise was unmaintained since the necessary iterator to handle graphemes was removed in rust 1.3 (and google got me straight to that information;-), but a human mentor said it is intended for users to hunt for a crate.

So add some pointer to crates.io and how to use external crates to the hints section of this exercise. This is the first real exercise, so do not expect users to know about crates.io yet and provide the link on how to use crates that the auto-mentor provides straight up in the hints.
