### PR TITLE
paasio: Title as "PaaS I/O" instead of default Paasio

### DIFF
--- a/exercises/paasio/README.md
+++ b/exercises/paasio/README.md
@@ -1,4 +1,4 @@
-# Paasio
+# PaaS I/O
 
 Report network IO statistics.
 


### PR DESCRIPTION
See how it is currently listed as Paasio:
http://exercism.io/tracks/rust/exercises/paasio

Given that the exercise is about input/output statistics for a
platform-as-a-service, "PaaS I/O" seems a better way than the default.

https://github.com/exercism/problem-specifications/pull/1589