### PR TITLE
diffie-hellman: Add test cases for inputs near the type limits

### DIFF
--- a/exercises/diffie-hellman/.meta/hints.md
+++ b/exercises/diffie-hellman/.meta/hints.md
@@ -1,2 +1,14 @@
 One possible solution for this exercise is to implement your own modular exponentiation function.
 To learn more about it refer to the [following page](https://en.wikipedia.org/wiki/Modular_exponentiation).
+
+## For bonus points
+
+Many implementations do not work for the entire domain of inputs.
+There are additional optional tests defined which help ensure that all valid inputs produce valid results.
+
+To run the bonus tests, remove the `#[ignore]` flag and execute the tests with
+the `big-primes` feature, like this:
+
+```bash
+$ cargo test --features big-primes
+```

--- a/exercises/diffie-hellman/Cargo-example.toml
+++ b/exercises/diffie-hellman/Cargo-example.toml
@@ -5,3 +5,6 @@ version = "0.1.0"
 
 [dependencies]
 rand = "0.3.18"
+
+[features]
+big-primes = []

--- a/exercises/diffie-hellman/Cargo.toml
+++ b/exercises/diffie-hellman/Cargo.toml
@@ -4,3 +4,6 @@ name = "diffie-hellman"
 version = "0.1.0"
 
 [dependencies]
+
+[features]
+big-primes = []

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -40,6 +40,18 @@ secret s.
 One possible solution for this exercise is to implement your own modular exponentiation function.
 To learn more about it refer to the [following page](https://en.wikipedia.org/wiki/Modular_exponentiation).
 
+## For bonus points
+
+Many implementations do not work for the entire domain of inputs.
+There are additional optional tests defined which help ensure that all valid inputs produce valid results.
+
+To run the bonus tests, remove the `#[ignore]` flag and execute the tests with
+the `big-primes` feature, like this:
+
+```bash
+$ cargo test --features big-primes
+```
+
 
 ## Rust Installation
 

--- a/exercises/diffie-hellman/example.rs
+++ b/exercises/diffie-hellman/example.rs
@@ -7,21 +7,22 @@ use rand::distributions::{IndependentSample, Range};
 fn modular_exponentiation(base: u64, exponent: u64, modulus: u64) -> u64 {
     let mut result = 1;
 
-    let mut e = exponent;
-
-    let mut b = base;
+    // avoid overflow on multiplication
+    let mut e = exponent as u128;
+    let m = modulus as u128;
+    let mut b = (base % modulus) as u128;
 
     while e > 0 {
         if (e & 1) == 1 {
-            result = (result * b) % modulus;
+            result = (result * b) % m;
         }
 
         e >>= 1;
 
-        b = (b * b) % modulus;
+        b = (b * b) % m;
     }
 
-    result
+    result as u64
 }
 
 pub fn private_key(p: u64) -> u64 {

--- a/exercises/diffie-hellman/tests/diffie-hellman.rs
+++ b/exercises/diffie-hellman/tests/diffie-hellman.rs
@@ -67,6 +67,63 @@ fn test_secret_key_correct_big_numbers() {
     assert_eq!(secret, expected);
 }
 
+// two biggest 64bit primes
+#[cfg(feature = "big-primes")]
+const PRIME_64BIT_1: u64 = 0xFFFF_FFFF_FFFF_FFC5;
+#[cfg(feature = "big-primes")]
+const PRIME_64BIT_2: u64 = 0xFFFF_FFFF_FFFF_FFAC;
+#[cfg(feature = "big-primes")]
+const PRIVATE_KEY_64BIT: u64 = 0xFFFF_FFFF_FFFF_FFC3;
+#[cfg(feature = "big-primes")]
+const PUBLIC_KEY_64BIT: u64 = 0xB851_EB85_1EB8_51C1;
+
+#[test]
+#[ignore]
+#[cfg(feature = "big-primes")]
+fn test_public_key_correct_biggest_numbers() {
+    assert_eq!(
+        public_key(PRIME_64BIT_1, PRIME_64BIT_2, PRIVATE_KEY_64BIT),
+        PUBLIC_KEY_64BIT
+    );
+}
+
+#[test]
+#[ignore]
+#[cfg(feature = "big-primes")]
+fn test_secret_key_correct_biggest_numbers() {
+    let private_key_b = 0xEFFF_FFFF_FFFF_FFC0;
+    let public_key_b = public_key(PRIME_64BIT_1, PRIME_64BIT_2, private_key_b);
+
+    let expected_b = 4_340_425_873_327_658_043;
+    assert_eq!(public_key_b, expected_b);
+
+    let expected_key = 12_669_955_479_143_291_250;
+
+    let secret_key = secret(PRIME_64BIT_1, public_key_b, PRIVATE_KEY_64BIT);
+
+    assert_eq!(secret_key, expected_key);
+
+    let secret_key = secret(PRIME_64BIT_1, PUBLIC_KEY_64BIT, private_key_b);
+
+    assert_eq!(secret_key, expected_key);
+}
+
+#[test]
+#[ignore]
+#[cfg(feature = "big-primes")]
+fn test_changed_secret_key_biggest_numbers() {
+    let private_key_a = private_key(PRIME_64BIT_1);
+    let public_key_a = public_key(PRIME_64BIT_1, PRIME_64BIT_2, private_key_a);
+
+    let private_key_b = private_key(PRIME_64BIT_1);
+    let public_key_b = public_key(PRIME_64BIT_1, PRIME_64BIT_2, private_key_b);
+
+    let secret_a = secret(PRIME_64BIT_1, public_key_b, private_key_a);
+    let secret_b = secret(PRIME_64BIT_1, public_key_a, private_key_b);
+
+    assert_eq!(secret_a, secret_b);
+}
+
 #[test]
 #[ignore]
 fn test_changed_secret_key() {


### PR DESCRIPTION
Fixes https://github.com/exercism/rust/issues/936

* Add tests with inputs near the u64 type limits as a solutions may
  panic 'multiplication overflow' while passing existing tests
* Fix example code to also pass these tests