### PR TITLE
macros: Check recursive solutions use $crate

### DIFF
--- a/exercises/macros/example.rs
+++ b/exercises/macros/example.rs
@@ -3,7 +3,7 @@
 
 #[macro_export]
 macro_rules! hashmap {
-    ($($key:expr => $value:expr,)+) => { hashmap!($($key => $value),+) };
+    ($($key:expr => $value:expr,)+) => { $crate::hashmap!($($key => $value),+) };
     ($($key:expr => $value:expr),*) => {
         {
             let mut _map = ::std::collections::HashMap::new();

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -68,22 +68,19 @@ fn test_nested() {
 }
 
 mod test {
-    use macros::hashmap;
     #[test]
     #[ignore]
     fn type_not_in_scope() {
+        use macros::hashmap;
+
         let _empty: ::std::collections::HashMap<(), ()> = hashmap!();
         let _expected = hashmap!(23=> 623, 34 => 21);
     }
-}
-
-mod renamed {
-    use macros as macros_renamed;
 
     #[test]
     #[ignore]
-    fn test_renamed_module() {
-        let _expected = macros_renamed::hashmap!(23 => 623, 34 => 21,);
+    fn test_macro_out_of_scope() {
+        let _expected = macros::hashmap!(23 => 623, 34 => 21,);
     }
 }
 

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -77,6 +77,15 @@ mod test {
     }
 }
 
+mod renamed {
+    use macros as macros_renamed;
+
+    #[test]
+    fn test_renamed_module() {
+        let _expected = macros_renamed::hashmap!(23 => 623, 34 => 21,);
+    }
+}
+
 #[test]
 #[ignore]
 fn test_type_override() {

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -81,6 +81,7 @@ mod renamed {
     use macros as macros_renamed;
 
     #[test]
+    #[ignore]
     fn test_renamed_module() {
         let _expected = macros_renamed::hashmap!(23 => 623, 34 => 21,);
     }


### PR DESCRIPTION
- A recursive solution, including the one in `example.rs` should
  use `$crate::` to prefix the recursive macro call. Otherwise,
  renaming the module fails.