### PR TITLE
acronym: Update to 1.7.0

### DIFF
--- a/exercises/acronym/Cargo.toml
+++ b/exercises/acronym/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2018"
 name = "acronym"
-version = "1.0.0"
+version = "1.7.0"
 
 [dependencies]

--- a/exercises/acronym/example.rs
+++ b/exercises/acronym/example.rs
@@ -1,6 +1,6 @@
 pub fn abbreviate(phrase: &str) -> String {
     phrase
-        .split(|c: char| c.is_whitespace() || !c.is_alphanumeric())
+        .split(|c: char| c.is_whitespace() || (c != '\'' && !c.is_alphanumeric()))
         .flat_map(|word| split_camel(word))
         .filter_map(|word| word.chars().next())
         .collect::<String>()

--- a/exercises/acronym/tests/acronym.rs
+++ b/exercises/acronym/tests/acronym.rs
@@ -31,24 +31,57 @@ fn punctuation() {
 
 #[test]
 #[ignore]
-fn all_caps_words() {
+fn all_caps_word() {
+    assert_eq!(acronym::abbreviate("GNU Image Manipulation Program"), "GIMP");
+}
+
+#[test]
+#[ignore]
+fn all_caps_word_with_punctuation() {
     assert_eq!(acronym::abbreviate("PHP: Hypertext Preprocessor"), "PHP");
 }
 
 #[test]
 #[ignore]
-fn non_acronym_all_caps_word() {
+fn punctuation_without_whitespace() {
     assert_eq!(
-        acronym::abbreviate("GNU Image Manipulation Program"),
-        "GIMP"
+        acronym::abbreviate("Complementary metal-oxide semiconductor"),
+        "CMOS"
     );
 }
 
 #[test]
 #[ignore]
-fn hyphenated() {
+fn very_long_abbreviation() {
     assert_eq!(
-        acronym::abbreviate("Complementary metal-oxide semiconductor"),
-        "CMOS"
+        acronym::abbreviate("Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me"),
+        "ROTFLSHTMDCOALM"
+    );
+}
+
+#[test]
+#[ignore]
+fn consecutive_delimiters() {
+    assert_eq!(
+        acronym::abbreviate("Something - I made up from thin air"),
+        "SIMUFTA"
+    );
+}
+
+#[test]
+#[ignore]
+fn apostrophes() {
+    assert_eq!(
+        acronym::abbreviate("Halley's Comet"),
+        "HC"
+    );
+}
+
+#[test]
+#[ignore]
+fn underscore_emphasis() {
+    assert_eq!(
+        acronym::abbreviate("The Road _Not_ Taken"),
+        "TRNT"
     );
 }


### PR DESCRIPTION
Acronym 1.7.0 has several new test cases and removed a couple of others.
Of particular note is the new `apostrophes()` test case, which broke the
original example implementation.