### PR TITLE
travis: reject invalid UUIDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
 - "./_test/check-configlet-fmt.sh"
 - "sh ./_test/ensure-readmes-are-updated.sh"
 - "./bin/configlet lint ."
+- "sh ./_test/check-uuids.sh"
 - "./_test/verify-exercise-difficulties.sh"
 - "./_test/check-exercises-for-authors.sh"
 - "sh ./_test/check-exercise-crate.sh"

--- a/_test/check-uuids.sh
+++ b/_test/check-uuids.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+repo=$(cd "$(dirname "$0")/.." && pwd)
+
+# Check for invalid UUIDs.
+# can be removed once `configlet lint` gains this ability.
+# Check issue https://github.com/exercism/configlet/issues/99
+bad_uuid=$(jq --raw-output '.exercises | map(.uuid) | .[]' $repo/config.json | grep -vE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+if [ -n "$bad_uuid" ]; then
+  echo "invalid UUIDs found! please correct these to be valid UUIDs:"
+  echo "$bad_uuid"
+  exit 1
+fi

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
   "exercises": [
     {
       "slug": "hello-world",
-      "uuid": "13ec1ebe-d71b-436f-ab12-25305e81417",
+      "uuid": "13ec1ebe-d71b-436f-ab12-25305e814171",
       "core": true,
       "auto_approve": true,
       "unlocked_by": null,
@@ -21,7 +21,7 @@
     },
     {
       "slug": "leap",
-      "uuid": "ef52f576-9c33-4cc1-a018-803ace8897f60",
+      "uuid": "ef52f576-9c33-4cc1-a018-803ace8897f6",
       "core": false,
       "unlocked_by": "hello-world",
       "difficulty": 1,
@@ -32,7 +32,7 @@
     },
     {
       "slug": "raindrops",
-      "uuid": "2c12be9b-3a02-4161-8eac-050642ad791g",
+      "uuid": "2c12be9b-3a02-4161-8eac-050642ad791f",
       "core": false,
       "unlocked_by": "hello-world",
       "difficulty": 1,

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
   "exercises": [
     {
       "slug": "hello-world",
-      "uuid": "13ec1ebe-d71b-436f-ab12-25305e814171",
+      "uuid": "13ec1ebe-d71b-436f-ab12-25305e81417",
       "core": true,
       "auto_approve": true,
       "unlocked_by": null,
@@ -21,7 +21,7 @@
     },
     {
       "slug": "leap",
-      "uuid": "ef52f576-9c33-4cc1-a018-803ace8897f6",
+      "uuid": "ef52f576-9c33-4cc1-a018-803ace8897f60",
       "core": false,
       "unlocked_by": "hello-world",
       "difficulty": 1,
@@ -32,7 +32,7 @@
     },
     {
       "slug": "raindrops",
-      "uuid": "2c12be9b-3a02-4161-8eac-050642ad791f",
+      "uuid": "2c12be9b-3a02-4161-8eac-050642ad791g",
       "core": false,
       "unlocked_by": "hello-world",
       "difficulty": 1,


### PR DESCRIPTION
Want to prevent any invalid UUIDs from being entered.

Want to put this in configlet lint, but can't:
exercism/configlet#99
exercism/configlet#168
So it will go in individual tracks' .travis.yml for now.

It appears that the site will accept pretty much arbitrary strings as
UUIDs for now, but we want to make less work for ourselves when valid
UUIDs are required.