### PR TITLE
gigasecond: Remove no-op import from tests

### DIFF
--- a/exercises/gigasecond/tests/gigasecond.rs
+++ b/exercises/gigasecond/tests/gigasecond.rs
@@ -1,5 +1,3 @@
-use gigasecond;
-
 use chrono::{TimeZone, Utc};
 
 #[test]


### PR DESCRIPTION
A student has reported that clippy now complains about this line in tests. Indeed, it's not necessary.