### PR TITLE
exercise-util: rename "dont_ignore" to "first_test_case" in templates

### DIFF
--- a/util/exercise/src/cmd/templates/macros.rs
+++ b/util/exercise/src/cmd/templates/macros.rs
@@ -34,7 +34,7 @@
     {% endif -%}
 {% endmacro -%}
 
-{% macro gen_test_fn(case, dont_ignore=false) -%}
+{% macro gen_test_fn(case, first_test_case=false) -%}
     {# Need to set up the variables for the template. #}
     {% set description = case.description -%}
     {% set comments = case.comments -%}

--- a/util/exercise/src/cmd/templates/test_file.rs
+++ b/util/exercise/src/cmd/templates/test_file.rs
@@ -8,7 +8,7 @@
 //! [canonical_data]: https://raw.githubusercontent.com/exercism/problem-specifications/master/exercises/{{ exercise }}/canonical-data.json
 
 {% for comment in comments -%}
-    /// {{ comment }}
+/// {{ comment }}
 {% endfor %}
 
 {% if use_maplit -%}
@@ -16,11 +16,11 @@ use maplit::hashmap;
 {% endif %}
 
 {% for property in properties | sort -%}
-    {% include "property_fn.rs" %}
+{% include "property_fn.rs" %}
 {% endfor -%}
 
 {# Don't ignore the first case. -#}
-{% set dont_ignore = true -%}
+{% set first_test_case = true -%}
 
 {% for item in cases -%}
     {# Check if we're dealing with a group of cases. #}
@@ -37,13 +37,13 @@ use maplit::hashmap;
         {% endif -%}
 
         {% for case in item.cases -%}
-            {{ macros::gen_test_fn(case=case, dont_ignore=dont_ignore) }}
-            {% set_global dont_ignore = false -%}
+            {{ macros::gen_test_fn(case=case, first_test_case=first_test_case) }}
+            {% set_global first_test_case = false -%}
         {% endfor -%}
 
     {# Or just a single one. #}
     {% else -%}
-        {{ macros::gen_test_fn(case=item, dont_ignore=dont_ignore) }}
-        {% set_global dont_ignore = false -%}
+        {{ macros::gen_test_fn(case=item, first_test_case=first_test_case) }}
+        {% set_global first_test_case = false -%}
     {% endif -%}
 {% endfor -%}

--- a/util/exercise/src/cmd/templates/test_fn.rs
+++ b/util/exercise/src/cmd/templates/test_fn.rs
@@ -1,7 +1,7 @@
 {% import "macros.rs" as macros -%}
 
 #[test]
-{% if not dont_ignore -%}
+{% if not first_test_case -%}
 #[ignore]
 {% endif -%}
 /// {{ description }}


### PR DESCRIPTION
Follow-up to #908 . Sadly, since macros and included templates do not share the global context of the caller, we can't devolve the logic to the callees. But at least we can make the intent clearer by renaming the variable (thanks to @coriolinus for the suggestion!).

I also removed some indentation in the template (comments and properties) when it had no impact on readability. I'm a bit more hesitant to do so within the loops.