### PR TITLE
Fix clippy warnings for simple-linked-list

### DIFF
--- a/exercises/simple-linked-list/src/lib.rs
+++ b/exercises/simple-linked-list/src/lib.rs
@@ -1,5 +1,6 @@
 use std::iter::FromIterator;
 
+#[derive(Default)]
 pub struct SimpleLinkedList<T> {
     // Delete this field
     // dummy is needed to avoid unused parameter error during compilation
@@ -12,6 +13,10 @@ impl<T> SimpleLinkedList<T> {
     }
 
     pub fn len(&self) -> usize {
+        unimplemented!()
+    }
+
+    pub fn is_empty(&self) -> bool {
         unimplemented!()
     }
 


### PR DESCRIPTION
- [len_without_is_empty](https://rust-lang.github.io/rust-clippy/master/index.html#len_without_is_empty)
- [new_without_default](https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default)

They are minor, but still.