### PR TITLE
Optimize saddle-points; show some Rust "tricks"

### DIFF
--- a/exercises/saddle-points/example.rs
+++ b/exercises/saddle-points/example.rs
@@ -1,20 +1,21 @@
 pub fn find_saddle_points(input: &[Vec<u64>]) -> Vec<(usize, usize)> {
-    let (width, height) = match (input.len(), input[0].len()) {
-        (0, _) | (_, 0) => return Vec::new(),
-        (n, k) => (n, k),
+    let height = if !input.is_empty() && !input[0].is_empty() {
+        input[0].len()
+    } else {
+        return Vec::new();
     };
 
     let mut saddle_points = Vec::new();
 
-    for i in 0..width {
-        let row_max = input[i].iter().max().unwrap();
+    let col_mins: Vec<u64> = (0..height)
+        .filter_map(|j| input.iter().map(|row| row[j]).min())
+        .collect();
+
+    for (i, row) in input.iter().enumerate() {
+        let row_max = *row.iter().max().unwrap();
 
         for j in 0..height {
-            let column_min = input.iter().map(|x| x[j]).min().unwrap();
-
-            let value = input[i][j];
-
-            if value == *row_max && value == column_min {
+            if row[j] == row_max && row[j] == col_mins[j] {
                 saddle_points.push((i, j));
             }
         }

--- a/exercises/saddle-points/example.rs
+++ b/exercises/saddle-points/example.rs
@@ -1,23 +1,24 @@
 pub fn find_saddle_points(input: &[Vec<u64>]) -> Vec<(usize, usize)> {
+    let (width, height) = match (input.len(), input[0].len()) {
+        (0, _) | (_, 0) => return Vec::new(),
+        (n, k) => (n, k),
+    };
+
     let mut saddle_points = Vec::new();
 
-    let width = input.len();
-    let height = input[0].len();
-
     for i in 0..width {
-        for j in 0..height {
-            let column = input.iter().map(|x| x[j]).collect::<Vec<u64>>();
-            let row = &input[i];
+        let row_max = input[i].iter().max().unwrap();
 
-            let max = row.iter().max().unwrap();
-            let min = column.iter().min().unwrap();
+        for j in 0..height {
+            let column_min = input.iter().map(|x| x[j]).min().unwrap();
 
             let value = input[i][j];
 
-            if value >= *max && value <= *min {
+            if value == *row_max && value == column_min {
                 saddle_points.push((i, j));
             }
         }
     }
+
     saddle_points
 }


### PR DESCRIPTION
Optimizations:

- row maximum is calculated once per row, not once per matrix element
- no `Vec` allocations for column minimums, using iterators is sufficient

---

Commit also shows some Rust "tricks":

- assign several variables in one `let` statement
- `match` on several items
- use logical or `|` in `match` arms conditions

---

What do you think of the suggested changes?