### PR TITLE
two-bucket: test inability to reach the goal

### DIFF
--- a/exercises/two-bucket/example.rs
+++ b/exercises/two-bucket/example.rs
@@ -31,7 +31,7 @@ pub struct BucketStats {
 }
 
 /// Solve the bucket problem
-pub fn solve(capacity_1: u8, capacity_2: u8, goal: u8, start_bucket: &Bucket) -> BucketStats {
+pub fn solve(capacity_1: u8, capacity_2: u8, goal: u8, start_bucket: &Bucket) -> Option<BucketStats> {
     let state = match *start_bucket {
         Bucket::One => (capacity_1, 0),
         Bucket::Two => (0, capacity_2),
@@ -56,17 +56,17 @@ pub fn solve(capacity_1: u8, capacity_2: u8, goal: u8, start_bucket: &Bucket) ->
             let (bucket_1, bucket_2) = state;
 
             if bucket_1 == goal {
-                return BucketStats {
+                return Some(BucketStats {
                     moves,
                     goal_bucket: Bucket::One,
                     other_bucket: bucket_2,
-                };
+                });
             } else if bucket_2 == goal {
-                return BucketStats {
+                return Some(BucketStats {
                     moves,
                     goal_bucket: Bucket::Two,
                     other_bucket: bucket_1,
-                };
+                });
             }
 
             // Empty the first bucket

--- a/exercises/two-bucket/example.rs
+++ b/exercises/two-bucket/example.rs
@@ -48,7 +48,7 @@ pub fn solve(capacity_1: u8, capacity_2: u8, goal: u8, start_bucket: &Bucket) ->
     visited.insert((capacity_1, 0));
     visited.insert((0, capacity_2));
 
-    loop {
+    while !next_search.is_empty() {
         let mut current_search = next_search;
         next_search = VecDeque::new();
 
@@ -122,4 +122,7 @@ pub fn solve(capacity_1: u8, capacity_2: u8, goal: u8, start_bucket: &Bucket) ->
 
         moves += 1;
     }
+
+    // We ran out of states to search but still didn't reach the goal.
+    None
 }

--- a/exercises/two-bucket/src/lib.rs
+++ b/exercises/two-bucket/src/lib.rs
@@ -17,9 +17,9 @@ pub struct BucketStats {
 }
 
 /// Solve the bucket problem
-pub fn solve(capacity_1: u8, capacity_2: u8, goal: u8, start_bucket: &Bucket) -> BucketStats {
+pub fn solve(capacity_1: u8, capacity_2: u8, goal: u8, start_bucket: &Bucket) -> Option<BucketStats> {
     unimplemented!(
-        "Given one bucket of capacity {}, another of capacity {}, starting with {:?}, find pours to reach {}",
+        "Given one bucket of capacity {}, another of capacity {}, starting with {:?}, find pours to reach {}, or None if impossible",
         capacity_1,
         capacity_2,
         start_bucket,

--- a/exercises/two-bucket/tests/two-bucket.rs
+++ b/exercises/two-bucket/tests/two-bucket.rs
@@ -4,11 +4,11 @@ use two_bucket::{solve, Bucket, BucketStats};
 fn test_case_1() {
     assert_eq!(
         solve(3, 5, 1, &Bucket::One),
-        BucketStats {
+        Some(BucketStats {
             moves: 4,
             goal_bucket: Bucket::One,
             other_bucket: 5,
-        }
+        })
     );
 }
 
@@ -17,11 +17,11 @@ fn test_case_1() {
 fn test_case_2() {
     assert_eq!(
         solve(3, 5, 1, &Bucket::Two),
-        BucketStats {
+        Some(BucketStats {
             moves: 8,
             goal_bucket: Bucket::Two,
             other_bucket: 3,
-        }
+        })
     );
 }
 
@@ -30,11 +30,11 @@ fn test_case_2() {
 fn test_case_3() {
     assert_eq!(
         solve(7, 11, 2, &Bucket::One),
-        BucketStats {
+        Some(BucketStats {
             moves: 14,
             goal_bucket: Bucket::One,
             other_bucket: 11,
-        }
+        })
     );
 }
 
@@ -43,11 +43,11 @@ fn test_case_3() {
 fn test_case_4() {
     assert_eq!(
         solve(7, 11, 2, &Bucket::Two),
-        BucketStats {
+        Some(BucketStats {
             moves: 18,
             goal_bucket: Bucket::Two,
             other_bucket: 7,
-        }
+        })
     );
 }
 
@@ -56,11 +56,11 @@ fn test_case_4() {
 fn goal_equal_to_start_bucket() {
     assert_eq!(
         solve(1, 3, 3, &Bucket::Two),
-        BucketStats {
+        Some(BucketStats {
             moves: 1,
             goal_bucket: Bucket::Two,
             other_bucket: 0,
-        }
+        })
     );
 }
 
@@ -69,10 +69,10 @@ fn goal_equal_to_start_bucket() {
 fn goal_equal_to_other_bucket() {
     assert_eq!(
         solve(2, 3, 3, &Bucket::One),
-        BucketStats {
+        Some(BucketStats {
             moves: 2,
             goal_bucket: Bucket::Two,
             other_bucket: 2,
-        }
+        })
     );
 }

--- a/exercises/two-bucket/tests/two-bucket.rs
+++ b/exercises/two-bucket/tests/two-bucket.rs
@@ -76,3 +76,25 @@ fn goal_equal_to_other_bucket() {
         })
     );
 }
+
+#[test]
+#[ignore]
+fn not_possible_to_reach_the_goal() {
+    assert_eq!(
+        solve(6, 15, 5, &Bucket::One),
+        None
+    );
+}
+
+#[test]
+#[ignore]
+fn with_same_buckets_but_different_goal_then_it_is_possible() {
+    assert_eq!(
+        solve(6, 15, 9, &Bucket::One),
+        Some(BucketStats {
+            moves: 10,
+            goal_bucket: Bucket::Two,
+            other_bucket: 0,
+        })
+    );
+}


### PR DESCRIPTION
The student solution would need to employ one of several strategies:

* (If searching the state space) Notice that there are no further states
  to be visited, and yet the solution has not been reached.
* Notice that the goal is not divisible by the GCD of the bucket sizes,
  therefore can be rejected immediately.

In case the student assumes that all non-coprime bucket counts will
invalidate the goal, a counterexample to that is given as well (buckets
not coprime but goal is still possible).

There are ten implementing tracks:
bash csharp fsharp go java javascript python ruby rust typescript

Of these tracks, only two of them (Bash, Go) currently test the
condition where it is not possible to reach the goal.

Having this test serves as a reminder that it remains wise to handle the
situation where a search has not found its goal.

exercism/problem-specifications#1580

---

Completely indifferent as to whether commits are squashed. In the case of no opinions, I will choose not to.