### PR TITLE
triangle: Add invalid floating-point tests

### DIFF
--- a/exercises/triangle/tests/triangle.rs
+++ b/exercises/triangle/tests/triangle.rs
@@ -184,3 +184,21 @@ fn isosceles_triangle_with_floating_point_sides() {
     assert!(triangle.is_isosceles());
     assert!(!triangle.is_scalene());
 }
+
+#[test]
+#[ignore]
+#[cfg(feature = "generic")]
+fn invalid_triangle_with_floating_point_sides_one() {
+    let sides = [0.0, 0.4, 0.3];
+    let triangle = Triangle::build(sides);
+    assert!(triangle.is_none());
+}
+
+#[test]
+#[ignore]
+#[cfg(feature = "generic")]
+fn invalid_triangle_with_floating_point_sides_two() {
+    let sides = [0.1, 0.3, 0.5];
+    let triangle = Triangle::build(sides);
+    assert!(triangle.is_none());
+}


### PR DESCRIPTION
For completeness' sake, and just in case someone comes up with a crazy solution that would pass everything else but break at this point, I've added a pair of tests for invalid triangles to the bonus floating-point section.