### PR TITLE
macros: Additional syntax for hashmap override

### DIFF
--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -109,7 +109,9 @@ fn test_type_override() {
         }
     }
 
-    let _computed = hashmap!(1 => 2, 3 => 4);
+    let _empty: ::std::collections::HashMap<(), ()> = hashmap!();
+    let _without_comma = hashmap!(1 => 2, 3 => 4);
+    let _with_trailing = hashmap!(1 => 2, 3 => 4,);
 }
 
 #[test]


### PR DESCRIPTION
- Some students implement the solution in different ways. This
  ensures that they prefix the namespace to make sure no one
  overrides it.