### PR TITLE
clock: deemphasize suggestion to implement From<Clock> for String

### DIFF
--- a/exercises/clock/.meta/hints.md
+++ b/exercises/clock/.meta/hints.md
@@ -1,10 +1,13 @@
-## Rust Traits for .to_string()
+## Rust Traits for `.to_string()`
 
-Did you implement .to_string() for the Clock struct?
+Did you implement `.to_string()` for the `Clock` struct?
 
 If so, try implementing the
-[Display trait](https://doc.rust-lang.org/std/fmt/trait.Display.html) for Clock instead.
+[Display trait](https://doc.rust-lang.org/std/fmt/trait.Display.html) for `Clock` instead.
 
 Traits allow for a common way to implement functionality for various types.
 
-For additional learning, how would you implement String::from for the Clock type?
+For additional learning, consider how you might implement `String::from` for the `Clock` type.
+You don't have to actually implement this—it's redundant with `Display`, which is generally the
+better choice when the destination type is `String`—but it's useful to have a few type-conversion
+traits in your toolkit.

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -6,16 +6,19 @@ You should be able to add and subtract minutes to it.
 
 Two clocks that represent the same time should be equal to each other.
 
-## Rust Traits for .to_string()
+## Rust Traits for `.to_string()`
 
-Did you implement .to_string() for the Clock struct?
+Did you implement `.to_string()` for the `Clock` struct?
 
 If so, try implementing the
-[Display trait](https://doc.rust-lang.org/std/fmt/trait.Display.html) for Clock instead.
+[Display trait](https://doc.rust-lang.org/std/fmt/trait.Display.html) for `Clock` instead.
 
 Traits allow for a common way to implement functionality for various types.
 
-For additional learning, how would you implement String::from for the Clock type?
+For additional learning, consider how you might implement `String::from` for the `Clock` type.
+You don't have to actually implement this—it's redundant with `Display`, which is generally the
+better choice when the destination type is `String`—but it's useful to have a few type-conversion
+traits in your toolkit.
 
 
 ## Rust Installation


### PR DESCRIPTION
That suggestion was meant to get students to explore the available
type-conversion traits, not as a serious command that students
have to implement it. This PR makes the hypotheticality of the
suggestion more explicit.