### PR TITLE
Move bob later into the track

### DIFF
--- a/config.json
+++ b/config.json
@@ -153,27 +153,6 @@
       ]
     },
     {
-      "slug": "bob",
-      "uuid": "38ef1802-2730-4f94-bafe-d2cd6b3e7f95",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "chars",
-        "string_functions"
-      ]
-    },
-    {
-      "slug": "matching-brackets",
-      "uuid": "40729822-4265-4c14-b03f-a00bff5f24bb",
-      "core": false,
-      "unlocked_by": "bob",
-      "difficulty": 1,
-      "topics": [
-        "stack_or_recursion"
-      ]
-    },
-    {
       "slug": "clock",
       "uuid": "543a3ca2-fb9b-4f20-a873-ff23595d41df",
       "core": true,
@@ -759,6 +738,27 @@
         "generic_over_type",
         "struct",
         "vector"
+      ]
+    },
+    {
+      "slug": "bob",
+      "uuid": "38ef1802-2730-4f94-bafe-d2cd6b3e7f95",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "chars",
+        "string_functions"
+      ]
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "40729822-4265-4c14-b03f-a00bff5f24bb",
+      "core": false,
+      "unlocked_by": "bob",
+      "difficulty": 1,
+      "topics": [
+        "stack_or_recursion"
       ]
     },
     {


### PR DESCRIPTION
Bob is extremely painful to mentor due to the large amount of permutations of solutions. We're therefore moving it to later in tracks across Exercism, or removing it from core altogether. This PR moves it a few notches down for now. We can analyse the data and determine if it needs to go further down or be removed from core altogether at a later stage.

(cc @kytrinyx)