### PR TITLE
Add testcases to matching brackets

### DIFF
--- a/exercises/matching-brackets/tests/matching-brackets.rs
+++ b/exercises/matching-brackets/tests/matching-brackets.rs
@@ -91,6 +91,18 @@ fn too_many_closing_brackets() {
 
 #[test]
 #[ignore]
+fn early_incomplete_brackets() {
+    assert!(!brackets_are_balanced(")()"));
+}
+
+#[test]
+#[ignore]
+fn early_mismatched_brackets() {
+    assert!(!brackets_are_balanced("{)()"));
+}
+
+#[test]
+#[ignore]
 fn math_expression() {
     assert!(brackets_are_balanced("(((185 + 223.85) * 15) - 543)/2"));
 }


### PR DESCRIPTION
I Wrote code that passed all of the testcases but it had a bug. If there was any isolated error with mismatched brackets or extra brackets when the stack was empty it would essentially ignore the error.
My code https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=1661c960aaf13f061dbeb747a587cece

These testcases could also be push up to the problem description repo.

Should i also open a pull request to the problem description repo?