### PR TITLE
Parallel-letter-frequency: correct link

### DIFF
--- a/exercises/parallel-letter-frequency/.meta/hints.md
+++ b/exercises/parallel-letter-frequency/.meta/hints.md
@@ -2,7 +2,7 @@
 
 Learn more about concurrency in Rust here:
 
-- [Concurrency](https://doc.rust-lang.org/book/2018-edition/ch16-00-concurrency.html)
+- [Concurrency](https://doc.rust-lang.org/book/ch16-00-concurrency.html)
 
 ## Bonus
 

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -11,7 +11,7 @@ list of texts and that employs parallelism.
 
 Learn more about concurrency in Rust here:
 
-- [Concurrency](https://doc.rust-lang.org/book/2018-edition/ch16-00-concurrency.html)
+- [Concurrency](https://doc.rust-lang.org/book/ch16-00-concurrency.html)
 
 ## Bonus
 


### PR DESCRIPTION
Parallel-letter-frequency has a link in its Readme to read about
concurrency in Rust. Unfortunately it used to link to a splash page
saying it wasn't the current version of the book. I've changed it to
point to the current version of the book.