### PR TITLE
Beer Song: use u32 instead of i32

### DIFF
--- a/exercises/beer-song/example.rs
+++ b/exercises/beer-song/example.rs
@@ -1,4 +1,4 @@
-pub fn verse(n: i32) -> String {
+pub fn verse(n: u32) -> String {
     match n {
         0 => "No more bottles of beer on the wall, no more bottles of beer.\n\
               Go to the store and buy some more, 99 bottles of beer on the wall.\n"
@@ -19,7 +19,7 @@ pub fn verse(n: i32) -> String {
     }
 }
 
-pub fn sing(start: i32, end: i32) -> String {
+pub fn sing(start: u32, end: u32) -> String {
     (end..=start)
         .rev()
         .map(verse)

--- a/exercises/beer-song/src/lib.rs
+++ b/exercises/beer-song/src/lib.rs
@@ -1,7 +1,7 @@
-pub fn verse(n: i32) -> String {
+pub fn verse(n: u32) -> String {
     unimplemented!("emit verse {}", n)
 }
 
-pub fn sing(start: i32, end: i32) -> String {
+pub fn sing(start: u32, end: u32) -> String {
     unimplemented!("sing verses {} to {}, inclusive", start, end)
 }


### PR DESCRIPTION
Why not to use more appropriate data type for the given excercise? There are no negative numbers of beer bottles.

If it's not merged, *I owe you `-1` beer!* :wink: 