### PR TITLE
doubly-linked-list: test drops of large lists

### DIFF
--- a/exercises/doubly-linked-list/tests/doubly-linked-list.rs
+++ b/exercises/doubly-linked-list/tests/doubly-linked-list.rs
@@ -249,6 +249,12 @@ fn drop_no_double_frees() {
     assert_eq!(counter.get(), N);
 }
 
+#[test]
+#[ignore]
+fn drop_large_list() {
+    drop((0..2_000_000).collect::<LinkedList<i32>>());
+}
+
 // ———————————————————————————————————————————————————————————
 // Tests for Step 5 (advanced): covariance and Send/Sync
 // ———————————————————————————————————————————————————————————


### PR DESCRIPTION
I've been watching submissions of the new exercise and the very first one (from an independent mode user) uses a node struct like this:

```rust
struct Link<T> {
    value : T,
    next : Option<Box<Link::<T>>>,
    prev : *mut Link::<T>,
}
```

with no separate `Drop` implementation. This is a bad idea because `Box` recursively calls the drop of its contained type. That causes 2 function calls per element in the list, leading to a stackoverflow on large lists.

This PR adds a test provoking exactly that.