### PR TITLE
macros: Assign invalid tests to variable

### DIFF
--- a/exercises/macros/tests/invalid/Cargo.toml
+++ b/exercises/macros/tests/invalid/Cargo.toml
@@ -41,3 +41,7 @@ path = "triple-arguments.rs"
 [[bin]]
 name = "two-arrows-rs"
 path = "two-arrows.rs"
+
+[[bin]]
+name = "leading-comma-rs"
+path = "leading-comma.rs"

--- a/exercises/macros/tests/invalid/comma-sep.rs
+++ b/exercises/macros/tests/invalid/comma-sep.rs
@@ -2,5 +2,5 @@ use macros::hashmap;
 
 fn main() {
     // using only commas is invalid
-    hashmap!('a', 1);
+    let _hm: ::std::collections::HashMap<_, _> = hashmap!('a', 1);
 }

--- a/exercises/macros/tests/invalid/double-commas.rs
+++ b/exercises/macros/tests/invalid/double-commas.rs
@@ -2,5 +2,5 @@ use macros::hashmap;
 
 fn main() {
     // a single trailing comma is okay, but two is not
-    hashmap!('a' => 2, ,);
+    let _hm: ::std::collections::HashMap<_, _> = hashmap!('a' => 2, ,);
 }

--- a/exercises/macros/tests/invalid/leading-comma.rs
+++ b/exercises/macros/tests/invalid/leading-comma.rs
@@ -2,5 +2,5 @@ use macros::hashmap;
 
 fn main() {
     // leading commas are not valid
-    hashmap!(, 'a' => 2);
+    let _hm: ::std::collections::HashMap<_, _> = hashmap!(, 'a' => 2);
 }

--- a/exercises/macros/tests/invalid/only-arrow.rs
+++ b/exercises/macros/tests/invalid/only-arrow.rs
@@ -2,5 +2,5 @@ use macros::hashmap;
 
 fn main() {
     // a single random arrow is not valid
-    hashmap!(=>);
+    let _hm: ::std::collections::HashMap<(), ()> = hashmap!(=>);
 }

--- a/exercises/macros/tests/invalid/only-comma.rs
+++ b/exercises/macros/tests/invalid/only-comma.rs
@@ -2,5 +2,5 @@ use macros::hashmap;
 
 fn main() {
     // a single random comma is not valid
-    hashmap!(,);
+    let _hm: ::std::collections::HashMap<(), ()> = hashmap!(,);
 }

--- a/exercises/macros/tests/invalid/single-argument.rs
+++ b/exercises/macros/tests/invalid/single-argument.rs
@@ -2,5 +2,5 @@ use macros::hashmap;
 
 fn main() {
     // a single argument is invalid
-    hashmap!('a');
+    let _hm: ::std::collections::HashMap<_, _> = hashmap!('a');
 }

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -144,6 +144,12 @@ fn test_compile_fails_two_arrows() {
     simple_trybuild::compile_fail("two-arrows.rs");
 }
 
+#[test]
+#[ignore]
+fn test_compile_fails_leading_comma() {
+    simple_trybuild::compile_fail("leading-comma.rs");
+}
+
 mod simple_trybuild {
     use std::path::PathBuf;
     use std::process::Command;


### PR DESCRIPTION
- Try to assign to variable, in most cases this is `<_, _>`
- only-arrow and only-comma use `<(), ()>`
- Also enables leading-comma which was accidentally not enabled