### PR TITLE
macros: Add tests to check for HashMap scoping

### DIFF
--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -73,7 +73,7 @@ fn test_type_override() {
     // The macro should always use std::collections::HashMap and ignore crate::std::collections::HashMap
     mod std {
         pub mod collections {
-            pub struct HashMap();
+            pub struct HashMap;
 
             impl HashMap {
                 #[allow(dead_code)]

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -68,6 +68,35 @@ fn test_nested() {
 }
 
 #[test]
+fn test_type_override() {
+    // Don't allow users to override the intended type with their own
+    mod std {
+        pub mod collections {
+            #[allow(dead_code)]
+            #[derive(Debug)]
+            pub struct HashMap();
+
+            impl HashMap {
+                #[allow(dead_code)]
+                pub fn new() -> Self {
+                    panic!("Don't allow users to override which HashMap is used");
+                }
+            }
+
+            impl<K, V> PartialEq<::std::collections::HashMap<K, V>> for HashMap {
+                fn eq(&self, _: &::std::collections::HashMap<K, V>) -> bool {
+                    panic!("Don't allow users to override which HashMap is used");
+                }
+            }
+        }
+    }
+
+    let expected: ::std::collections::HashMap<u32, u32> = ::std::collections::HashMap::new();
+    let computed = hashmap!();
+    assert_eq!(computed, expected);
+}
+
+#[test]
 #[ignore]
 fn test_compile_fails_comma_sep() {
     simple_trybuild::compile_fail("comma-sep.rs");

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -68,32 +68,28 @@ fn test_nested() {
 }
 
 #[test]
+#[ignore]
 fn test_type_override() {
-    // Don't allow users to override the intended type with their own
+    // The macro should always use std::collections::HashMap and ignore crate::std::collections::HashMap
     mod std {
         pub mod collections {
-            #[allow(dead_code)]
-            #[derive(Debug)]
             pub struct HashMap();
 
             impl HashMap {
                 #[allow(dead_code)]
                 pub fn new() -> Self {
-                    panic!("Don't allow users to override which HashMap is used");
+                    panic!("Do not allow users to override which HashMap is used");
                 }
-            }
 
-            impl<K, V> PartialEq<::std::collections::HashMap<K, V>> for HashMap {
-                fn eq(&self, _: &::std::collections::HashMap<K, V>) -> bool {
-                    panic!("Don't allow users to override which HashMap is used");
+                #[allow(dead_code)]
+                pub fn insert<K, V>(&mut self, _key: K, _val: V) {
+                    panic!("Do not allow users to override which HashMap is used");
                 }
             }
         }
     }
 
-    let expected: ::std::collections::HashMap<u32, u32> = ::std::collections::HashMap::new();
-    let computed = hashmap!();
-    assert_eq!(computed, expected);
+    let _computed = hashmap!(1 => 2, 3 => 4);
 }
 
 #[test]


### PR DESCRIPTION
This test makes sure that students use `::std::collections::HashMap`
instead of just `std::collections::HashMap`. It is intended
to show that a user can override the intended type.

They receive this error if the wrong scoping is used:

```
---- test_type_override stdout ----
thread 'test_type_override' panicked at 'Do not allow users to override which HashMap is used', tests/macros.rs:81:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```