### PR TITLE
simple-linked-list: test_peek_returns_head_element tests head element

### DIFF
--- a/exercises/simple-linked-list/tests/simple-linked-list.rs
+++ b/exercises/simple-linked-list/tests/simple-linked-list.rs
@@ -30,7 +30,7 @@ fn test_pop_decrements_length() {
 
 #[test]
 #[ignore]
-fn test_pop_returns_last_added_element() {
+fn test_pop_returns_head_element_and_removes_it() {
     let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
     list.push(1);
     list.push(2);
@@ -41,7 +41,7 @@ fn test_pop_returns_last_added_element() {
 
 #[test]
 #[ignore]
-fn test_peek_returns_head_element() {
+fn test_peek_returns_reference_to_head_element_but_does_not_remove_it() {
     let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
     assert_eq!(list.peek(), None, "No element should be contained in list");
     list.push(2);

--- a/exercises/simple-linked-list/tests/simple-linked-list.rs
+++ b/exercises/simple-linked-list/tests/simple-linked-list.rs
@@ -47,6 +47,12 @@ fn test_peek_returns_head_element() {
     list.push(2);
     assert_eq!(list.peek(), Some(&2), "Element must be 2");
     assert_eq!(list.peek(), Some(&2), "Element must be still 2");
+    list.push(3);
+    assert_eq!(list.peek(), Some(&3), "Head element is now 3");
+    assert_eq!(list.pop(), Some(3), "Element must be 3");
+    assert_eq!(list.peek(), Some(&2), "Head element is now 2");
+    assert_eq!(list.pop(), Some(2), "Element must be 2");
+    assert_eq!(list.peek(), None, "No element should be contained in list");
 }
 
 #[test]


### PR DESCRIPTION
This PR aims to close #834, making sure that the `peek` method always references the head element and doesn't remove it (like `pop`).