### PR TITLE
Grep: replacing deprecated 'failure' with 'thiserror'

### DIFF
--- a/exercises/grep/.meta/hints.md
+++ b/exercises/grep/.meta/hints.md
@@ -1,7 +1,7 @@
 ### Error handling
-This exercise introduces the usage of `failure` crate,
-that gives you the means to manage your custom error types.
-To learn more about the crate refer to the [failure documentation](https://boats.gitlab.io/failure/intro.html)
+This exercise introduces the usage of the `thiserror` crate,
+which gives you the means to manage your custom error types.
+To learn more about the crate refer to the [thiserror documentation](https://docs.rs/thiserror)
 
 ### Additional reading
 

--- a/exercises/grep/Cargo.toml
+++ b/exercises/grep/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-failure = "0.1.1"
+thiserror = "1.0"
 
 [package]
 edition = "2018"

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -65,9 +65,9 @@ For example, running `grep -l -v "hello" file1.txt file2.txt` should
 print the names of files that do not contain the string "hello".
 
 ### Error handling
-This exercise introduces the usage of `failure` crate,
-that gives you the means to manage your custom error types.
-To learn more about the crate refer to the [failure documentation](https://boats.gitlab.io/failure/intro.html)
+This exercise introduces the usage of the `thiserror` crate,
+which gives you the means to manage your custom error types.
+To learn more about the crate refer to the [thiserror documentation](https://docs.rs/thiserror)
 
 ### Additional reading
 

--- a/exercises/grep/example.rs
+++ b/exercises/grep/example.rs
@@ -1,16 +1,11 @@
-#[macro_use]
-extern crate failure;
-
-use failure::Error;
 use std::{fs, path::Path};
 
-#[derive(Debug, Fail)]
-enum FileAccessError {
-    #[fail(display = "File not found: {}", file_name)]
-    FileNotFoundError { file_name: String },
-
-    #[fail(display = "Error reading file: {}", file_name)]
-    FileReadError { file_name: String },
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub enum FileAccessError {
+    #[error("File not found: {file_name}")]
+    FileNotFoundError{file_name: String},
+    #[error("Error reading file: {file_name}")]
+    FileReadError{file_name: String},
 }
 
 pub struct Flags {
@@ -38,7 +33,7 @@ fn get_file_lines(file_name: &str) -> Result<Vec<String>, FileAccessError> {
 
     if !file_path.exists() {
         return Err(FileAccessError::FileNotFoundError {
-            file_name: String::from(file_name),
+            file_name: String::from(file_name)
         });
     }
 
@@ -51,7 +46,7 @@ fn get_file_lines(file_name: &str) -> Result<Vec<String>, FileAccessError> {
     }
 }
 
-pub fn grep(pattern: &str, flags: &Flags, files: &[&str]) -> Result<Vec<String>, Error> {
+pub fn grep(pattern: &str, flags: &Flags, files: &[&str]) -> Result<Vec<String>, FileAccessError> {
     let mut grep_result = vec![];
 
     let is_multiple_file_search = files.len() > 1;

--- a/exercises/grep/src/lib.rs
+++ b/exercises/grep/src/lib.rs
@@ -1,5 +1,3 @@
-use failure::Error;
-
 /// While using raw slice of str to handle flags is convenient,
 /// in the real-world projects it is customary to use a struct,
 /// that contains flags-related logic. So in this exercise
@@ -19,7 +17,15 @@ impl Flags {
     }
 }
 
-pub fn grep(pattern: &str, flags: &Flags, files: &[&str]) -> Result<Vec<String>, Error> {
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub enum FileAccessError {
+    #[error("File not found: {file_name}")]
+    FileNotFoundError{file_name: String},
+    #[error("Error reading file: {file_name}")]
+    FileReadError{file_name: String},
+}
+
+pub fn grep(pattern: &str, flags: &Flags, files: &[&str]) -> Result<Vec<String>, FileAccessError> {
     unimplemented!(
         "Search the files '{:?}' for '{}' pattern and save the matches in a vector. Your search logic should be aware of the given flags '{:?}'",
         files,

--- a/exercises/grep/tests/grep.rs
+++ b/exercises/grep/tests/grep.rs
@@ -1,4 +1,4 @@
-use grep::{grep, Flags};
+use grep::{FileAccessError, Flags, grep};
 
 use std::fs;
 
@@ -167,9 +167,10 @@ fn test_nonexistent_file_returns_error() {
 
     let flags = Flags::new(&[]);
 
-    let files = vec!["test_nonexistent_file_returns_error_iliad.txt"];
+    let file_name = "test_nonexistent_file_returns_error_iliad.txt";
+    let files = vec![file_name];
 
-    assert!(grep(&pattern, &flags, &files).is_err());
+    assert_eq!(grep(&pattern, &flags, &files).unwrap_err(), FileAccessError::FileNotFoundError{file_name: String::from(file_name)});
 }
 
 #[test]


### PR DESCRIPTION
As failure [is deprecated](https://github.com/rust-lang-nursery/failure/commit/135e2a3b9af422d9a9dc37ce7c69354c9b36e94b#diff-04c6e90faac2675aa89e2176d2eec7d8), I suggest to switch to [thiserror](https://github.com/dtolnay/thiserror). Also changing the test so it checks the error type.