### PR TITLE
macros: Add new tests to check for invalid syntax without trybuild

### DIFF
--- a/exercises/macros/.meta/hints.md
+++ b/exercises/macros/.meta/hints.md
@@ -1,0 +1,3 @@
+## Compatability
+
+Note that this exercise requires Rust 1.36 or later.

--- a/exercises/macros/.meta/hints.md
+++ b/exercises/macros/.meta/hints.md
@@ -1,3 +1,3 @@
-## Compatability
+## Compatibility
 
 Note that this exercise requires Rust 1.36 or later.

--- a/exercises/macros/README.md
+++ b/exercises/macros/README.md
@@ -30,6 +30,11 @@ For example, a user of your library might write `hashmap!('a' => 3, 'b' => 11, '
 
 Note that the [`maplit` crate](https://crates.io/crates/maplit) provides a macro which perfectly solves this exercise. Please implement your own solution instead of using this crate; please make an attempt on your own before viewing its source.
 
+## Compatability
+
+Note that this exercise requires Rust 1.36 or later.
+
+
 ## Rust Installation
 
 Refer to the [exercism help page][help-page] for Rust installation and learning

--- a/exercises/macros/README.md
+++ b/exercises/macros/README.md
@@ -30,7 +30,7 @@ For example, a user of your library might write `hashmap!('a' => 3, 'b' => 11, '
 
 Note that the [`maplit` crate](https://crates.io/crates/maplit) provides a macro which perfectly solves this exercise. Please implement your own solution instead of using this crate; please make an attempt on your own before viewing its source.
 
-## Compatability
+## Compatibility
 
 Note that this exercise requires Rust 1.36 or later.
 

--- a/exercises/macros/tests/invalid/Cargo.toml
+++ b/exercises/macros/tests/invalid/Cargo.toml
@@ -1,0 +1,43 @@
+#
+# This Cargo.toml file is used by the simple-trybuild module.
+# When adding a new file, please name the [[bin]] name to match the file
+# it is used to produce an error message
+#
+
+[package]
+name = "macros-tests"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies.macros]
+path = "../../"
+default-features = false
+
+[[bin]]
+name = "comma-sep-rs"
+path = "comma-sep.rs"
+
+[[bin]]
+name = "double-commas-rs"
+path = "double-commas.rs"
+
+[[bin]]
+name = "only-arrow-rs"
+path = "only-arrow.rs"
+
+[[bin]]
+name = "only-comma-rs"
+path = "only-comma.rs"
+
+[[bin]]
+name = "single-argument-rs"
+path = "single-argument.rs"
+
+[[bin]]
+name = "triple-arguments-rs"
+path = "triple-arguments.rs"
+
+[[bin]]
+name = "two-arrows-rs"
+path = "two-arrows.rs"

--- a/exercises/macros/tests/invalid/comma-sep.rs
+++ b/exercises/macros/tests/invalid/comma-sep.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // using only commas is invalid
+    hashmap!('a', 1);
+}

--- a/exercises/macros/tests/invalid/double-commas.rs
+++ b/exercises/macros/tests/invalid/double-commas.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // a single trailing comma is okay, but two is not
+    hashmap!('a' => 2, ,);
+}

--- a/exercises/macros/tests/invalid/leading-comma.rs
+++ b/exercises/macros/tests/invalid/leading-comma.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // leading commas are not valid
+    hashmap!(, 'a' => 2);
+}

--- a/exercises/macros/tests/invalid/only-arrow.rs
+++ b/exercises/macros/tests/invalid/only-arrow.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // a single random arrow is not valid
+    hashmap!(=>);
+}

--- a/exercises/macros/tests/invalid/only-comma.rs
+++ b/exercises/macros/tests/invalid/only-comma.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // a single random comma is not valid
+    hashmap!(,);
+}

--- a/exercises/macros/tests/invalid/single-argument.rs
+++ b/exercises/macros/tests/invalid/single-argument.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // a single argument is invalid
+    hashmap!('a');
+}

--- a/exercises/macros/tests/invalid/triple-arguments.rs
+++ b/exercises/macros/tests/invalid/triple-arguments.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // three arguments are invalid
+    hashmap!('a' => 1, 'b');
+}

--- a/exercises/macros/tests/invalid/two-arrows.rs
+++ b/exercises/macros/tests/invalid/two-arrows.rs
@@ -1,0 +1,6 @@
+use macros::hashmap;
+
+fn main() {
+    // a trailing => isn't valid either
+    hashmap!('a' => 2, =>);
+}

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -67,11 +67,79 @@ fn test_nested() {
     );
 }
 
