### PR TITLE
[leap-test] Fix typo in test function name.

### DIFF
--- a/exercises/leap/tests/leap.rs
+++ b/exercises/leap/tests/leap.rs
@@ -35,7 +35,7 @@ fn test_year_divisible_by_100_not_divisible_by_400_common_year() {
 
 #[test]
 #[ignore]
-fn test_year_divisible_by_100_but_not_by_3_is_still_not_a_leap_year() {
+fn test_year_divisible_by_100_but_not_by_400_is_still_not_a_leap_year() {
     process_leapyear_case(1900, false);
 }
 


### PR DESCRIPTION
I open this pull-request because I may found a small typo in test cases in leap exercises. I was confused by reading

> divisible by 100 not by 3 is still not a leap year

Better change may be:

> divisible by 100 but not 400

Please tell me if i am wrong ! :)