### PR TITLE
macros: Check for additional scoped syntax

### DIFF
--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -74,13 +74,16 @@ mod test {
         use macros::hashmap;
 
         let _empty: ::std::collections::HashMap<(), ()> = hashmap!();
-        let _expected = hashmap!(23=> 623, 34 => 21);
+        let _without_comma = hashmap!(23=> 623, 34 => 21);
+        let _with_trailing = hashmap!(23 => 623, 34 => 21,);
     }
 
     #[test]
     #[ignore]
     fn test_macro_out_of_scope() {
-        let _expected = macros::hashmap!(23 => 623, 34 => 21,);
+        let _empty: ::std::collections::HashMap<(), ()> = macros::hashmap!();
+        let _without_comma = macros::hashmap!(23=> 623, 34 => 21);
+        let _with_trailing = macros::hashmap!(23 => 623, 34 => 21,);
     }
 }
 


### PR DESCRIPTION
- Had a student who had inverted the logic between trailing-comma
  and non-trailing comma. This change ensures that it works in both
  cases.
- Also added lines between the two similar tests to check for all
  three possible inputs.