### PR TITLE
rna-transcription: avoid using assert!(something().is_err())

### DIFF
--- a/exercises/rna-transcription/tests/rna-transcription.rs
+++ b/exercises/rna-transcription/tests/rna-transcription.rs
@@ -26,11 +26,11 @@ fn test_invalid_dna_input() {
 #[ignore]
 fn test_invalid_rna_input() {
     // Invalid character
-    assert!(dna::RNA::new("X").is_err());
+    assert_eq!(dna::RNA::new("X").unwrap_err(), 0);
     // Valid nucleotide, but invalid in context
-    assert!(dna::RNA::new("T").is_err());
+    assert_eq!(dna::RNA::new("T").unwrap_err(), 0);
     // Longer string with contained errors
-    assert!(dna::RNA::new("ACGUTTXCUUAA").is_err());
+    assert_eq!(dna::RNA::new("ACGUTTXCUUAA").unwrap_err(), 4);
 }
 
 #[test]


### PR DESCRIPTION
`assert!(something().is_err())` is an antipattern in testing because
it hides the particular error, and most of the time that is undesired.
It's better to expect a particular error result. This demonstrates
better error-handling techniques for students.