### PR TITLE
grep: replace failure with anyhow

### DIFF
--- a/config.json
+++ b/config.json
@@ -1049,8 +1049,8 @@
       "unlocked_by": "poker",
       "difficulty": 7,
       "topics": [
+        "anyhow_crate",
         "conditionals",
-        "failure_crate",
         "file_io",
         "parsing",
         "result_type",

--- a/exercises/grep/.meta/hints.md
+++ b/exercises/grep/.meta/hints.md
@@ -1,14 +1,23 @@
-### Error handling
-This exercise introduces the usage of `failure` crate,
-that gives you the means to manage your custom error types.
-To learn more about the crate refer to the [failure documentation](https://boats.gitlab.io/failure/intro.html)
+## Error handling
 
-### Additional reading
+This exercise introduces the `anyhow` crate, which makes it easy to handle arbitrary error types.
+Its intent is to ensure that when you're writing an application, you don't have to worry about what
+particular errors your called function is returning, but to just do the right thing when propagating them.
+
+N.B.: it is actually somewhat bad form to use `anyhow` when writing a library, as we are here; it's more
+explicit and more useful to write your own `Error` enum when writing a library (potentially with the aid of helper
+macros such as are provided by the [`thiserror` crate](https://crates.io/crates/thiserror)). However, we are
+intentionally and explicitly doing so here to demonstrate the use of this crate.
+
+To learn more about this crate refer to its [documentation](https://docs.rs/anyhow/1.0.32/anyhow/).
+
+## Additional reading
 
 While this exercise asks you to implement only the most basic functions of `grep`,
 there is actually a project to fully re-implement `grep` in Rust - [ripgrep](https://github.com/BurntSushi/ripgrep).
 
 If you liked the concept of rewriting the basic util programs in Rust be sure to check the following projects:
+
 - [fd](https://github.com/sharkdp/fd) - a clone of `find`
 - [exa](https://github.com/ogham/exa) - a clone of `ls`
 - [bat](https://github.com/sharkdp/bat) - a clone of `cat`

--- a/exercises/grep/Cargo-example.toml
+++ b/exercises/grep/Cargo-example.toml
@@ -1,5 +1,6 @@
 [dependencies]
 anyhow = "1.0"
+thiserror = "1.0"
 
 [package]
 edition = "2018"

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -64,17 +64,26 @@ The `grep` command should support multiple flags at once.
 For example, running `grep -l -v "hello" file1.txt file2.txt` should
 print the names of files that do not contain the string "hello".
 
-### Error handling
-This exercise introduces the usage of `failure` crate,
-that gives you the means to manage your custom error types.
-To learn more about the crate refer to the [failure documentation](https://boats.gitlab.io/failure/intro.html)
+## Error handling
 
-### Additional reading
+This exercise introduces the `anyhow` crate, which makes it easy to handle arbitrary error types.
+Its intent is to ensure that when you're writing an application, you don't have to worry about what
+particular errors your called function is returning, but to just do the right thing when propagating them.
+
+N.B.: it is actually somewhat bad form to use `anyhow` when writing a library, as we are here; it's more
+explicit and more useful to write your own `Error` enum when writing a library (potentially with the aid of helper
+macros such as are provided by the [`thiserror` crate](https://crates.io/crates/thiserror)). However, we are
+intentionally and explicitly doing so here to demonstrate the use of this crate.
+
+To learn more about this crate refer to its [documentation](https://docs.rs/anyhow/1.0.32/anyhow/).
+
+## Additional reading
 
 While this exercise asks you to implement only the most basic functions of `grep`,
 there is actually a project to fully re-implement `grep` in Rust - [ripgrep](https://github.com/BurntSushi/ripgrep).
 
 If you liked the concept of rewriting the basic util programs in Rust be sure to check the following projects:
+
 - [fd](https://github.com/sharkdp/fd) - a clone of `find`
 - [exa](https://github.com/ogham/exa) - a clone of `ls`
 - [bat](https://github.com/sharkdp/bat) - a clone of `cat`

--- a/exercises/grep/example.rs
+++ b/exercises/grep/example.rs
@@ -1,15 +1,13 @@
-#[macro_use]
-extern crate failure;
+use anyhow::Error;
 
-use failure::Error;
 use std::{fs, path::Path};
 
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 enum FileAccessError {
-    #[fail(display = "File not found: {}", file_name)]
+    #[error("File not found: {}", file_name)]
     FileNotFoundError { file_name: String },
 
-    #[fail(display = "Error reading file: {}", file_name)]
+    #[error("Error reading file: {}", file_name)]
     FileReadError { file_name: String },
 }
 

--- a/exercises/grep/src/lib.rs
+++ b/exercises/grep/src/lib.rs
@@ -1,12 +1,17 @@
-use failure::Error;
+use anyhow::Error;
 
-/// While using raw slice of str to handle flags is convenient,
-/// in the real-world projects it is customary to use a struct,
-/// that contains flags-related logic. So in this exercise
-/// we ask you to implement a custom struct.
+/// While using `&[&str]` to handle flags is convenient for exercise purposes,
+/// and resembles the output of [`std::env::args`], in real-world projects it is
+/// both more convenient and more idiomatic to contain runtime configuration in
+/// a dedicated struct. Therefore, we suggest that you do so in this exercise.
 ///
-/// If you are curious about real-world implementation, refer to the `clap-rs` crate:
-/// https://github.com/kbknapp/clap-rs/blob/master/src/args/arg_matches.rs
+/// In the real world, it's common to use crates such as [`clap`] or
+/// [`structopt`] to handle argument parsing, and of course doing so is
+/// permitted in this exercise as well, though it may be somewhat overkill.
+///
+/// [`clap`]: https://crates.io/crates/clap
+/// [`std::env::args`]: https://doc.rust-lang.org/std/env/fn.args.html
+/// [`structopt`]: https://crates.io/crates/structopt
 #[derive(Debug)]
 pub struct Flags;
 

--- a/exercises/grep/tests/grep.rs
+++ b/exercises/grep/tests/grep.rs
@@ -190,130 +190,154 @@ fn test_grep_returns_result() {
 
 // Test grepping a single file
 
-set_up_test_case!(#[test]
-#[ignore]
-test_one_file_one_match_no_flags(
-    pattern = "Agamemnon",
-    flags = [],
-    files = ["iliad.txt"],
-    expected = ["Of Atreus, Agamemnon, King of men."]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_one_file_one_match_no_flags(
+        pattern = "Agamemnon",
+        flags = [],
+        files = ["iliad.txt"],
+        expected = ["Of Atreus, Agamemnon, King of men."]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_one_file_one_match_print_line_numbers_flag(
-    pattern = "Forbidden",
-    flags = ["-n"],
-    files = ["paradise_lost.txt"],
-    expected = ["2:Of that Forbidden Tree, whose mortal tast"]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_one_file_one_match_print_line_numbers_flag(
+        pattern = "Forbidden",
+        flags = ["-n"],
+        files = ["paradise_lost.txt"],
+        expected = ["2:Of that Forbidden Tree, whose mortal tast"]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_one_file_one_match_caseinsensitive_flag(
-    pattern = "FORBIDDEN",
-    flags = ["-i"],
-    files = ["paradise_lost.txt"],
-    expected = ["Of that Forbidden Tree, whose mortal tast"]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_one_file_one_match_caseinsensitive_flag(
+        pattern = "FORBIDDEN",
+        flags = ["-i"],
+        files = ["paradise_lost.txt"],
+        expected = ["Of that Forbidden Tree, whose mortal tast"]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_one_file_one_match_print_file_names_flag(
-    pattern = "Forbidden",
-    flags = ["-l"],
-    files = ["paradise_lost.txt"],
-    prefix_expected = ["paradise_lost.txt"]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_one_file_one_match_print_file_names_flag(
+        pattern = "Forbidden",
+        flags = ["-l"],
+        files = ["paradise_lost.txt"],
+        prefix_expected = ["paradise_lost.txt"]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_one_file_one_match_match_entire_lines_flag(
-    pattern = "With loss of Eden, till one greater Man",
-    flags = ["-x"],
-    files = ["paradise_lost.txt"],
-    expected = ["With loss of Eden, till one greater Man"]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_one_file_one_match_match_entire_lines_flag(
+        pattern = "With loss of Eden, till one greater Man",
+        flags = ["-x"],
+        files = ["paradise_lost.txt"],
+        expected = ["With loss of Eden, till one greater Man"]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_one_file_one_match_multiple_flags(
-    pattern = "OF ATREUS, Agamemnon, KIng of MEN.",
-    flags = ["-x", "-i", "-n"],
-    files = ["iliad.txt"],
-    expected = ["9:Of Atreus, Agamemnon, King of men."]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_one_file_one_match_multiple_flags(
+        pattern = "OF ATREUS, Agamemnon, KIng of MEN.",
+        flags = ["-x", "-i", "-n"],
+        files = ["iliad.txt"],
+        expected = ["9:Of Atreus, Agamemnon, King of men."]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_one_file_several_matches_no_flags(
-    pattern = "may",
-    flags = [],
-    files = ["midsummer_night.txt"],
-    expected = [
-        "Nor how it may concern my modesty,",
-        "But I beseech your grace that I may know",
-        "The worst that may befall me in this case,"
-    ]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_one_file_several_matches_no_flags(
+        pattern = "may",
+        flags = [],
+        files = ["midsummer_night.txt"],
+        expected = [
+            "Nor how it may concern my modesty,",
+            "But I beseech your grace that I may know",
+            "The worst that may befall me in this case,"
+        ]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_one_file_several_matches_print_line_numbers_flag(
-    pattern = "may",
-    flags = ["-n"],
-    files = ["midsummer_night.txt"],
-    expected = [
-        "3:Nor how it may concern my modesty,",
-        "5:But I beseech your grace that I may know",
-        "6:The worst that may befall me in this case,"
-    ]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_one_file_several_matches_print_line_numbers_flag(
+        pattern = "may",
+        flags = ["-n"],
+        files = ["midsummer_night.txt"],
+        expected = [
+            "3:Nor how it may concern my modesty,",
+            "5:But I beseech your grace that I may know",
+            "6:The worst that may befall me in this case,"
+        ]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_one_file_several_matches_match_entire_lines_flag(
-    pattern = "may",
-    flags = ["-x"],
-    files = ["midsummer_night.txt"],
-    expected = []
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_one_file_several_matches_match_entire_lines_flag(
+        pattern = "may",
+        flags = ["-x"],
+        files = ["midsummer_night.txt"],
+        expected = []
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_one_file_several_matches_caseinsensitive_flag(
-    pattern = "ACHILLES",
-    flags = ["-i"],
-    files = ["iliad.txt"],
-    expected = [
-        "Achilles sing, O Goddess! Peleus' son;",
-        "The noble Chief Achilles from the son"
-    ]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_one_file_several_matches_caseinsensitive_flag(
+        pattern = "ACHILLES",
+        flags = ["-i"],
+        files = ["iliad.txt"],
+        expected = [
+            "Achilles sing, O Goddess! Peleus' son;",
+            "The noble Chief Achilles from the son"
+        ]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_one_file_several_matches_inverted_flag(
-    pattern = "Of",
-    flags = ["-v"],
-    files = ["paradise_lost.txt"],
-    expected = [
-        "Brought Death into the World, and all our woe,",
-        "With loss of Eden, till one greater Man",
-        "Restore us, and regain the blissful Seat,",
-        "Sing Heav'nly Muse, that on the secret top",
-        "That Shepherd, who first taught the chosen Seed"
-    ]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_one_file_several_matches_inverted_flag(
+        pattern = "Of",
+        flags = ["-v"],
+        files = ["paradise_lost.txt"],
+        expected = [
+            "Brought Death into the World, and all our woe,",
+            "With loss of Eden, till one greater Man",
+            "Restore us, and regain the blissful Seat,",
+            "Sing Heav'nly Muse, that on the secret top",
+            "That Shepherd, who first taught the chosen Seed"
+        ]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_one_file_no_matches_various_flags(
-    pattern = "Gandalf",
-    flags = ["-n", "-l", "-x", "-i"],
-    files = ["iliad.txt"],
-    expected = []
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_one_file_no_matches_various_flags(
+        pattern = "Gandalf",
+        flags = ["-n", "-l", "-x", "-i"],
+        files = ["iliad.txt"],
+        expected = []
+    )
+);
 
 set_up_test_case!(
     #[test]
@@ -348,70 +372,80 @@ set_up_test_case!(
 
 // Test grepping multiples files at once
 
-set_up_test_case!(#[test]
-#[ignore]
-test_multiple_files_one_match_no_flags(
-    pattern = "Agamemnon",
-    flags = [],
-    files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
-    prefix_expected = ["iliad.txt:Of Atreus, Agamemnon, King of men."]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_multiple_files_one_match_no_flags(
+        pattern = "Agamemnon",
+        flags = [],
+        files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
+        prefix_expected = ["iliad.txt:Of Atreus, Agamemnon, King of men."]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_multiple_files_several_matches_no_flags(
-    pattern = "may",
-    flags = [],
-    files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
-    prefix_expected = [
-        "midsummer_night.txt:Nor how it may concern my modesty,",
-        "midsummer_night.txt:But I beseech your grace that I may know",
-        "midsummer_night.txt:The worst that may befall me in this case,"
-    ]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_multiple_files_several_matches_no_flags(
+        pattern = "may",
+        flags = [],
+        files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
+        prefix_expected = [
+            "midsummer_night.txt:Nor how it may concern my modesty,",
+            "midsummer_night.txt:But I beseech your grace that I may know",
+            "midsummer_night.txt:The worst that may befall me in this case,"
+        ]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_multiple_files_several_matches_print_line_numbers_flag(
-    pattern = "that",
-    flags = ["-n"],
-    files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
-    prefix_expected = [
-        "midsummer_night.txt:5:But I beseech your grace that I may know",
-        "midsummer_night.txt:6:The worst that may befall me in this case,",
-        "paradise_lost.txt:2:Of that Forbidden Tree, whose mortal tast",
-        "paradise_lost.txt:6:Sing Heav'nly Muse, that on the secret top"
-    ]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_multiple_files_several_matches_print_line_numbers_flag(
+        pattern = "that",
+        flags = ["-n"],
+        files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
+        prefix_expected = [
+            "midsummer_night.txt:5:But I beseech your grace that I may know",
+            "midsummer_night.txt:6:The worst that may befall me in this case,",
+            "paradise_lost.txt:2:Of that Forbidden Tree, whose mortal tast",
+            "paradise_lost.txt:6:Sing Heav'nly Muse, that on the secret top"
+        ]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_multiple_files_one_match_print_file_names_flag(
-    pattern = "who",
-    flags = ["-l"],
-    files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
-    prefix_expected = ["iliad.txt", "paradise_lost.txt"]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_multiple_files_one_match_print_file_names_flag(
+        pattern = "who",
+        flags = ["-l"],
+        files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
+        prefix_expected = ["iliad.txt", "paradise_lost.txt"]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_multiple_files_several_matches_caseinsensitive_flag(
-    pattern = "TO",
-    flags = ["-i"],
-    files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
-    prefix_expected = [
-        "iliad.txt:Caused to Achaia's host, sent many a soul",
-        "iliad.txt:Illustrious into Ades premature,",
-        "iliad.txt:And Heroes gave (so stood the will of Jove)",
-        "iliad.txt:To dogs and to all ravening fowls a prey,",
-        "midsummer_night.txt:I do entreat your grace to pardon me.",
-        "midsummer_night.txt:In such a presence here to plead my thoughts;",
-        "midsummer_night.txt:If I refuse to wed Demetrius.",
-        "paradise_lost.txt:Brought Death into the World, and all our woe,",
-        "paradise_lost.txt:Restore us, and regain the blissful Seat,",
-        "paradise_lost.txt:Sing Heav'nly Muse, that on the secret top"
-    ]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_multiple_files_several_matches_caseinsensitive_flag(
+        pattern = "TO",
+        flags = ["-i"],
+        files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
+        prefix_expected = [
+            "iliad.txt:Caused to Achaia's host, sent many a soul",
+            "iliad.txt:Illustrious into Ades premature,",
+            "iliad.txt:And Heroes gave (so stood the will of Jove)",
+            "iliad.txt:To dogs and to all ravening fowls a prey,",
+            "midsummer_night.txt:I do entreat your grace to pardon me.",
+            "midsummer_night.txt:In such a presence here to plead my thoughts;",
+            "midsummer_night.txt:If I refuse to wed Demetrius.",
+            "paradise_lost.txt:Brought Death into the World, and all our woe,",
+            "paradise_lost.txt:Restore us, and regain the blissful Seat,",
+            "paradise_lost.txt:Sing Heav'nly Muse, that on the secret top"
+        ]
+    )
+);
 
 set_up_test_case!(
     #[test]
@@ -429,45 +463,53 @@ set_up_test_case!(
     )
 );
 
-set_up_test_case!(#[test]
-#[ignore]
-test_multiple_files_several_matches_inverted_flag(
-    pattern = "a",
-    flags = ["-v"],
-    files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
-    prefix_expected = [
-        "iliad.txt:Achilles sing, O Goddess! Peleus' son;",
-        "iliad.txt:The noble Chief Achilles from the son",
-        "midsummer_night.txt:If I refuse to wed Demetrius."
-    ]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_multiple_files_several_matches_inverted_flag(
+        pattern = "a",
+        flags = ["-v"],
+        files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
+        prefix_expected = [
+            "iliad.txt:Achilles sing, O Goddess! Peleus' son;",
+            "iliad.txt:The noble Chief Achilles from the son",
+            "midsummer_night.txt:If I refuse to wed Demetrius."
+        ]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_multiple_files_one_match_match_entire_lines_flag(
-    pattern = "But I beseech your grace that I may know",
-    flags = ["-x"],
-    files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
-    prefix_expected = ["midsummer_night.txt:But I beseech your grace that I may know"]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_multiple_files_one_match_match_entire_lines_flag(
+        pattern = "But I beseech your grace that I may know",
+        flags = ["-x"],
+        files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
+        prefix_expected = ["midsummer_night.txt:But I beseech your grace that I may know"]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_multiple_files_one_match_multiple_flags(
-    pattern = "WITH LOSS OF EDEN, TILL ONE GREATER MAN",
-    flags = ["-n", "-i", "-x"],
-    files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
-    prefix_expected = ["paradise_lost.txt:4:With loss of Eden, till one greater Man"]
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_multiple_files_one_match_multiple_flags(
+        pattern = "WITH LOSS OF EDEN, TILL ONE GREATER MAN",
+        flags = ["-n", "-i", "-x"],
+        files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
+        prefix_expected = ["paradise_lost.txt:4:With loss of Eden, till one greater Man"]
+    )
+);
 
-set_up_test_case!(#[test]
-#[ignore]
-test_multiple_files_no_matches_various_flags(
-    pattern = "Frodo",
-    flags = ["-n", "-i", "-x", "-l"],
-    files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
-    expected = []
-));
+set_up_test_case!(
+    #[test]
+    #[ignore]
+    test_multiple_files_no_matches_various_flags(
+        pattern = "Frodo",
+        flags = ["-n", "-i", "-x", "-l"],
+        files = ["iliad.txt", "midsummer_night.txt", "paradise_lost.txt"],
+        expected = []
+    )
+);
 
 set_up_test_case!(
     #[test]


### PR DESCRIPTION
The `failure` crate is getting old, and has largely been superseded
in the ecosystem by the `anyhow` crate, which better uses the standard
library (and which only became possible with Rust v1.34). We should
demonstrate more modern techniques to students.

See:

- bytecodealliance/wasmtime#436
- https://blog.yoshuawuyts.com/error-handling-survey/
- https://internals.rust-lang.org/t/failure-crate-maintenance/12087