### PR TITLE
Add new test for clear() to 'Circular Buffer'

### DIFF
--- a/exercises/circular-buffer/example.rs
+++ b/exercises/circular-buffer/example.rs
@@ -55,6 +55,11 @@ impl<T: Default + Clone> CircularBuffer<T> {
     pub fn clear(&mut self) {
         self.start = 0;
         self.end = 0;
+
+        // Clear any values in the buffer
+        for element in self.buffer.iter_mut() {
+            std::mem::take(element);
+        }
     }
 
     pub fn is_empty(&self) -> bool {

--- a/exercises/circular-buffer/tests/circular-buffer.rs
+++ b/exercises/circular-buffer/tests/circular-buffer.rs
@@ -1,4 +1,5 @@
 use circular_buffer::{CircularBuffer, Error};
+use std::rc::Rc;
 
 #[test]
 fn error_on_read_empty_buffer() {

--- a/exercises/circular-buffer/tests/circular-buffer.rs
+++ b/exercises/circular-buffer/tests/circular-buffer.rs
@@ -94,6 +94,17 @@ fn clear_does_nothing_on_empty_buffer() {
 
 #[test]
 #[ignore]
+fn clear_actually_frees_up_its_elements() {
+    let mut buffer = CircularBuffer::new(1);
+    let element = Rc::new(());
+    assert!(buffer.write(Rc::clone(&element)).is_ok());
+    assert_eq!(Rc::strong_count(&element), 2);
+    buffer.clear();
+    assert_eq!(Rc::strong_count(&element), 1);
+}
+
+#[test]
+#[ignore]
 fn overwrite_acts_like_write_on_non_full_buffer() {
     let mut buffer = CircularBuffer::new(2);
     assert!(buffer.write('1').is_ok());


### PR DESCRIPTION
Verifies that clear() actually clears the buffer. Resolves #930.