### PR TITLE
pig-latin example: Use lazy_static 1.4.0

### DIFF
--- a/exercises/pig-latin/Cargo-example.toml
+++ b/exercises/pig-latin/Cargo-example.toml
@@ -5,4 +5,4 @@ version = "1.0.0"
 
 [dependencies]
 regex = "0.2"
-lazy_static = "0.2"
+lazy_static = "1.4.0"


### PR DESCRIPTION
Otherwise, ONCE_INIT deprecated in ~~Ruby~~Rust 1.38.0.
https://travis-ci.org/exercism/rust/jobs/590089919

Need 1.4.0 with this commit:
https://github.com/rust-lang-nursery/lazy-static.rs/commit/1dbd5ae6ccb33c1f88fe521c9ab1f8f0e4cf5193