### PR TITLE
macros: Add new tests to check for invalid syntax

### DIFF
--- a/exercises/macros/.meta/hints.md
+++ b/exercises/macros/.meta/hints.md
@@ -1,0 +1,3 @@
+## Compatability
+
+Note that this exercise requires Rust 1.36 or later.

--- a/exercises/macros/Cargo.toml
+++ b/exercises/macros/Cargo.toml
@@ -4,3 +4,6 @@ name = "macros"
 version = "0.1.0"
 
 [dependencies]
+
+[dev-dependencies]
+trybuild = "1.0"  # required to check for invalid syntax

--- a/exercises/macros/README.md
+++ b/exercises/macros/README.md
@@ -30,12 +30,15 @@ For example, a user of your library might write `hashmap!('a' => 3, 'b' => 11, '
 
 Note that the [`maplit` crate](https://crates.io/crates/maplit) provides a macro which perfectly solves this exercise. Please implement your own solution instead of using this crate; please make an attempt on your own before viewing its source.
 
+## Compatability
+
+Note that this exercise requires Rust 1.36 or later.
+
+
 ## Rust Installation
 
 Refer to the [exercism help page][help-page] for Rust installation and learning
 resources.
-
-Note that this exercise requires Rust 1.36 or later. Refer to the [rustup update page][rustup-update] for instructions to update to the latest version.
 
 ## Writing the Code
 
@@ -104,7 +107,6 @@ If you want to know more about Exercism, take a look at the [contribution guide]
 [modules]: https://doc.rust-lang.org/book/ch07-02-defining-modules-to-control-scope-and-privacy.html
 [cargo]: https://doc.rust-lang.org/book/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/ch11-02-running-tests.html
-[rustup-update]: https://github.com/rust-lang/rustup#keeping-rust-up-to-date
 
 ## Source
 

--- a/exercises/macros/README.md
+++ b/exercises/macros/README.md
@@ -35,6 +35,8 @@ Note that the [`maplit` crate](https://crates.io/crates/maplit) provides a macro
 Refer to the [exercism help page][help-page] for Rust installation and learning
 resources.
 
+Note that this exercise requires Rust 1.36 or later. Refer to the [rustup update page][rustup-update] for instructions to update to the latest version.
+
 ## Writing the Code
 
 Execute the tests with:
@@ -102,6 +104,7 @@ If you want to know more about Exercism, take a look at the [contribution guide]
 [modules]: https://doc.rust-lang.org/book/ch07-02-defining-modules-to-control-scope-and-privacy.html
 [cargo]: https://doc.rust-lang.org/book/ch14-00-more-about-cargo.html
 [rust-tests]: https://doc.rust-lang.org/book/ch11-02-running-tests.html
+[rustup-update]: https://github.com/rust-lang/rustup#keeping-rust-up-to-date
 
 ## Source
 

--- a/exercises/macros/tests/invalid/comma-sep.rs
+++ b/exercises/macros/tests/invalid/comma-sep.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // using only commas is invalid
+    hashmap!('a', 1);
+}

--- a/exercises/macros/tests/invalid/comma-sep.stderr
+++ b/exercises/macros/tests/invalid/comma-sep.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> $DIR/comma-sep.rs:5:17
+  |
+5 |     hashmap!('a', 1);
+  |                 ^ no rules expected this token in macro call

--- a/exercises/macros/tests/invalid/double-commas.rs
+++ b/exercises/macros/tests/invalid/double-commas.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // a single trailing comma is okay, but two is not
+    hashmap!('a' => 2, ,);
+}

--- a/exercises/macros/tests/invalid/double-commas.stderr
+++ b/exercises/macros/tests/invalid/double-commas.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> $DIR/double-commas.rs:5:24
+  |
+5 |     hashmap!('a' => 2, ,);
+  |                        ^ no rules expected this token in macro call

--- a/exercises/macros/tests/invalid/leading-comma.rs
+++ b/exercises/macros/tests/invalid/leading-comma.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // leading commas are not valid
+    hashmap!(, 'a' => 2);
+}

--- a/exercises/macros/tests/invalid/leading-comma.stderr
+++ b/exercises/macros/tests/invalid/leading-comma.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> $DIR/leading-comma.rs:5:14
+  |
+5 |     hashmap!(, 'a' => 2);
+  |              ^ no rules expected this token in macro call

--- a/exercises/macros/tests/invalid/only-arrow.rs
+++ b/exercises/macros/tests/invalid/only-arrow.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // a single random arrow is not valid
+    hashmap!(=>);
+}

--- a/exercises/macros/tests/invalid/only-arrow.stderr
+++ b/exercises/macros/tests/invalid/only-arrow.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `=>`
+ --> $DIR/only-arrow.rs:5:14
+  |
+5 |     hashmap!(=>);
+  |              ^^ no rules expected this token in macro call

--- a/exercises/macros/tests/invalid/only-comma.rs
+++ b/exercises/macros/tests/invalid/only-comma.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // a single random comma is not valid
+    hashmap!(,);
+}

--- a/exercises/macros/tests/invalid/only-comma.stderr
+++ b/exercises/macros/tests/invalid/only-comma.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> $DIR/only-comma.rs:5:14
+  |
+5 |     hashmap!(,);
+  |              ^ no rules expected this token in macro call

--- a/exercises/macros/tests/invalid/single-argument.rs
+++ b/exercises/macros/tests/invalid/single-argument.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // a single argument is invalid
+    hashmap!('a');
+}

--- a/exercises/macros/tests/invalid/single-argument.stderr
+++ b/exercises/macros/tests/invalid/single-argument.stderr
@@ -1,0 +1,5 @@
+error: unexpected end of macro invocation
+ --> $DIR/single-argument.rs:5:17
+  |
+5 |     hashmap!('a');
+  |                 ^ missing tokens in macro arguments

--- a/exercises/macros/tests/invalid/triple-arguments.rs
+++ b/exercises/macros/tests/invalid/triple-arguments.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // three arguments are invalid
+    hashmap!('a' => 1, 'b');
+}

--- a/exercises/macros/tests/invalid/triple-arguments.stderr
+++ b/exercises/macros/tests/invalid/triple-arguments.stderr
@@ -1,0 +1,5 @@
+error: unexpected end of macro invocation
+ --> $DIR/triple-arguments.rs:5:27
+  |
+5 |     hashmap!('a' => 1, 'b');
+  |                           ^ missing tokens in macro arguments

--- a/exercises/macros/tests/invalid/two-arrows.rs
+++ b/exercises/macros/tests/invalid/two-arrows.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // a trailing => isn't valid either
+    hashmap!('a' => 2, =>);
+}

--- a/exercises/macros/tests/invalid/two-arrows.stderr
+++ b/exercises/macros/tests/invalid/two-arrows.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `=>`
+ --> $DIR/two-arrows.rs:5:24
+  |
+5 |     hashmap!('a' => 2, =>);
+  |                        ^^ no rules expected this token in macro call

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -73,8 +73,25 @@ fn test_invalid_syntax() {
     // These tests check for syntax that is invalid and should not compile.
     // If the test fail, then that means the hashmap! macro is allowing
     // invalid syntax
-    let t = trybuild::TestCases::new();
-    t.compile_fail("tests/invalid/*.rs");
+
+    const TRYBUILD: &str = "TRYBUILD";
+    let cleanup = if std::env::var(TRYBUILD).is_ok() {
+        false
+    } else {
+        std::env::set_var(TRYBUILD, "overwrite");
+        true
+    };
+
+    let result = std::panic::catch_unwind(|| {
+        let t = trybuild::TestCases::new();
+        t.compile_fail("tests/invalid/*.rs");
+    });
+
+    if cleanup {
+        std::env::remove_var(TRYBUILD);
+    }
+
+    assert!(result.is_ok());
 }
 
 mod test {

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -67,6 +67,16 @@ fn test_nested() {
     );
 }
 
+#[test]
+#[ignore]
+fn test_invalid_syntax() {
+    // These tests check for syntax that is invalid and should not compile.
+    // If the test fail, then that means the hashmap! macro is allowing
+    // invalid syntax
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/invalid/*.rs");
+}
+
 mod test {
     use macros::hashmap;
     #[test]


### PR DESCRIPTION
- Use the trybuild crate for additional tests.
- These tests contain invalid syntax, and are designed not to compile.
- Student macros should produce an error instead of compile.