### PR TITLE
leap: update to canonical data v1.6.0

### DIFF
--- a/exercises/leap/Cargo.toml
+++ b/exercises/leap/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 edition = "2018"
 name = "leap"
-version = "1.4.0"
+version = "1.6.0"

--- a/exercises/leap/tests/leap.rs
+++ b/exercises/leap/tests/leap.rs
@@ -5,20 +5,26 @@ fn process_leapyear_case(year: u64, expected: bool) {
 }
 
 #[test]
-fn test_year_divisible_by_4_not_divisible_by_100_leap_year() {
-    process_leapyear_case(1996, true);
-}
-
-#[test]
-#[ignore]
 fn test_year_not_divisible_by_4_common_year() {
     process_leapyear_case(2015, false);
 }
 
 #[test]
 #[ignore]
-fn test_year_divisible_by_200_not_divisible_by_400_common_year() {
-    process_leapyear_case(1800, false);
+fn test_year_divisible_by_2_not_divisible_by_4_in_common_year() {
+    process_leapyear_case(1970, false);
+}
+
+#[test]
+#[ignore]
+fn test_year_divisible_by_4_not_divisible_by_100_leap_year() {
+    process_leapyear_case(1996, true);
+}
+
+#[test]
+#[ignore]
+fn test_year_divisible_by_4_and_5_is_still_a_leap_year() {
+    process_leapyear_case(1960, true);
 }
 
 #[test]
@@ -29,8 +35,26 @@ fn test_year_divisible_by_100_not_divisible_by_400_common_year() {
 
 #[test]
 #[ignore]
+fn test_year_divisible_by_100_but_not_by_3_is_still_not_a_leap_year() {
+    process_leapyear_case(1900, false);
+}
+
+#[test]
+#[ignore]
 fn test_year_divisible_by_400_leap_year() {
     process_leapyear_case(2000, true);
+}
+
+#[test]
+#[ignore]
+fn test_year_divisible_by_400_but_not_by_125_is_still_a_leap_year() {
+    process_leapyear_case(2400, true);
+}
+
+#[test]
+#[ignore]
+fn test_year_divisible_by_200_not_divisible_by_400_common_year() {
+    process_leapyear_case(1800, false);
 }
 
 #[test]


### PR DESCRIPTION
See https://raw.githubusercontent.com/exercism/problem-specifications/master/exercises/leap/canonical-data.json
for the current canonical data.