### PR TITLE
gigasecond: update to canonical data v2.0.0

### DIFF
--- a/exercises/gigasecond/Cargo.toml
+++ b/exercises/gigasecond/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "gigasecond"
-version = "1.1.0"
+version = "2.0.0"
 
 [dependencies]
 chrono = "0.4"


### PR DESCRIPTION
Version 2.0.0 modifies the name of the input variable, which has no bearing on the tests.

Relevant PRs:
 - 1.1.0 -> 2.0.0: exercism/problem-specifications#1405

See https://raw.githubusercontent.com/exercism/problem-specifications/master/exercises/gigasecond/canonical-data.json for the current canonical data.

While this update does not require any change to the tests, there is some divergence between the tests' names and those from the specs. I'm a bit on the fence about whether it would be better to update the names as well while we're at it.