### PR TITLE
bowling: Replace double semicolons with single

### DIFF
--- a/exercises/bowling/tests/bowling.rs
+++ b/exercises/bowling/tests/bowling.rs
@@ -11,7 +11,7 @@ fn roll_returns_a_result() {
 fn you_cannot_roll_more_than_ten_pins_in_a_single_roll() {
     let mut game = BowlingGame::new();
 
-    assert_eq!(game.roll(11), Err(Error::NotEnoughPinsLeft));;
+    assert_eq!(game.roll(11), Err(Error::NotEnoughPinsLeft));
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn a_roll_is_err_if_the_game_is_done() {
         let _ = game.roll(0);
     }
 
-    assert_eq!(game.roll(0), Err(Error::GameComplete));;
+    assert_eq!(game.roll(0), Err(Error::GameComplete));
 }
 
 #[test]
@@ -281,7 +281,7 @@ fn you_cannot_roll_more_than_ten_pins_in_a_single_frame() {
     let mut game = BowlingGame::new();
 
     assert!(game.roll(5).is_ok());
-    assert_eq!(game.roll(6), Err(Error::NotEnoughPinsLeft));;
+    assert_eq!(game.roll(6), Err(Error::NotEnoughPinsLeft));
 }
 
 #[test]
@@ -295,7 +295,7 @@ fn first_bonus_ball_after_a_final_strike_cannot_score_an_invalid_number_of_pins(
 
     let _ = game.roll(10);
 
-    assert_eq!(game.roll(11), Err(Error::NotEnoughPinsLeft));;
+    assert_eq!(game.roll(11), Err(Error::NotEnoughPinsLeft));
 }
 
 #[test]
@@ -310,7 +310,7 @@ fn the_two_balls_after_a_final_strike_cannot_score_an_invalid_number_of_pins() {
     let _ = game.roll(10);
 
     assert!(game.roll(5).is_ok());
-    assert_eq!(game.roll(6), Err(Error::NotEnoughPinsLeft));;
+    assert_eq!(game.roll(6), Err(Error::NotEnoughPinsLeft));
 }
 
 #[test]
@@ -340,7 +340,7 @@ fn the_two_balls_after_a_final_strike_cannot_be_a_non_strike_followed_by_a_strik
     let _ = game.roll(10);
 
     assert!(game.roll(6).is_ok());
-    assert_eq!(game.roll(10), Err(Error::NotEnoughPinsLeft));;
+    assert_eq!(game.roll(10), Err(Error::NotEnoughPinsLeft));
 }
 
 #[test]
@@ -356,7 +356,7 @@ fn second_bonus_ball_after_a_final_strike_cannot_score_an_invalid_number_of_pins
     let _ = game.roll(10);
 
     assert!(game.roll(10).is_ok());
-    assert_eq!(game.roll(11), Err(Error::NotEnoughPinsLeft));;
+    assert_eq!(game.roll(11), Err(Error::NotEnoughPinsLeft));
 }
 
 #[test]


### PR DESCRIPTION
I am the culprit; In ffc10d5fd7c35c1387da70b27cfe41981bc1b25e, authored
by me, the double semicolons were introduced. I am sorry.

As you can see on Travis CI, they are a warning in upcoming 1.39.0.
https://travis-ci.org/exercism/rust/builds/590089916