### PR TITLE
hello world: make topics match the content

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,7 +16,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "println"
+        "strings",
+        "test_driven_development"
       ]
     },
     {


### PR DESCRIPTION
This used to be `println` which actually occures nowhere in the excercise.
Change this to:
* `strings` - because the function returns a string and we compare strings
* `test_driven_development` - as this is the first excercise and people learn the red, green flow.

Both topics are taken from https://github.com/exercism/problem-specifications/blob/master/TOPICS.txt

This also addresses #529 for `hello world`.