### PR TITLE
Clarify Rust indices from 0 in saddle-points and regenerate READMEs

### DIFF
--- a/exercises/saddle-points/.meta/hints.md
+++ b/exercises/saddle-points/.meta/hints.md
@@ -1,3 +1,11 @@
+## Rust Indices Start At 0
+
+By convention, ordered sequences of values in Rust have their contents numbered
+("indexed") starting from 0. This applies regardless of what the rest of the
+exercise description in this README says, such as references to indices that
+start at 1, so you will have to subtract 1 to translate those index numbers
+to Rust index numbers.
+
 ## Efficiency Notice
 
 This exercise uses a _vector of vectors_ to store the content of matrices. While

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -28,6 +28,14 @@ The matrix can have a different number of rows and columns (Non square).
 Note that you may find other definitions of matrix saddle points online,
 but the tests for this exercise follow the above unambiguous definition.
 
+## Rust Indices Start At 0
+
+By convention, ordered sequences of values in Rust have their contents numbered
+("indexed") starting from 0. This applies regardless of what the rest of the
+exercise description in this README says, such as references to indices that
+start at 1, so you will have to subtract 1 to translate those index numbers
+to Rust index numbers.
+
 ## Efficiency Notice
 
 This exercise uses a _vector of vectors_ to store the content of matrices. While


### PR DESCRIPTION
Closes #791 

Of the 5 choices in that issue, results of the discussion were (effectively):
"Do not do 2."
"Do 2 or 3 to be consistent with Rust."
"Do 3 for now since it is easy, then 1 later."
"1 would be possible using a little more code."

As option 2 effectively has a negative vote, and 3 has two votes for, modifying hints.md comes out as the maintainer-preferred solution. This PR implements that and regenerates the README appropriately. Or rather, READMEs. While doing so, I discovered two other READMEs were dated and their latest version was more readable, so I included them in this PR.