### PR TITLE
armstrong-numbers: update to canonical data v1.1.0

### DIFF
--- a/exercises/armstrong-numbers/Cargo.toml
+++ b/exercises/armstrong-numbers/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 edition = "2018"
 name = "armstrong_numbers"
-version = "1.0.0"
+version = "1.1.0"

--- a/exercises/armstrong-numbers/tests/armstrong-numbers.rs
+++ b/exercises/armstrong-numbers/tests/armstrong-numbers.rs
@@ -6,6 +6,7 @@ fn test_zero_is_an_armstrong_number() {
 }
 
 #[test]
+#[ignore]
 fn test_single_digit_numbers_are_armstrong_numbers() {
     assert!(is_armstrong_number(5))
 }

--- a/exercises/armstrong-numbers/tests/armstrong-numbers.rs
+++ b/exercises/armstrong-numbers/tests/armstrong-numbers.rs
@@ -1,6 +1,11 @@
 use armstrong_numbers::*;
 
 #[test]
+fn test_zero_is_an_armstrong_number() {
+    assert!(is_armstrong_number(0))
+}
+
+#[test]
 fn test_single_digit_numbers_are_armstrong_numbers() {
     assert!(is_armstrong_number(5))
 }


### PR DESCRIPTION
See https://github.com/exercism/problem-specifications/blob/master/exercises/armstrong-numbers/canonical-data.json for the current canonical data.