### PR TITLE
forth: Two tests which have definitions not as the first word in an `eval`

### DIFF
--- a/exercises/forth/tests/forth.rs
+++ b/exercises/forth/tests/forth.rs
@@ -343,3 +343,20 @@ fn calling_non_existing_word() {
     let mut f = Forth::new();
     assert_eq!(Err(Error::UnknownWord), f.eval("1 foo"));
 }
+
+#[test]
+#[ignore]
+fn multiple_definitions() {
+    let mut f = Forth::new();
+    assert!(f.eval(": one 1 ; : two 2 ; one two +").is_ok());
+    assert_eq!(vec![3], f.stack());
+}
+
+#[test]
+#[ignore]
+fn definitions_after_ops() {
+    let mut f = Forth::new();
+    assert!(f.eval("1 2 + : addone 1 + ; addone").is_ok());
+    assert_eq!(vec![4], f.stack());
+}
+


### PR DESCRIPTION
I've seen solutions to this exercise which test if the first character
or lexeme in an `eval` call is `:`, handle a definition if it is, and
then process the rest of the input as normal operations. I feel like
that shouldn't be allowed; a Forth interpreter should be able to
handle definitions interleaved with operations and sequences of
multiple definitions.