### PR TITLE
Changed discord link to official rust language discord server

### DIFF
--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -5,4 +5,4 @@
 * [Stack Overflow](http://stackoverflow.com/questions/tagged/rust) can be used to search for your problem and see if it has been answered already.  You can also ask and answer questions.
 * The [Rust User Forum](http://users.rust-lang.org) is for general discussion about Rust.
 * [/r/rust](http://www.reddit.com/r/rust/) is the official Rust subreddit.
-* [The Rust Programming Language](https://discordapp.com/invite/rust) official server on [Discord](https://discordapp.com/) can be used for quick queries and discussions about the language.  
+* [The Rust Programming Language](https://discord.gg/rust-lang) official server on [Discord](https://discordapp.com/) can be used for quick queries and discussions about the language.  


### PR DESCRIPTION
The discord link was pointing to the game Rust.