### PR TITLE
book-store: don't use std::mem::replace unnecessarily

### DIFF
--- a/exercises/book-store/example.rs
+++ b/exercises/book-store/example.rs
@@ -132,7 +132,7 @@ impl Iterator for DecomposeGroups {
                             let hypothetical_hash = hash_of(&hypothetical);
                             if !self.prev_states.contains(&hypothetical_hash) {
                                 self.prev_states.insert(hypothetical_hash);
-                                mem::replace(&mut self.next, Some(hypothetical));
+                                self.next = Some(hypothetical);
                                 return return_value;
                             }
                         }
@@ -151,7 +151,7 @@ impl Iterator for DecomposeGroups {
                 hypothetical.push(Group::new_containing(book));
                 hypothetical.sort();
                 self.prev_states.insert(hash_of(&hypothetical));
-                mem::replace(&mut self.next, Some(hypothetical));
+                self.next = Some(hypothetical);
             }
         }
         return_value


### PR DESCRIPTION
At some point, std::mem::replace gained the `#[must_use]` attribute:
if you don't use the previous value, there's no reason not to just
assign to the target directly. This caused a warning to be emitted,
which broke our check that no examples generate warnings.

This PR fixes that.

FWIW, I'm apparently to blame for the original use of mem::replace;
at this remove, I have no idea what I was thinking then.