### PR TITLE
macros: additional tests without HashMap in scope

### DIFF
--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -72,7 +72,7 @@ mod test {
     #[test]
     #[ignore]
     fn type_not_in_scope() {
-        let _empty = hashmap!();
+        let _empty: ::std::collections::HashMap<(), ()> = hashmap!();
         let _expected = hashmap!(23=> 623, 34 => 21);
     }
 }

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -67,6 +67,16 @@ fn test_nested() {
     );
 }
 
+mod test {
+    use macros::hashmap;
+    #[test]
+    #[ignore]
+    fn type_not_in_scope() {
+        let _empty = hashmap!();
+        let _expected = hashmap!(23=> 623, 34 => 21);
+    }
+}
+
 #[test]
 #[ignore]
 fn test_compile_fails_comma_sep() {
@@ -107,15 +117,6 @@ fn test_compile_fails_only_arrow() {
 #[ignore]
 fn test_compile_fails_two_arrows() {
     simple_trybuild::compile_fail("two-arrows.rs");
-}
-
-mod test {
-    use macros::hashmap;
-    #[test]
-    #[ignore]
-    fn type_not_in_scope() {
-        let _expected: ::std::collections::HashMap<(), ()> = hashmap!();
-    }
 }
 
 mod simple_trybuild {


### PR DESCRIPTION
- This is a continuation of #649
- Move the tests above the compilation failure tests.
- Add a line to test with parameters. If students submit a macro
  with a specific match for e.g. ` () => {{ ::std::collections::HashMap::new() }};`
  but then not include the same for the default case.