### PR TITLE
Fix the fetch-configlet script, which broke recently

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 LATEST=https://github.com/exercism/configlet/releases/latest
 
 OS=$(
@@ -26,7 +28,12 @@ case $(uname -m) in
         echo 64bit;;
 esac)
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
+VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/[lL]ocation:/{print $NF}' | tr -d '\r')"
+if [ -z "$VERSION" ]; then
+    echo "Latest configlet release could not be determined; aborting"
+    exit 1
+fi
+
 URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
 
-curl -s --location $URL | tar xz -C bin/
+curl -sS --location $URL | tar xz -C bin/


### PR DESCRIPTION
Looks like Github has recently started returning non-uppercased
HTTP headers, at least some of the time. This broke the script,
which looked for a case-sensitive 'Location' header to find the
newest version. We can see this problem in spurious build failures like [this](https://travis-ci.org/exercism/rust/jobs/655967583?utm_medium=notification&utm_source=github_status).

This fixes the script such that it no longer cares whether the initial
L is capital or not, and if it breaks again in the future, it will
give a more informative error.

Request relatively rapid review for this, given that we have an [external PR](https://github.com/exercism/rust/pull/928) which is broken pending this fix.