### PR TITLE
atbash-cipher: update to canonical data v1.2.0

### DIFF
--- a/exercises/atbash-cipher/Cargo.toml
+++ b/exercises/atbash-cipher/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 edition = "2018"
 name = "atbash-cipher"
-version = "1.1.0"
+version = "1.2.0"

--- a/exercises/atbash-cipher/tests/atbash-cipher.rs
+++ b/exercises/atbash-cipher/tests/atbash-cipher.rs
@@ -55,12 +55,6 @@ fn test_encode_all_the_letters() {
 
 #[test]
 #[ignore]
-fn test_encode_ignores_non_ascii() {
-    assert_eq!(cipher::encode("non ascii éignored"), "mlmzh xrrrt mlivw");
-}
-
-#[test]
-#[ignore]
 fn test_decode_exercism() {
     assert_eq!(cipher::decode("vcvix rhn"), "exercism");
 }
@@ -86,5 +80,20 @@ fn test_decode_all_the_letters() {
     assert_eq!(
         cipher::decode("gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"),
         "thequickbrownfoxjumpsoverthelazydog"
+    );
+}
+
+#[test]
+#[ignore]
+fn test_decode_with_too_many_spaces() {
+    assert_eq!(cipher::decode("vc vix    r hn"), "exercism");
+}
+
+#[test]
+#[ignore]
+fn test_decode_with_no_spaces() {
+    assert_eq!(
+        cipher::decode("zmlyhgzxovrhlugvmzhgvkkrmthglmv"),
+        "anobstacleisoftenasteppingstone",
     );
 }


### PR DESCRIPTION
Version 1.2.0 adds two tests: "decode with too many spaces" and "decode with no spaces".

Relevant PRs:
 - 1.1.0 -> 1.2.0: exercism/problem-specifications#1277

Of possible relevance is exercism/problem-specifications#529, which removed the "encode ignores non ascii" test from the specs, but that test is still present in the Rust track tests. I feel it would be best to remove it, as it doesn't really add much for this particular exercise (compared to, say, "reverse-string"), but I thought I'd check others' opinion first.