### PR TITLE
space-age: update to canonical data v1.2.0

### DIFF
--- a/exercises/space-age/Cargo.toml
+++ b/exercises/space-age/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 edition = "2018"
 name = "space-age"
-version = "1.1.0"
+version = "1.2.0"

--- a/exercises/space-age/tests/space-age.rs
+++ b/exercises/space-age/tests/space-age.rs
@@ -34,8 +34,8 @@ fn venus_age() {
 #[test]
 #[ignore]
 fn mars_age() {
-    let duration = Duration::from(2_329_871_239);
-    assert_in_delta(39.25, Mars::years_during(&duration));
+    let duration = Duration::from(2_129_871_239);
+    assert_in_delta(35.88, Mars::years_during(&duration));
 }
 
 #[test]
@@ -48,20 +48,20 @@ fn jupiter_age() {
 #[test]
 #[ignore]
 fn saturn_age() {
-    let duration = Duration::from(3_000_000_000);
-    assert_in_delta(3.23, Saturn::years_during(&duration));
+    let duration = Duration::from(2_000_000_000);
+    assert_in_delta(2.15, Saturn::years_during(&duration));
 }
 
 #[test]
 #[ignore]
 fn uranus_age() {
-    let duration = Duration::from(3_210_123_456);
-    assert_in_delta(1.21, Uranus::years_during(&duration));
+    let duration = Duration::from(1_210_123_456);
+    assert_in_delta(0.46, Uranus::years_during(&duration));
 }
 
 #[test]
 #[ignore]
 fn neptune_age() {
-    let duration = Duration::from(8_210_123_456);
-    assert_in_delta(1.58, Neptune::years_during(&duration));
+    let duration = Duration::from(1_821_023_456);
+    assert_in_delta(0.35, Neptune::years_during(&duration));
 }


### PR DESCRIPTION
Version 1.2.0 modifies the input values so that the number of seconds fits into an `i32`. The expected values are updated to reflect the change.

Relevant PRs:
 - 1.1.0 -> 1.2.0: exercism/problem-specifications#1441
