### PR TITLE
leap: More test cases for years in the past (less than four digits)

### DIFF
--- a/exercises/leap/tests/leap.rs
+++ b/exercises/leap/tests/leap.rs
@@ -37,6 +37,11 @@ fn test_year_divisible_by_400_leap_year() {
 #[ignore]
 fn test_any_old_year() {
     assert_eq!(leap::is_leap_year(1997), false);
+    assert_eq!(leap::is_leap_year(1), false);
+    assert_eq!(leap::is_leap_year(4), true);
+    assert_eq!(leap::is_leap_year(100), false);
+    assert_eq!(leap::is_leap_year(400), true);
+    assert_eq!(leap::is_leap_year(900), false);
 }
 
 #[test]

--- a/exercises/leap/tests/leap.rs
+++ b/exercises/leap/tests/leap.rs
@@ -37,6 +37,11 @@ fn test_year_divisible_by_400_leap_year() {
 #[ignore]
 fn test_any_old_year() {
     assert_eq!(leap::is_leap_year(1997), false);
+}
+
+#[test]
+#[ignore]
+fn test_early_years() {
     assert_eq!(leap::is_leap_year(1), false);
     assert_eq!(leap::is_leap_year(4), true);
     assert_eq!(leap::is_leap_year(100), false);


### PR DESCRIPTION
Having observed basic solutions on other Rust exercises ignoring the fact that years might not necessarily only be four digit, bys adding tests for years in the past might assist the aspiring Rust programmer.

