### PR TITLE
Add test for single macro argument

### DIFF
--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -10,6 +10,14 @@ fn test_empty() {
 
 #[test]
 #[ignore]
+fn test_single() {
+    let mut expected = HashMap::new();
+    expected.insert(1, "one");
+    assert_eq!(hashmap!(1 => "one"), expected);
+}
+
+#[test]
+#[ignore]
 fn test_no_trailing_comma() {
     let mut expected = HashMap::new();
     expected.insert(1, "one");


### PR DESCRIPTION
I was mystified that replacing `$(...),*` with `$(...),+` in my macro rule seemed to work fine.