+#[test]
+#[ignore]
+fn test_compile_fails_comma_sep() {
+    simple_trybuild::compile_fail("comma-sep.rs");
+}
+
+#[test]
+#[ignore]
+fn test_compile_fails_double_commas() {
+    simple_trybuild::compile_fail("double-commas.rs");
+}
+
+#[test]
+#[ignore]
+fn test_compile_fails_only_comma() {
+    simple_trybuild::compile_fail("only-comma.rs");
+}
+
+#[test]
+#[ignore]
+fn test_compile_fails_single_argument() {
+    simple_trybuild::compile_fail("single-argument.rs");
+}
+
+#[test]
+#[ignore]
+fn test_compile_fails_triple_arguments() {
+    simple_trybuild::compile_fail("triple-argumentss.rs");
+}
+
+#[test]
+#[ignore]
+fn test_compile_fails_only_arrow() {
+    simple_trybuild::compile_fail("only-arrow.rs");
+}
+
+#[test]
+#[ignore]
+fn test_compile_fails_two_arrows() {
+    simple_trybuild::compile_fail("two-arrows.rs");
+}
+
 mod test {
     use macros::hashmap;
     #[test]
     #[ignore]
     fn type_not_in_scope() {
         let _expected: ::std::collections::HashMap<(), ()> = hashmap!();
+    }
+}
+
+mod simple_trybuild {
+    use std::process::Command;
+
+    pub fn compile_fail(file_name: &str) {
+        let test_name = file_name.replace(".", "-");
+
+        let result = Command::new("cargo")
+            .current_dir("tests/invalid/")
+            .arg("build")
+            .arg("--offline")
+            .arg("--target-dir=../../target/tests/macros/")
+            .arg("--bin")
+            .arg(test_name)
+            .output();
+
+        assert!(result.is_ok());
+        if let Ok(result) = result {
+            assert!(
+                !result.status.success(),
+                "tests/invalid/{} compiled sucessfully, but should not.",
+                file_name,
+            );
+        }
     }
 }

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -94,7 +94,7 @@ fn test_compile_fails_single_argument() {
 #[test]
 #[ignore]
 fn test_compile_fails_triple_arguments() {
-    simple_trybuild::compile_fail("triple-argumentss.rs");
+    simple_trybuild::compile_fail("triple-arguments.rs");
 }
 
 #[test]
@@ -122,10 +122,21 @@ mod simple_trybuild {
     use std::process::Command;
 
     pub fn compile_fail(file_name: &str) {
+        const INVALID_PATH: &str = "tests/invalid";
+
+        assert!(
+            [INVALID_PATH, file_name]
+                .iter()
+                .collect::<std::path::PathBuf>()
+                .exists(),
+            "file tests/invalid/{} does not exist.",
+            file_name
+        );
+
         let test_name = file_name.replace(".", "-");
 
         let result = Command::new("cargo")
-            .current_dir("tests/invalid/")
+            .current_dir(INVALID_PATH)
             .arg("build")
             .arg("--offline")
             .arg("--target-dir=../../target/tests/macros/")
@@ -137,8 +148,9 @@ mod simple_trybuild {
         if let Ok(result) = result {
             assert!(
                 !result.status.success(),
-                "tests/invalid/{} compiled sucessfully, but should not.",
-                file_name,
+                "{}/{} compiled sucessfully, but should not.",
+                INVALID_PATH,
+                file_name
             );
         }
     }


### PR DESCRIPTION
- This uses code inspired by buildtry, but this is less flexible.
- These tests contain invalid syntax, and are designed not to compile.
- Student macros should produce an error instead of compile.
- Add note about Rust 1.36 requirement

---

Output of all passing tests like with `example.rs` and this [student's implementation](https://exercism.io/mentor/solutions/80240c6472fd40f4a6ae5924e2bd0f33):
```
running 13 tests
test test::type_not_in_scope ... ok
test test_empty ... ok
test test_single ... ok
test test_no_trailing_comma ... ok
test test_nested ... ok
test test_trailing_comma ... ok
test test_compile_fails_triple_arguments ... ok
test test_compile_fails_two_arrows ... ok
test test_compile_fails_double_commas ... ok
test test_compile_fails_only_arrow ... ok
test test_compile_fails_single_argument ... ok
test test_compile_fails_only_comma ... ok
test test_compile_fails_comma_sep ... ok
```

[Another student](https://exercism.io/mentor/solutions/644c98b29f7041a5a46b26f093b26263) that has a failure sees this:
```
running 13 tests
test test::type_not_in_scope ... ok
test test_empty ... ok
test test_single ... ok
test test_no_trailing_comma ... ok
test test_nested ... ok
test test_trailing_comma ... ok
test test_compile_fails_triple_arguments ... ok
test test_compile_fails_only_arrow ... ok
test test_compile_fails_comma_sep ... ok
test test_compile_fails_only_comma ... ok
test test_compile_fails_double_commas ... FAILED
test test_compile_fails_single_argument ... ok
test test_compile_fails_two_arrows ... ok

failures:

---- test_compile_fails_double_commas stdout ----
thread 'test_compile_fails_double_commas' panicked at 'tests/invalid/double-commas.rs compiled sucessfully, but should not.', tests/macros.rs:138:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

