### PR TITLE
Bringing your track in line with the latest changes to Problem Specifications

### DIFF
--- a/exercises/acronym/.meta/tests.toml
+++ b/exercises/acronym/.meta/tests.toml
@@ -1,0 +1,28 @@
+[canonical-tests]
+
+# basic
+"1e22cceb-c5e4-4562-9afe-aef07ad1eaf4" = true
+
+# lowercase words
+"79ae3889-a5c0-4b01-baf0-232d31180c08" = true
+
+# punctuation
+"ec7000a7-3931-4a17-890e-33ca2073a548" = true
+
+# all caps word
+"32dd261c-0c92-469a-9c5c-b192e94a63b0" = true
+
+# punctuation without whitespace
+"ae2ac9fa-a606-4d05-8244-3bcc4659c1d4" = true
+
+# very long abbreviation
+"0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9" = true
+
+# consecutive delimiters
+"6a078f49-c68d-4b7b-89af-33a1a98c28cc" = true
+
+# apostrophes
+"5118b4b1-4572-434c-8d57-5b762e57973e" = true
+
+# underscore emphasis
+"adc12eab-ec2d-414f-b48c-66a4fc06cdef" = true

--- a/exercises/affine-cipher/.meta/tests.toml
+++ b/exercises/affine-cipher/.meta/tests.toml
@@ -1,0 +1,49 @@
+[canonical-tests]
+
+# encode yes
+"2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a" = true
+
+# encode no
+"785bade9-e98b-4d4f-a5b0-087ba3d7de4b" = true
+
+# encode OMG
+"2854851c-48fb-40d8-9bf6-8f192ed25054" = true
+
+# encode O M G
+"bc0c1244-b544-49dd-9777-13a770be1bad" = true
+
+# encode mindblowingly
+"381a1a20-b74a-46ce-9277-3778625c9e27" = true
+
+# encode numbers
+"6686f4e2-753b-47d4-9715-876fdc59029d" = true
+
+# encode deep thought
+"ae23d5bd-30a8-44b6-afbe-23c8c0c7faa3" = true
+
+# encode all the letters
+"c93a8a4d-426c-42ef-9610-76ded6f7ef57" = true
+
+# encode with a not coprime to m
+"0673638a-4375-40bd-871c-fb6a2c28effb" = true
+
+# decode exercism
+"3f0ac7e2-ec0e-4a79-949e-95e414953438" = true
+
+# decode a sentence
+"241ee64d-5a47-4092-a5d7-7939d259e077" = true
+
+# decode numbers
+"33fb16a1-765a-496f-907f-12e644837f5e" = true
+
+# decode all the letters
+"20bc9dce-c5ec-4db6-a3f1-845c776bcbf7" = true
+
+# decode with no spaces in input
+"623e78c0-922d-49c5-8702-227a3e8eaf81" = true
+
+# decode with too many spaces
+"58fd5c2a-1fd9-4563-a80a-71cff200f26f" = true
+
+# decode with a not coprime to m
+"b004626f-c186-4af9-a3f4-58f74cdb86d5" = true

--- a/exercises/affine-cipher/.meta/tests.toml
+++ b/exercises/affine-cipher/.meta/tests.toml
@@ -1,49 +1,49 @@
 [canonical-tests]
 
 # encode yes
-"2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a" = true
+2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a = true
 
 # encode no
-"785bade9-e98b-4d4f-a5b0-087ba3d7de4b" = true
+785bade9-e98b-4d4f-a5b0-087ba3d7de4b = true
 
 # encode OMG
-"2854851c-48fb-40d8-9bf6-8f192ed25054" = true
+2854851c-48fb-40d8-9bf6-8f192ed25054 = true
 
 # encode O M G
-"bc0c1244-b544-49dd-9777-13a770be1bad" = true
+bc0c1244-b544-49dd-9777-13a770be1bad = true
 
 # encode mindblowingly
-"381a1a20-b74a-46ce-9277-3778625c9e27" = true
+381a1a20-b74a-46ce-9277-3778625c9e27 = true
 
 # encode numbers
-"6686f4e2-753b-47d4-9715-876fdc59029d" = true
+6686f4e2-753b-47d4-9715-876fdc59029d = true
 
 # encode deep thought
-"ae23d5bd-30a8-44b6-afbe-23c8c0c7faa3" = true
+ae23d5bd-30a8-44b6-afbe-23c8c0c7faa3 = true
 
 # encode all the letters
-"c93a8a4d-426c-42ef-9610-76ded6f7ef57" = true
+c93a8a4d-426c-42ef-9610-76ded6f7ef57 = true
 
 # encode with a not coprime to m
-"0673638a-4375-40bd-871c-fb6a2c28effb" = true
+0673638a-4375-40bd-871c-fb6a2c28effb = true
 
 # decode exercism
-"3f0ac7e2-ec0e-4a79-949e-95e414953438" = true
+3f0ac7e2-ec0e-4a79-949e-95e414953438 = true
 
 # decode a sentence
-"241ee64d-5a47-4092-a5d7-7939d259e077" = true
+241ee64d-5a47-4092-a5d7-7939d259e077 = true
 
 # decode numbers
-"33fb16a1-765a-496f-907f-12e644837f5e" = true
+33fb16a1-765a-496f-907f-12e644837f5e = true
 
 # decode all the letters
-"20bc9dce-c5ec-4db6-a3f1-845c776bcbf7" = true
+20bc9dce-c5ec-4db6-a3f1-845c776bcbf7 = true
 
 # decode with no spaces in input
-"623e78c0-922d-49c5-8702-227a3e8eaf81" = true
+623e78c0-922d-49c5-8702-227a3e8eaf81 = true
 
 # decode with too many spaces
-"58fd5c2a-1fd9-4563-a80a-71cff200f26f" = true
+58fd5c2a-1fd9-4563-a80a-71cff200f26f = true
 
 # decode with a not coprime to m
-"b004626f-c186-4af9-a3f4-58f74cdb86d5" = true
+b004626f-c186-4af9-a3f4-58f74cdb86d5 = true

--- a/exercises/affine-cipher/.meta/tests.toml
+++ b/exercises/affine-cipher/.meta/tests.toml
@@ -1,49 +1,49 @@
 [canonical-tests]
 
 # encode yes
-2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a = true
+"2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a" = true
 
 # encode no
-785bade9-e98b-4d4f-a5b0-087ba3d7de4b = true
+"785bade9-e98b-4d4f-a5b0-087ba3d7de4b" = true
 
 # encode OMG
-2854851c-48fb-40d8-9bf6-8f192ed25054 = true
+"2854851c-48fb-40d8-9bf6-8f192ed25054" = true
 
 # encode O M G
-bc0c1244-b544-49dd-9777-13a770be1bad = true
+"bc0c1244-b544-49dd-9777-13a770be1bad" = true
 
 # encode mindblowingly
-381a1a20-b74a-46ce-9277-3778625c9e27 = true
+"381a1a20-b74a-46ce-9277-3778625c9e27" = true
 
 # encode numbers
-6686f4e2-753b-47d4-9715-876fdc59029d = true
+"6686f4e2-753b-47d4-9715-876fdc59029d" = true
 
 # encode deep thought
-ae23d5bd-30a8-44b6-afbe-23c8c0c7faa3 = true
+"ae23d5bd-30a8-44b6-afbe-23c8c0c7faa3" = true
 
 # encode all the letters
-c93a8a4d-426c-42ef-9610-76ded6f7ef57 = true
+"c93a8a4d-426c-42ef-9610-76ded6f7ef57" = true
 
 # encode with a not coprime to m
-0673638a-4375-40bd-871c-fb6a2c28effb = true
+"0673638a-4375-40bd-871c-fb6a2c28effb" = true
 
 # decode exercism
-3f0ac7e2-ec0e-4a79-949e-95e414953438 = true
+"3f0ac7e2-ec0e-4a79-949e-95e414953438" = true
 
 # decode a sentence
-241ee64d-5a47-4092-a5d7-7939d259e077 = true
+"241ee64d-5a47-4092-a5d7-7939d259e077" = true
 
 # decode numbers
-33fb16a1-765a-496f-907f-12e644837f5e = true
+"33fb16a1-765a-496f-907f-12e644837f5e" = true
 
 # decode all the letters
-20bc9dce-c5ec-4db6-a3f1-845c776bcbf7 = true
+"20bc9dce-c5ec-4db6-a3f1-845c776bcbf7" = true
 
 # decode with no spaces in input
-623e78c0-922d-49c5-8702-227a3e8eaf81 = true
+"623e78c0-922d-49c5-8702-227a3e8eaf81" = true
 
 # decode with too many spaces
-58fd5c2a-1fd9-4563-a80a-71cff200f26f = true
+"58fd5c2a-1fd9-4563-a80a-71cff200f26f" = true
 
 # decode with a not coprime to m
-b004626f-c186-4af9-a3f4-58f74cdb86d5 = true
+"b004626f-c186-4af9-a3f4-58f74cdb86d5" = true

--- a/exercises/all-your-base/.meta/tests.toml
+++ b/exercises/all-your-base/.meta/tests.toml
@@ -1,0 +1,64 @@
+[canonical-tests]
+
+# single bit one to decimal
+"5ce422f9-7a4b-4f44-ad29-49c67cb32d2c" = true
+
+# binary to single decimal
+"0cc3fea8-bb79-46ac-a2ab-5a2c93051033" = true
+
+# single decimal to binary
+"f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8" = true
+
+# binary to multiple decimal
+"2c45cf54-6da3-4748-9733-5a3c765d925b" = true
+
+# decimal to binary
+"65ddb8b4-8899-4fcc-8618-181b2cf0002d" = true
+
+# trinary to hexadecimal
+"8d418419-02a7-4824-8b7a-352d33c6987e" = true
+
+# hexadecimal to trinary
+"d3901c80-8190-41b9-bd86-38d988efa956" = true
+
+# 15-bit integer
+"5d42f85e-21ad-41bd-b9be-a3e8e4258bbf" = true
+
+# empty list
+"d68788f7-66dd-43f8-a543-f15b6d233f83" = true
+
+# single zero
+"5e27e8da-5862-4c5f-b2a9-26c0382b6be7" = true
+
+# multiple zeros
+"2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2" = true
+
+# leading zeros
+"3530cd9f-8d6d-43f5-bc6e-b30b1db9629b" = true
+
+# input base is one
+"a6b476a1-1901-4f2a-92c4-4d91917ae023" = true
+
+# input base is zero
+"e21a693a-7a69-450b-b393-27415c26a016" = true
+
+# input base is negative
+"54a23be5-d99e-41cc-88e0-a650ffe5fcc2" = true
+
+# negative digit
+"9eccf60c-dcc9-407b-95d8-c37b8be56bb6" = true
+
+# invalid positive digit
+"232fa4a5-e761-4939-ba0c-ed046cd0676a" = true
+
+# output base is one
+"14238f95-45da-41dc-95ce-18f860b30ad3" = true
+
+# output base is zero
+"73dac367-da5c-4a37-95fe-c87fad0a4047" = true
+
+# output base is negative
+"13f81f42-ff53-4e24-89d9-37603a48ebd9" = true
+
+# both bases are negative
+"0e6c895d-8a5d-4868-a345-309d094cfe8d" = true

--- a/exercises/all-your-base/.meta/tests.toml
+++ b/exercises/all-your-base/.meta/tests.toml
@@ -1,64 +1,64 @@
 [canonical-tests]
 
 # single bit one to decimal
-5ce422f9-7a4b-4f44-ad29-49c67cb32d2c = true
+"5ce422f9-7a4b-4f44-ad29-49c67cb32d2c" = true
 
 # binary to single decimal
-0cc3fea8-bb79-46ac-a2ab-5a2c93051033 = true
+"0cc3fea8-bb79-46ac-a2ab-5a2c93051033" = true
 
 # single decimal to binary
-f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8 = true
+"f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8" = true
 
 # binary to multiple decimal
-2c45cf54-6da3-4748-9733-5a3c765d925b = true
+"2c45cf54-6da3-4748-9733-5a3c765d925b" = true
 
 # decimal to binary
-65ddb8b4-8899-4fcc-8618-181b2cf0002d = true
+"65ddb8b4-8899-4fcc-8618-181b2cf0002d" = true
 
 # trinary to hexadecimal
-8d418419-02a7-4824-8b7a-352d33c6987e = true
+"8d418419-02a7-4824-8b7a-352d33c6987e" = true
 
 # hexadecimal to trinary
-d3901c80-8190-41b9-bd86-38d988efa956 = true
+"d3901c80-8190-41b9-bd86-38d988efa956" = true
 
 # 15-bit integer
-5d42f85e-21ad-41bd-b9be-a3e8e4258bbf = false
+"5d42f85e-21ad-41bd-b9be-a3e8e4258bbf" = false
 
 # empty list
-d68788f7-66dd-43f8-a543-f15b6d233f83 = true
+"d68788f7-66dd-43f8-a543-f15b6d233f83" = true
 
 # single zero
-5e27e8da-5862-4c5f-b2a9-26c0382b6be7 = true
+"5e27e8da-5862-4c5f-b2a9-26c0382b6be7" = true
 
 # multiple zeros
-2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2 = true
+"2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2" = true
 
 # leading zeros
-3530cd9f-8d6d-43f5-bc6e-b30b1db9629b = true
+"3530cd9f-8d6d-43f5-bc6e-b30b1db9629b" = true
 
 # input base is one
-a6b476a1-1901-4f2a-92c4-4d91917ae023 = true
+"a6b476a1-1901-4f2a-92c4-4d91917ae023" = true
 
 # input base is zero
-e21a693a-7a69-450b-b393-27415c26a016 = true
+"e21a693a-7a69-450b-b393-27415c26a016" = true
 
 # input base is negative
-54a23be5-d99e-41cc-88e0-a650ffe5fcc2 = false
+"54a23be5-d99e-41cc-88e0-a650ffe5fcc2" = false
 
 # negative digit
-9eccf60c-dcc9-407b-95d8-c37b8be56bb6 = false
+"9eccf60c-dcc9-407b-95d8-c37b8be56bb6" = false
 
 # invalid positive digit
-232fa4a5-e761-4939-ba0c-ed046cd0676a = true
+"232fa4a5-e761-4939-ba0c-ed046cd0676a" = true
 
 # output base is one
-14238f95-45da-41dc-95ce-18f860b30ad3 = true
+"14238f95-45da-41dc-95ce-18f860b30ad3" = true
 
 # output base is zero
-73dac367-da5c-4a37-95fe-c87fad0a4047 = true
+"73dac367-da5c-4a37-95fe-c87fad0a4047" = true
 
 # output base is negative
-13f81f42-ff53-4e24-89d9-37603a48ebd9 = false
+"13f81f42-ff53-4e24-89d9-37603a48ebd9" = false
 
 # both bases are negative
-0e6c895d-8a5d-4868-a345-309d094cfe8d = false
+"0e6c895d-8a5d-4868-a345-309d094cfe8d" = false

--- a/exercises/all-your-base/.meta/tests.toml
+++ b/exercises/all-your-base/.meta/tests.toml
@@ -1,64 +1,64 @@
 [canonical-tests]
 
 # single bit one to decimal
-"5ce422f9-7a4b-4f44-ad29-49c67cb32d2c" = true
+5ce422f9-7a4b-4f44-ad29-49c67cb32d2c = true
 
 # binary to single decimal
-"0cc3fea8-bb79-46ac-a2ab-5a2c93051033" = true
+0cc3fea8-bb79-46ac-a2ab-5a2c93051033 = true
 
 # single decimal to binary
-"f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8" = true
+f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8 = true
 
 # binary to multiple decimal
-"2c45cf54-6da3-4748-9733-5a3c765d925b" = true
+2c45cf54-6da3-4748-9733-5a3c765d925b = true
 
 # decimal to binary
-"65ddb8b4-8899-4fcc-8618-181b2cf0002d" = true
+65ddb8b4-8899-4fcc-8618-181b2cf0002d = true
 
 # trinary to hexadecimal
-"8d418419-02a7-4824-8b7a-352d33c6987e" = true
+8d418419-02a7-4824-8b7a-352d33c6987e = true
 
 # hexadecimal to trinary
-"d3901c80-8190-41b9-bd86-38d988efa956" = true
+d3901c80-8190-41b9-bd86-38d988efa956 = true
 
 # 15-bit integer
-"5d42f85e-21ad-41bd-b9be-a3e8e4258bbf" = true
+5d42f85e-21ad-41bd-b9be-a3e8e4258bbf = false
 
 # empty list
-"d68788f7-66dd-43f8-a543-f15b6d233f83" = true
+d68788f7-66dd-43f8-a543-f15b6d233f83 = true
 
 # single zero
-"5e27e8da-5862-4c5f-b2a9-26c0382b6be7" = true
+5e27e8da-5862-4c5f-b2a9-26c0382b6be7 = true
 
 # multiple zeros
-"2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2" = true
+2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2 = true
 
 # leading zeros
-"3530cd9f-8d6d-43f5-bc6e-b30b1db9629b" = true
+3530cd9f-8d6d-43f5-bc6e-b30b1db9629b = true
 
 # input base is one
-"a6b476a1-1901-4f2a-92c4-4d91917ae023" = true
+a6b476a1-1901-4f2a-92c4-4d91917ae023 = true
 
 # input base is zero
-"e21a693a-7a69-450b-b393-27415c26a016" = true
+e21a693a-7a69-450b-b393-27415c26a016 = true
 
 # input base is negative
-"54a23be5-d99e-41cc-88e0-a650ffe5fcc2" = true
+54a23be5-d99e-41cc-88e0-a650ffe5fcc2 = false
 
 # negative digit
-"9eccf60c-dcc9-407b-95d8-c37b8be56bb6" = true
+9eccf60c-dcc9-407b-95d8-c37b8be56bb6 = false
 
 # invalid positive digit
-"232fa4a5-e761-4939-ba0c-ed046cd0676a" = true
+232fa4a5-e761-4939-ba0c-ed046cd0676a = true
 
 # output base is one
-"14238f95-45da-41dc-95ce-18f860b30ad3" = true
+14238f95-45da-41dc-95ce-18f860b30ad3 = true
 
 # output base is zero
-"73dac367-da5c-4a37-95fe-c87fad0a4047" = true
+73dac367-da5c-4a37-95fe-c87fad0a4047 = true
 
 # output base is negative
-"13f81f42-ff53-4e24-89d9-37603a48ebd9" = true
+13f81f42-ff53-4e24-89d9-37603a48ebd9 = false
 
 # both bases are negative
-"0e6c895d-8a5d-4868-a345-309d094cfe8d" = true
+0e6c895d-8a5d-4868-a345-309d094cfe8d = false

--- a/exercises/allergies/.meta/tests.toml
+++ b/exercises/allergies/.meta/tests.toml
@@ -1,0 +1,148 @@
+[canonical-tests]
+
+# not allergic to anything
+"17fc7296-2440-4ac4-ad7b-d07c321bc5a0" = true
+
+# allergic only to eggs
+"07ced27b-1da5-4c2e-8ae2-cb2791437546" = true
+
+# allergic to eggs and something else
+"5035b954-b6fa-4b9b-a487-dae69d8c5f96" = true
+
+# allergic to something, but not eggs
+"64a6a83a-5723-4b5b-a896-663307403310" = true
+
+# allergic to everything
+"90c8f484-456b-41c4-82ba-2d08d93231c6" = true
+
+# not allergic to anything
+"d266a59a-fccc-413b-ac53-d57cb1f0db9d" = true
+
+# allergic only to peanuts
+"ea210a98-860d-46b2-a5bf-50d8995b3f2a" = true
+
+# allergic to peanuts and something else
+"eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b" = true
+
+# allergic to something, but not peanuts
+"9152058c-ce39-4b16-9b1d-283ec6d25085" = true
+
+# allergic to everything
+"d2d71fd8-63d5-40f9-a627-fbdaf88caeab" = true
+
+# not allergic to anything
+"b948b0a1-cbf7-4b28-a244-73ff56687c80" = true
+
+# allergic only to shellfish
+"9ce9a6f3-53e9-4923-85e0-73019047c567" = true
+
+# allergic to shellfish and something else
+"b272fca5-57ba-4b00-bd0c-43a737ab2131" = true
+
+# allergic to something, but not shellfish
+"21ef8e17-c227-494e-8e78-470a1c59c3d8" = true
+
+# allergic to everything
+"cc789c19-2b5e-4c67-b146-625dc8cfa34e" = true
+
+# not allergic to anything
+"651bde0a-2a74-46c4-ab55-02a0906ca2f5" = true
+
+# allergic only to strawberries
+"b649a750-9703-4f5f-b7f7-91da2c160ece" = true
+
+# allergic to strawberries and something else
+"50f5f8f3-3bac-47e6-8dba-2d94470a4bc6" = true
+
+# allergic to something, but not strawberries
+"23dd6952-88c9-48d7-a7d5-5d0343deb18d" = true
+
+# allergic to everything
+"74afaae2-13b6-43a2-837a-286cd42e7d7e" = true
+
+# not allergic to anything
+"c49a91ef-6252-415e-907e-a9d26ef61723" = true
+
+# allergic only to tomatoes
+"b69c5131-b7d0-41ad-a32c-e1b2cc632df8" = true
+
+# allergic to tomatoes and something else
+"1ca50eb1-f042-4ccf-9050-341521b929ec" = true
+
+# allergic to something, but not tomatoes
+"e9846baa-456b-4eff-8025-034b9f77bd8e" = true
+
+# allergic to everything
+"b2414f01-f3ad-4965-8391-e65f54dad35f" = true
+
+# not allergic to anything
+"978467ab-bda4-49f7-b004-1d011ead947c" = true
+
+# allergic only to chocolate
+"59cf4e49-06ea-4139-a2c1-d7aad28f8cbc" = true
+
+# allergic to chocolate and something else
+"b0a7c07b-2db7-4f73-a180-565e07040ef1" = true
+
+# allergic to something, but not chocolate
+"f5506893-f1ae-482a-b516-7532ba5ca9d2" = true
+
+# allergic to everything
+"02debb3d-d7e2-4376-a26b-3c974b6595c6" = true
+
+# not allergic to anything
+"17f4a42b-c91e-41b8-8a76-4797886c2d96" = true
+
+# allergic only to pollen
+"7696eba7-1837-4488-882a-14b7b4e3e399" = true
+
+# allergic to pollen and something else
+"9a49aec5-fa1f-405d-889e-4dfc420db2b6" = true
+
+# allergic to something, but not pollen
+"3cb8e79f-d108-4712-b620-aa146b1954a9" = true
+
+# allergic to everything
+"1dc3fe57-7c68-4043-9d51-5457128744b2" = true
+
+# not allergic to anything
+"d3f523d6-3d50-419b-a222-d4dfd62ce314" = true
+
+# allergic only to cats
+"eba541c3-c886-42d3-baef-c048cb7fcd8f" = true
+
+# allergic to cats and something else
+"ba718376-26e0-40b7-bbbe-060287637ea5" = true
+
+# allergic to something, but not cats
+"3c6dbf4a-5277-436f-8b88-15a206f2d6c4" = true
+
+# allergic to everything
+"1faabb05-2b98-4995-9046-d83e4a48a7c1" = true
+
+# no allergies
+"f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f" = true
+
+# just eggs
+"9e1a4364-09a6-4d94-990f-541a94a4c1e8" = true
+
+# just peanuts
+"8851c973-805e-4283-9e01-d0c0da0e4695" = true
+
+# just strawberries
+"2c8943cb-005e-435f-ae11-3e8fb558ea98" = true
+
+# eggs and peanuts
+"6fa95d26-044c-48a9-8a7b-9ee46ec32c5c" = true
+
+# more than eggs but not peanuts
+"19890e22-f63f-4c5c-a9fb-fb6eacddfe8e" = true
+
+# lots of stuff
+"4b68f470-067c-44e4-889f-c9fe28917d2f" = true
+
+# everything
+"0881b7c5-9efa-4530-91bd-68370d054bc7" = true
+
+# no allergen score parts
+"12ce86de-b347-42a0-ab7c-2e0570f0c65b" = true

--- a/exercises/allergies/.meta/tests.toml
+++ b/exercises/allergies/.meta/tests.toml
@@ -1,148 +1,148 @@
 [canonical-tests]
 
 # not allergic to anything
-"17fc7296-2440-4ac4-ad7b-d07c321bc5a0" = true
+17fc7296-2440-4ac4-ad7b-d07c321bc5a0 = false
 
 # allergic only to eggs
-"07ced27b-1da5-4c2e-8ae2-cb2791437546" = true
+07ced27b-1da5-4c2e-8ae2-cb2791437546 = false
 
 # allergic to eggs and something else
-"5035b954-b6fa-4b9b-a487-dae69d8c5f96" = true
+5035b954-b6fa-4b9b-a487-dae69d8c5f96 = false
 
 # allergic to something, but not eggs
-"64a6a83a-5723-4b5b-a896-663307403310" = true
+64a6a83a-5723-4b5b-a896-663307403310 = false
 
 # allergic to everything
-"90c8f484-456b-41c4-82ba-2d08d93231c6" = true
+90c8f484-456b-41c4-82ba-2d08d93231c6 = true
 
 # not allergic to anything
-"d266a59a-fccc-413b-ac53-d57cb1f0db9d" = true
+d266a59a-fccc-413b-ac53-d57cb1f0db9d = false
 
 # allergic only to peanuts
-"ea210a98-860d-46b2-a5bf-50d8995b3f2a" = true
+ea210a98-860d-46b2-a5bf-50d8995b3f2a = false
 
 # allergic to peanuts and something else
-"eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b" = true
+eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b = false
 
 # allergic to something, but not peanuts
-"9152058c-ce39-4b16-9b1d-283ec6d25085" = true
+9152058c-ce39-4b16-9b1d-283ec6d25085 = false
 
 # allergic to everything
-"d2d71fd8-63d5-40f9-a627-fbdaf88caeab" = true
+d2d71fd8-63d5-40f9-a627-fbdaf88caeab = true
 
 # not allergic to anything
-"b948b0a1-cbf7-4b28-a244-73ff56687c80" = true
+b948b0a1-cbf7-4b28-a244-73ff56687c80 = false
 
 # allergic only to shellfish
-"9ce9a6f3-53e9-4923-85e0-73019047c567" = true
+9ce9a6f3-53e9-4923-85e0-73019047c567 = false
 
 # allergic to shellfish and something else
-"b272fca5-57ba-4b00-bd0c-43a737ab2131" = true
+b272fca5-57ba-4b00-bd0c-43a737ab2131 = false
 
 # allergic to something, but not shellfish
-"21ef8e17-c227-494e-8e78-470a1c59c3d8" = true
+21ef8e17-c227-494e-8e78-470a1c59c3d8 = false
 
 # allergic to everything
-"cc789c19-2b5e-4c67-b146-625dc8cfa34e" = true
+cc789c19-2b5e-4c67-b146-625dc8cfa34e = true
 
 # not allergic to anything
-"651bde0a-2a74-46c4-ab55-02a0906ca2f5" = true
+651bde0a-2a74-46c4-ab55-02a0906ca2f5 = false
 
 # allergic only to strawberries
-"b649a750-9703-4f5f-b7f7-91da2c160ece" = true
+b649a750-9703-4f5f-b7f7-91da2c160ece = false
 
 # allergic to strawberries and something else
-"50f5f8f3-3bac-47e6-8dba-2d94470a4bc6" = true
+50f5f8f3-3bac-47e6-8dba-2d94470a4bc6 = false
 
 # allergic to something, but not strawberries
-"23dd6952-88c9-48d7-a7d5-5d0343deb18d" = true
+23dd6952-88c9-48d7-a7d5-5d0343deb18d = false
 
 # allergic to everything
-"74afaae2-13b6-43a2-837a-286cd42e7d7e" = true
+74afaae2-13b6-43a2-837a-286cd42e7d7e = true
 
 # not allergic to anything
-"c49a91ef-6252-415e-907e-a9d26ef61723" = true
+c49a91ef-6252-415e-907e-a9d26ef61723 = false
 
 # allergic only to tomatoes
-"b69c5131-b7d0-41ad-a32c-e1b2cc632df8" = true
+b69c5131-b7d0-41ad-a32c-e1b2cc632df8 = false
 
 # allergic to tomatoes and something else
-"1ca50eb1-f042-4ccf-9050-341521b929ec" = true
+1ca50eb1-f042-4ccf-9050-341521b929ec = false
 
 # allergic to something, but not tomatoes
-"e9846baa-456b-4eff-8025-034b9f77bd8e" = true
+e9846baa-456b-4eff-8025-034b9f77bd8e = false
 
 # allergic to everything
-"b2414f01-f3ad-4965-8391-e65f54dad35f" = true
+b2414f01-f3ad-4965-8391-e65f54dad35f = true
 
 # not allergic to anything
-"978467ab-bda4-49f7-b004-1d011ead947c" = true
+978467ab-bda4-49f7-b004-1d011ead947c = false
 
 # allergic only to chocolate
-"59cf4e49-06ea-4139-a2c1-d7aad28f8cbc" = true
+59cf4e49-06ea-4139-a2c1-d7aad28f8cbc = false
 
 # allergic to chocolate and something else
-"b0a7c07b-2db7-4f73-a180-565e07040ef1" = true
+b0a7c07b-2db7-4f73-a180-565e07040ef1 = false
 
 # allergic to something, but not chocolate
-"f5506893-f1ae-482a-b516-7532ba5ca9d2" = true
+f5506893-f1ae-482a-b516-7532ba5ca9d2 = false
 
 # allergic to everything
-"02debb3d-d7e2-4376-a26b-3c974b6595c6" = true
+02debb3d-d7e2-4376-a26b-3c974b6595c6 = true
 
 # not allergic to anything
-"17f4a42b-c91e-41b8-8a76-4797886c2d96" = true
+17f4a42b-c91e-41b8-8a76-4797886c2d96 = false
 
 # allergic only to pollen
-"7696eba7-1837-4488-882a-14b7b4e3e399" = true
+7696eba7-1837-4488-882a-14b7b4e3e399 = false
 
 # allergic to pollen and something else
-"9a49aec5-fa1f-405d-889e-4dfc420db2b6" = true
+9a49aec5-fa1f-405d-889e-4dfc420db2b6 = false
 
 # allergic to something, but not pollen
-"3cb8e79f-d108-4712-b620-aa146b1954a9" = true
+3cb8e79f-d108-4712-b620-aa146b1954a9 = false
 
 # allergic to everything
-"1dc3fe57-7c68-4043-9d51-5457128744b2" = true
+1dc3fe57-7c68-4043-9d51-5457128744b2 = true
 
 # not allergic to anything
-"d3f523d6-3d50-419b-a222-d4dfd62ce314" = true
+d3f523d6-3d50-419b-a222-d4dfd62ce314 = false
 
 # allergic only to cats
-"eba541c3-c886-42d3-baef-c048cb7fcd8f" = true
+eba541c3-c886-42d3-baef-c048cb7fcd8f = false
 
 # allergic to cats and something else
-"ba718376-26e0-40b7-bbbe-060287637ea5" = true
+ba718376-26e0-40b7-bbbe-060287637ea5 = false
 
 # allergic to something, but not cats
-"3c6dbf4a-5277-436f-8b88-15a206f2d6c4" = true
+3c6dbf4a-5277-436f-8b88-15a206f2d6c4 = false
 
 # allergic to everything
-"1faabb05-2b98-4995-9046-d83e4a48a7c1" = true
+1faabb05-2b98-4995-9046-d83e4a48a7c1 = true
 
 # no allergies
-"f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f" = true
+f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f = false
 
 # just eggs
-"9e1a4364-09a6-4d94-990f-541a94a4c1e8" = true
+9e1a4364-09a6-4d94-990f-541a94a4c1e8 = false
 
 # just peanuts
-"8851c973-805e-4283-9e01-d0c0da0e4695" = true
+8851c973-805e-4283-9e01-d0c0da0e4695 = false
 
 # just strawberries
-"2c8943cb-005e-435f-ae11-3e8fb558ea98" = true
+2c8943cb-005e-435f-ae11-3e8fb558ea98 = false
 
 # eggs and peanuts
-"6fa95d26-044c-48a9-8a7b-9ee46ec32c5c" = true
+6fa95d26-044c-48a9-8a7b-9ee46ec32c5c = false
 
 # more than eggs but not peanuts
-"19890e22-f63f-4c5c-a9fb-fb6eacddfe8e" = true
+19890e22-f63f-4c5c-a9fb-fb6eacddfe8e = false
 
 # lots of stuff
-"4b68f470-067c-44e4-889f-c9fe28917d2f" = true
+4b68f470-067c-44e4-889f-c9fe28917d2f = false
 
 # everything
-"0881b7c5-9efa-4530-91bd-68370d054bc7" = true
+0881b7c5-9efa-4530-91bd-68370d054bc7 = false
 
 # no allergen score parts
-"12ce86de-b347-42a0-ab7c-2e0570f0c65b" = true
+12ce86de-b347-42a0-ab7c-2e0570f0c65b = false

--- a/exercises/allergies/.meta/tests.toml
+++ b/exercises/allergies/.meta/tests.toml
@@ -1,148 +1,148 @@
 [canonical-tests]
 
 # not allergic to anything
-17fc7296-2440-4ac4-ad7b-d07c321bc5a0 = false
+"17fc7296-2440-4ac4-ad7b-d07c321bc5a0" = false
 
 # allergic only to eggs
-07ced27b-1da5-4c2e-8ae2-cb2791437546 = false
+"07ced27b-1da5-4c2e-8ae2-cb2791437546" = false
 
 # allergic to eggs and something else
-5035b954-b6fa-4b9b-a487-dae69d8c5f96 = false
+"5035b954-b6fa-4b9b-a487-dae69d8c5f96" = false
 
 # allergic to something, but not eggs
-64a6a83a-5723-4b5b-a896-663307403310 = false
+"64a6a83a-5723-4b5b-a896-663307403310" = false
 
 # allergic to everything
-90c8f484-456b-41c4-82ba-2d08d93231c6 = true
+"90c8f484-456b-41c4-82ba-2d08d93231c6" = true
 
 # not allergic to anything
-d266a59a-fccc-413b-ac53-d57cb1f0db9d = false
+"d266a59a-fccc-413b-ac53-d57cb1f0db9d" = false
 
 # allergic only to peanuts
-ea210a98-860d-46b2-a5bf-50d8995b3f2a = false
+"ea210a98-860d-46b2-a5bf-50d8995b3f2a" = false
 
 # allergic to peanuts and something else
-eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b = false
+"eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b" = false
 
 # allergic to something, but not peanuts
-9152058c-ce39-4b16-9b1d-283ec6d25085 = false
+"9152058c-ce39-4b16-9b1d-283ec6d25085" = false
 
 # allergic to everything
-d2d71fd8-63d5-40f9-a627-fbdaf88caeab = true
+"d2d71fd8-63d5-40f9-a627-fbdaf88caeab" = true
 
 # not allergic to anything
-b948b0a1-cbf7-4b28-a244-73ff56687c80 = false
+"b948b0a1-cbf7-4b28-a244-73ff56687c80" = false
 
 # allergic only to shellfish
-9ce9a6f3-53e9-4923-85e0-73019047c567 = false
+"9ce9a6f3-53e9-4923-85e0-73019047c567" = false
 
 # allergic to shellfish and something else
-b272fca5-57ba-4b00-bd0c-43a737ab2131 = false
+"b272fca5-57ba-4b00-bd0c-43a737ab2131" = false
 
 # allergic to something, but not shellfish
-21ef8e17-c227-494e-8e78-470a1c59c3d8 = false
+"21ef8e17-c227-494e-8e78-470a1c59c3d8" = false
 
 # allergic to everything
-cc789c19-2b5e-4c67-b146-625dc8cfa34e = true
+"cc789c19-2b5e-4c67-b146-625dc8cfa34e" = true
 
 # not allergic to anything
-651bde0a-2a74-46c4-ab55-02a0906ca2f5 = false
+"651bde0a-2a74-46c4-ab55-02a0906ca2f5" = false
 
 # allergic only to strawberries
-b649a750-9703-4f5f-b7f7-91da2c160ece = false
+"b649a750-9703-4f5f-b7f7-91da2c160ece" = false
 
 # allergic to strawberries and something else
-50f5f8f3-3bac-47e6-8dba-2d94470a4bc6 = false
+"50f5f8f3-3bac-47e6-8dba-2d94470a4bc6" = false
 
 # allergic to something, but not strawberries
-23dd6952-88c9-48d7-a7d5-5d0343deb18d = false
+"23dd6952-88c9-48d7-a7d5-5d0343deb18d" = false
 
 # allergic to everything
-74afaae2-13b6-43a2-837a-286cd42e7d7e = true
+"74afaae2-13b6-43a2-837a-286cd42e7d7e" = true
 
 # not allergic to anything
-c49a91ef-6252-415e-907e-a9d26ef61723 = false
+"c49a91ef-6252-415e-907e-a9d26ef61723" = false
 
 # allergic only to tomatoes
-b69c5131-b7d0-41ad-a32c-e1b2cc632df8 = false
+"b69c5131-b7d0-41ad-a32c-e1b2cc632df8" = false
 
 # allergic to tomatoes and something else
-1ca50eb1-f042-4ccf-9050-341521b929ec = false
+"1ca50eb1-f042-4ccf-9050-341521b929ec" = false
 
 # allergic to something, but not tomatoes
-e9846baa-456b-4eff-8025-034b9f77bd8e = false
+"e9846baa-456b-4eff-8025-034b9f77bd8e" = false
 
 # allergic to everything
-b2414f01-f3ad-4965-8391-e65f54dad35f = true
+"b2414f01-f3ad-4965-8391-e65f54dad35f" = true
 
 # not allergic to anything
-978467ab-bda4-49f7-b004-1d011ead947c = false
+"978467ab-bda4-49f7-b004-1d011ead947c" = false
 
 # allergic only to chocolate
-59cf4e49-06ea-4139-a2c1-d7aad28f8cbc = false
+"59cf4e49-06ea-4139-a2c1-d7aad28f8cbc" = false
 
 # allergic to chocolate and something else
-b0a7c07b-2db7-4f73-a180-565e07040ef1 = false
+"b0a7c07b-2db7-4f73-a180-565e07040ef1" = false
 
 # allergic to something, but not chocolate
-f5506893-f1ae-482a-b516-7532ba5ca9d2 = false
+"f5506893-f1ae-482a-b516-7532ba5ca9d2" = false
 
 # allergic to everything
-02debb3d-d7e2-4376-a26b-3c974b6595c6 = true
+"02debb3d-d7e2-4376-a26b-3c974b6595c6" = true
 
 # not allergic to anything
-17f4a42b-c91e-41b8-8a76-4797886c2d96 = false
+"17f4a42b-c91e-41b8-8a76-4797886c2d96" = false
 
 # allergic only to pollen
-7696eba7-1837-4488-882a-14b7b4e3e399 = false
+"7696eba7-1837-4488-882a-14b7b4e3e399" = false
 
 # allergic to pollen and something else
-9a49aec5-fa1f-405d-889e-4dfc420db2b6 = false
+"9a49aec5-fa1f-405d-889e-4dfc420db2b6" = false
 
 # allergic to something, but not pollen
-3cb8e79f-d108-4712-b620-aa146b1954a9 = false
+"3cb8e79f-d108-4712-b620-aa146b1954a9" = false
 
 # allergic to everything
-1dc3fe57-7c68-4043-9d51-5457128744b2 = true
+"1dc3fe57-7c68-4043-9d51-5457128744b2" = true
 
 # not allergic to anything
-d3f523d6-3d50-419b-a222-d4dfd62ce314 = false
+"d3f523d6-3d50-419b-a222-d4dfd62ce314" = false
 
 # allergic only to cats
-eba541c3-c886-42d3-baef-c048cb7fcd8f = false
+"eba541c3-c886-42d3-baef-c048cb7fcd8f" = false
 
 # allergic to cats and something else
-ba718376-26e0-40b7-bbbe-060287637ea5 = false
+"ba718376-26e0-40b7-bbbe-060287637ea5" = false
 
 # allergic to something, but not cats
-3c6dbf4a-5277-436f-8b88-15a206f2d6c4 = false
+"3c6dbf4a-5277-436f-8b88-15a206f2d6c4" = false
 
 # allergic to everything
-1faabb05-2b98-4995-9046-d83e4a48a7c1 = true
+"1faabb05-2b98-4995-9046-d83e4a48a7c1" = true
 
 # no allergies
-f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f = false
+"f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f" = false
 
 # just eggs
-9e1a4364-09a6-4d94-990f-541a94a4c1e8 = false
+"9e1a4364-09a6-4d94-990f-541a94a4c1e8" = false
 
 # just peanuts
-8851c973-805e-4283-9e01-d0c0da0e4695 = false
+"8851c973-805e-4283-9e01-d0c0da0e4695" = false
 
 # just strawberries
-2c8943cb-005e-435f-ae11-3e8fb558ea98 = false
+"2c8943cb-005e-435f-ae11-3e8fb558ea98" = false
 
 # eggs and peanuts
-6fa95d26-044c-48a9-8a7b-9ee46ec32c5c = false
+"6fa95d26-044c-48a9-8a7b-9ee46ec32c5c" = false
 
 # more than eggs but not peanuts
-19890e22-f63f-4c5c-a9fb-fb6eacddfe8e = false
+"19890e22-f63f-4c5c-a9fb-fb6eacddfe8e" = false
 
 # lots of stuff
-4b68f470-067c-44e4-889f-c9fe28917d2f = false
+"4b68f470-067c-44e4-889f-c9fe28917d2f" = false
 
 # everything
-0881b7c5-9efa-4530-91bd-68370d054bc7 = false
+"0881b7c5-9efa-4530-91bd-68370d054bc7" = false
 
 # no allergen score parts
-12ce86de-b347-42a0-ab7c-2e0570f0c65b = false
+"12ce86de-b347-42a0-ab7c-2e0570f0c65b" = false

--- a/exercises/alphametics/.meta/tests.toml
+++ b/exercises/alphametics/.meta/tests.toml
@@ -1,0 +1,31 @@
+[canonical-tests]
+
+# puzzle with three letters
+"e0c08b07-9028-4d5f-91e1-d178fead8e1a" = true
+
+# solution must have unique value for each letter
+"a504ee41-cb92-4ec2-9f11-c37e95ab3f25" = true
+
+# leading zero solution is invalid
+"4e3b81d2-be7b-4c5c-9a80-cd72bc6d465a" = true
+
+# puzzle with two digits final carry
+"8a3e3168-d1ee-4df7-94c7-b9c54845ac3a" = true
+
+# puzzle with four letters
+"a9630645-15bd-48b6-a61e-d85c4021cc09" = true
+
+# puzzle with six letters
+"3d905a86-5a52-4e4e-bf80-8951535791bd" = true
+
+# puzzle with seven letters
+"4febca56-e7b7-4789-97b9-530d09ba95f0" = true
+
+# puzzle with eight letters
+"12125a75-7284-4f9a-a5fa-191471e0d44f" = true
+
+# puzzle with ten letters
+"fb05955f-38dc-477a-a0b6-5ef78969fffa" = true
+
+# puzzle with ten letters and 199 addends
+"9a101e81-9216-472b-b458-b513a7adacf7" = true

--- a/exercises/alphametics/.meta/tests.toml
+++ b/exercises/alphametics/.meta/tests.toml
@@ -1,31 +1,31 @@
 [canonical-tests]
 
 # puzzle with three letters
-e0c08b07-9028-4d5f-91e1-d178fead8e1a = false
+"e0c08b07-9028-4d5f-91e1-d178fead8e1a" = false
 
 # solution must have unique value for each letter
-a504ee41-cb92-4ec2-9f11-c37e95ab3f25 = false
+"a504ee41-cb92-4ec2-9f11-c37e95ab3f25" = false
 
 # leading zero solution is invalid
-4e3b81d2-be7b-4c5c-9a80-cd72bc6d465a = false
+"4e3b81d2-be7b-4c5c-9a80-cd72bc6d465a" = false
 
 # puzzle with two digits final carry
-8a3e3168-d1ee-4df7-94c7-b9c54845ac3a = true
+"8a3e3168-d1ee-4df7-94c7-b9c54845ac3a" = true
 
 # puzzle with four letters
-a9630645-15bd-48b6-a61e-d85c4021cc09 = false
+"a9630645-15bd-48b6-a61e-d85c4021cc09" = false
 
 # puzzle with six letters
-3d905a86-5a52-4e4e-bf80-8951535791bd = false
+"3d905a86-5a52-4e4e-bf80-8951535791bd" = false
 
 # puzzle with seven letters
-4febca56-e7b7-4789-97b9-530d09ba95f0 = false
+"4febca56-e7b7-4789-97b9-530d09ba95f0" = false
 
 # puzzle with eight letters
-12125a75-7284-4f9a-a5fa-191471e0d44f = false
+"12125a75-7284-4f9a-a5fa-191471e0d44f" = false
 
 # puzzle with ten letters
-fb05955f-38dc-477a-a0b6-5ef78969fffa = false
+"fb05955f-38dc-477a-a0b6-5ef78969fffa" = false
 
 # puzzle with ten letters and 199 addends
-9a101e81-9216-472b-b458-b513a7adacf7 = false
+"9a101e81-9216-472b-b458-b513a7adacf7" = false

--- a/exercises/alphametics/.meta/tests.toml
+++ b/exercises/alphametics/.meta/tests.toml
@@ -1,31 +1,31 @@
 [canonical-tests]
 
 # puzzle with three letters
-"e0c08b07-9028-4d5f-91e1-d178fead8e1a" = true
+e0c08b07-9028-4d5f-91e1-d178fead8e1a = false
 
 # solution must have unique value for each letter
-"a504ee41-cb92-4ec2-9f11-c37e95ab3f25" = true
+a504ee41-cb92-4ec2-9f11-c37e95ab3f25 = false
 
 # leading zero solution is invalid
-"4e3b81d2-be7b-4c5c-9a80-cd72bc6d465a" = true
+4e3b81d2-be7b-4c5c-9a80-cd72bc6d465a = false
 
 # puzzle with two digits final carry
-"8a3e3168-d1ee-4df7-94c7-b9c54845ac3a" = true
+8a3e3168-d1ee-4df7-94c7-b9c54845ac3a = true
 
 # puzzle with four letters
-"a9630645-15bd-48b6-a61e-d85c4021cc09" = true
+a9630645-15bd-48b6-a61e-d85c4021cc09 = false
 
 # puzzle with six letters
-"3d905a86-5a52-4e4e-bf80-8951535791bd" = true
+3d905a86-5a52-4e4e-bf80-8951535791bd = false
 
 # puzzle with seven letters
-"4febca56-e7b7-4789-97b9-530d09ba95f0" = true
+4febca56-e7b7-4789-97b9-530d09ba95f0 = false
 
 # puzzle with eight letters
-"12125a75-7284-4f9a-a5fa-191471e0d44f" = true
+12125a75-7284-4f9a-a5fa-191471e0d44f = false
 
 # puzzle with ten letters
-"fb05955f-38dc-477a-a0b6-5ef78969fffa" = true
+fb05955f-38dc-477a-a0b6-5ef78969fffa = false
 
 # puzzle with ten letters and 199 addends
-"9a101e81-9216-472b-b458-b513a7adacf7" = true
+9a101e81-9216-472b-b458-b513a7adacf7 = false

--- a/exercises/anagram/.meta/tests.toml
+++ b/exercises/anagram/.meta/tests.toml
@@ -1,0 +1,43 @@
+[canonical-tests]
+
+# no matches
+"dd40c4d2-3c8b-44e5-992a-f42b393ec373" = true
+
+# detects two anagrams
+"b3cca662-f50a-489e-ae10-ab8290a09bdc" = true
+
+# does not detect anagram subsets
+"a27558ee-9ba0-4552-96b1-ecf665b06556" = true
+
+# detects anagram
+"64cd4584-fc15-4781-b633-3d814c4941a4" = true
+
+# detects three anagrams
+"99c91beb-838f-4ccd-b123-935139917283" = true
+
+# detects multiple anagrams with different case
+"78487770-e258-4e1f-a646-8ece10950d90" = true
+
+# does not detect non-anagrams with identical checksum
+"1d0ab8aa-362f-49b7-9902-3d0c668d557b" = true
+
+# detects anagrams case-insensitively
+"9e632c0b-c0b1-4804-8cc1-e295dea6d8a8" = true
+
+# detects anagrams using case-insensitive subject
+"b248e49f-0905-48d2-9c8d-bd02d8c3e392" = true
+
+# detects anagrams using case-insensitive possible matches
+"f367325c-78ec-411c-be76-e79047f4bd54" = true
+
+# does not detect an anagram if the original word is repeated
+"7cc195ad-e3c7-44ee-9fd2-d3c344806a2c" = true
+
+# anagrams must use all letters exactly once
+"9878a1c9-d6ea-4235-ae51-3ea2befd6842" = true
+
+# words are not anagrams of themselves (case-insensitive)
+"85757361-4535-45fd-ac0e-3810d40debc1" = true
+
+# words other than themselves can be anagrams
+"a0705568-628c-4b55-9798-82e4acde51ca" = true

--- a/exercises/anagram/.meta/tests.toml
+++ b/exercises/anagram/.meta/tests.toml
@@ -1,43 +1,43 @@
 [canonical-tests]
 
 # no matches
-"dd40c4d2-3c8b-44e5-992a-f42b393ec373" = true
+dd40c4d2-3c8b-44e5-992a-f42b393ec373 = false
 
 # detects two anagrams
-"b3cca662-f50a-489e-ae10-ab8290a09bdc" = true
+b3cca662-f50a-489e-ae10-ab8290a09bdc = false
 
 # does not detect anagram subsets
-"a27558ee-9ba0-4552-96b1-ecf665b06556" = true
+a27558ee-9ba0-4552-96b1-ecf665b06556 = false
 
 # detects anagram
-"64cd4584-fc15-4781-b633-3d814c4941a4" = true
+64cd4584-fc15-4781-b633-3d814c4941a4 = false
 
 # detects three anagrams
-"99c91beb-838f-4ccd-b123-935139917283" = true
+99c91beb-838f-4ccd-b123-935139917283 = false
 
 # detects multiple anagrams with different case
-"78487770-e258-4e1f-a646-8ece10950d90" = true
+78487770-e258-4e1f-a646-8ece10950d90 = false
 
 # does not detect non-anagrams with identical checksum
-"1d0ab8aa-362f-49b7-9902-3d0c668d557b" = true
+1d0ab8aa-362f-49b7-9902-3d0c668d557b = false
 
 # detects anagrams case-insensitively
-"9e632c0b-c0b1-4804-8cc1-e295dea6d8a8" = true
+9e632c0b-c0b1-4804-8cc1-e295dea6d8a8 = false
 
 # detects anagrams using case-insensitive subject
-"b248e49f-0905-48d2-9c8d-bd02d8c3e392" = true
+b248e49f-0905-48d2-9c8d-bd02d8c3e392 = false
 
 # detects anagrams using case-insensitive possible matches
-"f367325c-78ec-411c-be76-e79047f4bd54" = true
+f367325c-78ec-411c-be76-e79047f4bd54 = false
 
 # does not detect an anagram if the original word is repeated
-"7cc195ad-e3c7-44ee-9fd2-d3c344806a2c" = true
+7cc195ad-e3c7-44ee-9fd2-d3c344806a2c = false
 
 # anagrams must use all letters exactly once
-"9878a1c9-d6ea-4235-ae51-3ea2befd6842" = true
+9878a1c9-d6ea-4235-ae51-3ea2befd6842 = false
 
 # words are not anagrams of themselves (case-insensitive)
-"85757361-4535-45fd-ac0e-3810d40debc1" = true
+85757361-4535-45fd-ac0e-3810d40debc1 = false
 
 # words other than themselves can be anagrams
-"a0705568-628c-4b55-9798-82e4acde51ca" = true
+a0705568-628c-4b55-9798-82e4acde51ca = false

--- a/exercises/anagram/.meta/tests.toml
+++ b/exercises/anagram/.meta/tests.toml
@@ -1,43 +1,43 @@
 [canonical-tests]
 
 # no matches
-dd40c4d2-3c8b-44e5-992a-f42b393ec373 = false
+"dd40c4d2-3c8b-44e5-992a-f42b393ec373" = false
 
 # detects two anagrams
-b3cca662-f50a-489e-ae10-ab8290a09bdc = false
+"b3cca662-f50a-489e-ae10-ab8290a09bdc" = false
 
 # does not detect anagram subsets
-a27558ee-9ba0-4552-96b1-ecf665b06556 = false
+"a27558ee-9ba0-4552-96b1-ecf665b06556" = false
 
 # detects anagram
-64cd4584-fc15-4781-b633-3d814c4941a4 = false
+"64cd4584-fc15-4781-b633-3d814c4941a4" = false
 
 # detects three anagrams
-99c91beb-838f-4ccd-b123-935139917283 = false
+"99c91beb-838f-4ccd-b123-935139917283" = false
 
 # detects multiple anagrams with different case
-78487770-e258-4e1f-a646-8ece10950d90 = false
+"78487770-e258-4e1f-a646-8ece10950d90" = false
 
 # does not detect non-anagrams with identical checksum
-1d0ab8aa-362f-49b7-9902-3d0c668d557b = false
+"1d0ab8aa-362f-49b7-9902-3d0c668d557b" = false
 
 # detects anagrams case-insensitively
-9e632c0b-c0b1-4804-8cc1-e295dea6d8a8 = false
+"9e632c0b-c0b1-4804-8cc1-e295dea6d8a8" = false
 
 # detects anagrams using case-insensitive subject
-b248e49f-0905-48d2-9c8d-bd02d8c3e392 = false
+"b248e49f-0905-48d2-9c8d-bd02d8c3e392" = false
 
 # detects anagrams using case-insensitive possible matches
-f367325c-78ec-411c-be76-e79047f4bd54 = false
+"f367325c-78ec-411c-be76-e79047f4bd54" = false
 
 # does not detect an anagram if the original word is repeated
-7cc195ad-e3c7-44ee-9fd2-d3c344806a2c = false
+"7cc195ad-e3c7-44ee-9fd2-d3c344806a2c" = false
 
 # anagrams must use all letters exactly once
-9878a1c9-d6ea-4235-ae51-3ea2befd6842 = false
+"9878a1c9-d6ea-4235-ae51-3ea2befd6842" = false
 
 # words are not anagrams of themselves (case-insensitive)
-85757361-4535-45fd-ac0e-3810d40debc1 = false
+"85757361-4535-45fd-ac0e-3810d40debc1" = false
 
 # words other than themselves can be anagrams
-a0705568-628c-4b55-9798-82e4acde51ca = false
+"a0705568-628c-4b55-9798-82e4acde51ca" = false

--- a/exercises/armstrong-numbers/.meta/tests.toml
+++ b/exercises/armstrong-numbers/.meta/tests.toml
@@ -1,0 +1,28 @@
+[canonical-tests]
+
+# Zero is an Armstrong number
+"c1ed103c-258d-45b2-be73-d8c6d9580c7b" = true
+
+# Single digit numbers are Armstrong numbers
+"579e8f03-9659-4b85-a1a2-d64350f6b17a" = true
+
+# There are no 2 digit Armstrong numbers
+"2d6db9dc-5bf8-4976-a90b-b2c2b9feba60" = true
+
+# Three digit number that is an Armstrong number
+"509c087f-e327-4113-a7d2-26a4e9d18283" = true
+
+# Three digit number that is not an Armstrong number
+"7154547d-c2ce-468d-b214-4cb953b870cf" = true
+
+# Four digit number that is an Armstrong number
+"6bac5b7b-42e9-4ecb-a8b0-4832229aa103" = true
+
+# Four digit number that is not an Armstrong number
+"eed4b331-af80-45b5-a80b-19c9ea444b2e" = true
+
+# Seven digit number that is an Armstrong number
+"f971ced7-8d68-4758-aea1-d4194900b864" = true
+
+# Seven digit number that is not an Armstrong number
+"7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18" = true

--- a/exercises/armstrong-numbers/.meta/tests.toml
+++ b/exercises/armstrong-numbers/.meta/tests.toml
@@ -1,28 +1,28 @@
 [canonical-tests]
 
 # Zero is an Armstrong number
-"c1ed103c-258d-45b2-be73-d8c6d9580c7b" = true
+c1ed103c-258d-45b2-be73-d8c6d9580c7b = false
 
 # Single digit numbers are Armstrong numbers
-"579e8f03-9659-4b85-a1a2-d64350f6b17a" = true
+579e8f03-9659-4b85-a1a2-d64350f6b17a = false
 
 # There are no 2 digit Armstrong numbers
-"2d6db9dc-5bf8-4976-a90b-b2c2b9feba60" = true
+2d6db9dc-5bf8-4976-a90b-b2c2b9feba60 = false
 
 # Three digit number that is an Armstrong number
-"509c087f-e327-4113-a7d2-26a4e9d18283" = true
+509c087f-e327-4113-a7d2-26a4e9d18283 = false
 
 # Three digit number that is not an Armstrong number
-"7154547d-c2ce-468d-b214-4cb953b870cf" = true
+7154547d-c2ce-468d-b214-4cb953b870cf = false
 
 # Four digit number that is an Armstrong number
-"6bac5b7b-42e9-4ecb-a8b0-4832229aa103" = true
+6bac5b7b-42e9-4ecb-a8b0-4832229aa103 = false
 
 # Four digit number that is not an Armstrong number
-"eed4b331-af80-45b5-a80b-19c9ea444b2e" = true
+eed4b331-af80-45b5-a80b-19c9ea444b2e = false
 
 # Seven digit number that is an Armstrong number
-"f971ced7-8d68-4758-aea1-d4194900b864" = true
+f971ced7-8d68-4758-aea1-d4194900b864 = false
 
 # Seven digit number that is not an Armstrong number
-"7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18" = true
+7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18 = false

--- a/exercises/armstrong-numbers/.meta/tests.toml
+++ b/exercises/armstrong-numbers/.meta/tests.toml
@@ -1,28 +1,28 @@
 [canonical-tests]
 
 # Zero is an Armstrong number
-c1ed103c-258d-45b2-be73-d8c6d9580c7b = false
+"c1ed103c-258d-45b2-be73-d8c6d9580c7b" = false
 
 # Single digit numbers are Armstrong numbers
-579e8f03-9659-4b85-a1a2-d64350f6b17a = false
+"579e8f03-9659-4b85-a1a2-d64350f6b17a" = false
 
 # There are no 2 digit Armstrong numbers
-2d6db9dc-5bf8-4976-a90b-b2c2b9feba60 = false
+"2d6db9dc-5bf8-4976-a90b-b2c2b9feba60" = false
 
 # Three digit number that is an Armstrong number
-509c087f-e327-4113-a7d2-26a4e9d18283 = false
+"509c087f-e327-4113-a7d2-26a4e9d18283" = false
 
 # Three digit number that is not an Armstrong number
-7154547d-c2ce-468d-b214-4cb953b870cf = false
+"7154547d-c2ce-468d-b214-4cb953b870cf" = false
 
 # Four digit number that is an Armstrong number
-6bac5b7b-42e9-4ecb-a8b0-4832229aa103 = false
+"6bac5b7b-42e9-4ecb-a8b0-4832229aa103" = false
 
 # Four digit number that is not an Armstrong number
-eed4b331-af80-45b5-a80b-19c9ea444b2e = false
+"eed4b331-af80-45b5-a80b-19c9ea444b2e" = false
 
 # Seven digit number that is an Armstrong number
-f971ced7-8d68-4758-aea1-d4194900b864 = false
+"f971ced7-8d68-4758-aea1-d4194900b864" = false
 
 # Seven digit number that is not an Armstrong number
-7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18 = false
+"7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18" = false

--- a/exercises/atbash-cipher/.meta/tests.toml
+++ b/exercises/atbash-cipher/.meta/tests.toml
@@ -1,0 +1,43 @@
+[canonical-tests]
+
+# encode yes
+"2f47ebe1-eab9-4d6b-b3c6-627562a31c77" = true
+
+# encode no
+"b4ffe781-ea81-4b74-b268-cc58ba21c739" = true
+
+# encode OMG
+"10e48927-24ab-4c4d-9d3f-3067724ace00" = true
+
+# encode spaces
+"d59b8bc3-509a-4a9a-834c-6f501b98750b" = true
+
+# encode mindblowingly
+"31d44b11-81b7-4a94-8b43-4af6a2449429" = true
+
+# encode numbers
+"d503361a-1433-48c0-aae0-d41b5baa33ff" = true
+
+# encode deep thought
+"79c8a2d5-0772-42d4-b41b-531d0b5da926" = true
+
+# encode all the letters
+"9ca13d23-d32a-4967-a1fd-6100b8742bab" = true
+
+# decode exercism
+"bb50e087-7fdf-48e7-9223-284fe7e69851" = true
+
+# decode a sentence
+"ac021097-cd5d-4717-8907-b0814b9e292c" = true
+
+# decode numbers
+"18729de3-de74-49b8-b68c-025eaf77f851" = true
+
+# decode all the letters
+"0f30325f-f53b-415d-ad3e-a7a4f63de034" = true
+
+# decode with too many spaces
+"39640287-30c6-4c8c-9bac-9d613d1a5674" = true
+
+# decode with no spaces
+"b34edf13-34c0-49b5-aa21-0768928000d5" = true

--- a/exercises/atbash-cipher/.meta/tests.toml
+++ b/exercises/atbash-cipher/.meta/tests.toml
@@ -1,43 +1,43 @@
 [canonical-tests]
 
 # encode yes
-"2f47ebe1-eab9-4d6b-b3c6-627562a31c77" = true
+2f47ebe1-eab9-4d6b-b3c6-627562a31c77 = false
 
 # encode no
-"b4ffe781-ea81-4b74-b268-cc58ba21c739" = true
+b4ffe781-ea81-4b74-b268-cc58ba21c739 = false
 
 # encode OMG
-"10e48927-24ab-4c4d-9d3f-3067724ace00" = true
+10e48927-24ab-4c4d-9d3f-3067724ace00 = false
 
 # encode spaces
-"d59b8bc3-509a-4a9a-834c-6f501b98750b" = true
+d59b8bc3-509a-4a9a-834c-6f501b98750b = false
 
 # encode mindblowingly
-"31d44b11-81b7-4a94-8b43-4af6a2449429" = true
+31d44b11-81b7-4a94-8b43-4af6a2449429 = false
 
 # encode numbers
-"d503361a-1433-48c0-aae0-d41b5baa33ff" = true
+d503361a-1433-48c0-aae0-d41b5baa33ff = false
 
 # encode deep thought
-"79c8a2d5-0772-42d4-b41b-531d0b5da926" = true
+79c8a2d5-0772-42d4-b41b-531d0b5da926 = false
 
 # encode all the letters
-"9ca13d23-d32a-4967-a1fd-6100b8742bab" = true
+9ca13d23-d32a-4967-a1fd-6100b8742bab = false
 
 # decode exercism
-"bb50e087-7fdf-48e7-9223-284fe7e69851" = true
+bb50e087-7fdf-48e7-9223-284fe7e69851 = false
 
 # decode a sentence
-"ac021097-cd5d-4717-8907-b0814b9e292c" = true
+ac021097-cd5d-4717-8907-b0814b9e292c = false
 
 # decode numbers
-"18729de3-de74-49b8-b68c-025eaf77f851" = true
+18729de3-de74-49b8-b68c-025eaf77f851 = false
 
 # decode all the letters
-"0f30325f-f53b-415d-ad3e-a7a4f63de034" = true
+0f30325f-f53b-415d-ad3e-a7a4f63de034 = false
 
 # decode with too many spaces
-"39640287-30c6-4c8c-9bac-9d613d1a5674" = true
+39640287-30c6-4c8c-9bac-9d613d1a5674 = false
 
 # decode with no spaces
-"b34edf13-34c0-49b5-aa21-0768928000d5" = true
+b34edf13-34c0-49b5-aa21-0768928000d5 = false

--- a/exercises/atbash-cipher/.meta/tests.toml
+++ b/exercises/atbash-cipher/.meta/tests.toml
@@ -1,43 +1,43 @@
 [canonical-tests]
 
 # encode yes
-2f47ebe1-eab9-4d6b-b3c6-627562a31c77 = false
+"2f47ebe1-eab9-4d6b-b3c6-627562a31c77" = false
 
 # encode no
-b4ffe781-ea81-4b74-b268-cc58ba21c739 = false
+"b4ffe781-ea81-4b74-b268-cc58ba21c739" = false
 
 # encode OMG
-10e48927-24ab-4c4d-9d3f-3067724ace00 = false
+"10e48927-24ab-4c4d-9d3f-3067724ace00" = false
 
 # encode spaces
-d59b8bc3-509a-4a9a-834c-6f501b98750b = false
+"d59b8bc3-509a-4a9a-834c-6f501b98750b" = false
 
 # encode mindblowingly
-31d44b11-81b7-4a94-8b43-4af6a2449429 = false
+"31d44b11-81b7-4a94-8b43-4af6a2449429" = false
 
 # encode numbers
-d503361a-1433-48c0-aae0-d41b5baa33ff = false
+"d503361a-1433-48c0-aae0-d41b5baa33ff" = false
 
 # encode deep thought
-79c8a2d5-0772-42d4-b41b-531d0b5da926 = false
+"79c8a2d5-0772-42d4-b41b-531d0b5da926" = false
 
 # encode all the letters
-9ca13d23-d32a-4967-a1fd-6100b8742bab = false
+"9ca13d23-d32a-4967-a1fd-6100b8742bab" = false
 
 # decode exercism
-bb50e087-7fdf-48e7-9223-284fe7e69851 = false
+"bb50e087-7fdf-48e7-9223-284fe7e69851" = false
 
 # decode a sentence
-ac021097-cd5d-4717-8907-b0814b9e292c = false
+"ac021097-cd5d-4717-8907-b0814b9e292c" = false
 
 # decode numbers
-18729de3-de74-49b8-b68c-025eaf77f851 = false
+"18729de3-de74-49b8-b68c-025eaf77f851" = false
 
 # decode all the letters
-0f30325f-f53b-415d-ad3e-a7a4f63de034 = false
+"0f30325f-f53b-415d-ad3e-a7a4f63de034" = false
 
 # decode with too many spaces
-39640287-30c6-4c8c-9bac-9d613d1a5674 = false
+"39640287-30c6-4c8c-9bac-9d613d1a5674" = false
 
 # decode with no spaces
-b34edf13-34c0-49b5-aa21-0768928000d5 = false
+"b34edf13-34c0-49b5-aa21-0768928000d5" = false

--- a/exercises/beer-song/.meta/tests.toml
+++ b/exercises/beer-song/.meta/tests.toml
@@ -1,0 +1,25 @@
+[canonical-tests]
+
+# first generic verse
+"5a02fd08-d336-4607-8006-246fe6fa9fb0" = true
+
+# last generic verse
+"77299ca6-545e-4217-a9cc-606b342e0187" = true
+
+# verse with 2 bottles
+"102cbca0-b197-40fd-b548-e99609b06428" = true
+
+# verse with 1 bottle
+"b8ef9fce-960e-4d85-a0c9-980a04ec1972" = true
+
+# verse with 0 bottles
+"c59d4076-f671-4ee3-baaa-d4966801f90d" = true
+
+# first two verses
+"7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e" = true
+
+# last three verses
+"949868e7-67e8-43d3-9bb4-69277fe020fb" = true
+
+# all verses
+"bc220626-126c-4e72-8df4-fddfc0c3e458" = true

--- a/exercises/beer-song/.meta/tests.toml
+++ b/exercises/beer-song/.meta/tests.toml
@@ -1,25 +1,25 @@
 [canonical-tests]
 
 # first generic verse
-5a02fd08-d336-4607-8006-246fe6fa9fb0 = false
+"5a02fd08-d336-4607-8006-246fe6fa9fb0" = false
 
 # last generic verse
-77299ca6-545e-4217-a9cc-606b342e0187 = false
+"77299ca6-545e-4217-a9cc-606b342e0187" = false
 
 # verse with 2 bottles
-102cbca0-b197-40fd-b548-e99609b06428 = false
+"102cbca0-b197-40fd-b548-e99609b06428" = false
 
 # verse with 1 bottle
-b8ef9fce-960e-4d85-a0c9-980a04ec1972 = false
+"b8ef9fce-960e-4d85-a0c9-980a04ec1972" = false
 
 # verse with 0 bottles
-c59d4076-f671-4ee3-baaa-d4966801f90d = false
+"c59d4076-f671-4ee3-baaa-d4966801f90d" = false
 
 # first two verses
-7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e = false
+"7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e" = false
 
 # last three verses
-949868e7-67e8-43d3-9bb4-69277fe020fb = false
+"949868e7-67e8-43d3-9bb4-69277fe020fb" = false
 
 # all verses
-bc220626-126c-4e72-8df4-fddfc0c3e458 = false
+"bc220626-126c-4e72-8df4-fddfc0c3e458" = false

--- a/exercises/beer-song/.meta/tests.toml
+++ b/exercises/beer-song/.meta/tests.toml
@@ -1,25 +1,25 @@
 [canonical-tests]
 
 # first generic verse
-"5a02fd08-d336-4607-8006-246fe6fa9fb0" = true
+5a02fd08-d336-4607-8006-246fe6fa9fb0 = false
 
 # last generic verse
-"77299ca6-545e-4217-a9cc-606b342e0187" = true
+77299ca6-545e-4217-a9cc-606b342e0187 = false
 
 # verse with 2 bottles
-"102cbca0-b197-40fd-b548-e99609b06428" = true
+102cbca0-b197-40fd-b548-e99609b06428 = false
 
 # verse with 1 bottle
-"b8ef9fce-960e-4d85-a0c9-980a04ec1972" = true
+b8ef9fce-960e-4d85-a0c9-980a04ec1972 = false
 
 # verse with 0 bottles
-"c59d4076-f671-4ee3-baaa-d4966801f90d" = true
+c59d4076-f671-4ee3-baaa-d4966801f90d = false
 
 # first two verses
-"7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e" = true
+7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e = false
 
 # last three verses
-"949868e7-67e8-43d3-9bb4-69277fe020fb" = true
+949868e7-67e8-43d3-9bb4-69277fe020fb = false
 
 # all verses
-"bc220626-126c-4e72-8df4-fddfc0c3e458" = true
+bc220626-126c-4e72-8df4-fddfc0c3e458 = false

--- a/exercises/binary-search/.meta/tests.toml
+++ b/exercises/binary-search/.meta/tests.toml
@@ -1,0 +1,34 @@
+[canonical-tests]
+
+# finds a value in an array with one element
+"b55c24a9-a98d-4379-a08c-2adcf8ebeee8" = true
+
+# finds a value in the middle of an array
+"73469346-b0a0-4011-89bf-989e443d503d" = true
+
+# finds a value at the beginning of an array
+"327bc482-ab85-424e-a724-fb4658e66ddb" = true
+
+# finds a value at the end of an array
+"f9f94b16-fe5e-472c-85ea-c513804c7d59" = true
+
+# finds a value in an array of odd length
+"f0068905-26e3-4342-856d-ad153cadb338" = true
+
+# finds a value in an array of even length
+"fc316b12-c8b3-4f5e-9e89-532b3389de8c" = true
+
+# identifies that a value is not included in the array
+"da7db20a-354f-49f7-a6a1-650a54998aa6" = true
+
+# a value smaller than the array's smallest value is not found
+"95d869ff-3daf-4c79-b622-6e805c675f97" = true
+
+# a value larger than the array's largest value is not found
+"8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba" = true
+
+# nothing is found in an empty array
+"f439a0fa-cf42-4262-8ad1-64bf41ce566a" = true
+
+# nothing is found when the left and right bounds cross
+"2c353967-b56d-40b8-acff-ce43115eed64" = true

--- a/exercises/binary-search/.meta/tests.toml
+++ b/exercises/binary-search/.meta/tests.toml
@@ -1,34 +1,34 @@
 [canonical-tests]
 
 # finds a value in an array with one element
-"b55c24a9-a98d-4379-a08c-2adcf8ebeee8" = true
+b55c24a9-a98d-4379-a08c-2adcf8ebeee8 = true
 
 # finds a value in the middle of an array
-"73469346-b0a0-4011-89bf-989e443d503d" = true
+73469346-b0a0-4011-89bf-989e443d503d = true
 
 # finds a value at the beginning of an array
-"327bc482-ab85-424e-a724-fb4658e66ddb" = true
+327bc482-ab85-424e-a724-fb4658e66ddb = true
 
 # finds a value at the end of an array
-"f9f94b16-fe5e-472c-85ea-c513804c7d59" = true
+f9f94b16-fe5e-472c-85ea-c513804c7d59 = true
 
 # finds a value in an array of odd length
-"f0068905-26e3-4342-856d-ad153cadb338" = true
+f0068905-26e3-4342-856d-ad153cadb338 = true
 
 # finds a value in an array of even length
-"fc316b12-c8b3-4f5e-9e89-532b3389de8c" = true
+fc316b12-c8b3-4f5e-9e89-532b3389de8c = true
 
 # identifies that a value is not included in the array
-"da7db20a-354f-49f7-a6a1-650a54998aa6" = true
+da7db20a-354f-49f7-a6a1-650a54998aa6 = true
 
 # a value smaller than the array's smallest value is not found
-"95d869ff-3daf-4c79-b622-6e805c675f97" = true
+95d869ff-3daf-4c79-b622-6e805c675f97 = false
 
 # a value larger than the array's largest value is not found
-"8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba" = true
+8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba = false
 
 # nothing is found in an empty array
-"f439a0fa-cf42-4262-8ad1-64bf41ce566a" = true
+f439a0fa-cf42-4262-8ad1-64bf41ce566a = false
 
 # nothing is found when the left and right bounds cross
-"2c353967-b56d-40b8-acff-ce43115eed64" = true
+2c353967-b56d-40b8-acff-ce43115eed64 = true

--- a/exercises/binary-search/.meta/tests.toml
+++ b/exercises/binary-search/.meta/tests.toml
@@ -1,34 +1,34 @@
 [canonical-tests]
 
 # finds a value in an array with one element
-b55c24a9-a98d-4379-a08c-2adcf8ebeee8 = true
+"b55c24a9-a98d-4379-a08c-2adcf8ebeee8" = true
 
 # finds a value in the middle of an array
-73469346-b0a0-4011-89bf-989e443d503d = true
+"73469346-b0a0-4011-89bf-989e443d503d" = true
 
 # finds a value at the beginning of an array
-327bc482-ab85-424e-a724-fb4658e66ddb = true
+"327bc482-ab85-424e-a724-fb4658e66ddb" = true
 
 # finds a value at the end of an array
-f9f94b16-fe5e-472c-85ea-c513804c7d59 = true
+"f9f94b16-fe5e-472c-85ea-c513804c7d59" = true
 
 # finds a value in an array of odd length
-f0068905-26e3-4342-856d-ad153cadb338 = true
+"f0068905-26e3-4342-856d-ad153cadb338" = true
 
 # finds a value in an array of even length
-fc316b12-c8b3-4f5e-9e89-532b3389de8c = true
+"fc316b12-c8b3-4f5e-9e89-532b3389de8c" = true
 
 # identifies that a value is not included in the array
-da7db20a-354f-49f7-a6a1-650a54998aa6 = true
+"da7db20a-354f-49f7-a6a1-650a54998aa6" = true
 
 # a value smaller than the array's smallest value is not found
-95d869ff-3daf-4c79-b622-6e805c675f97 = false
+"95d869ff-3daf-4c79-b622-6e805c675f97" = false
 
 # a value larger than the array's largest value is not found
-8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba = false
+"8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba" = false
 
 # nothing is found in an empty array
-f439a0fa-cf42-4262-8ad1-64bf41ce566a = false
+"f439a0fa-cf42-4262-8ad1-64bf41ce566a" = false
 
 # nothing is found when the left and right bounds cross
-2c353967-b56d-40b8-acff-ce43115eed64 = true
+"2c353967-b56d-40b8-acff-ce43115eed64" = true

--- a/exercises/bob/.meta/tests.toml
+++ b/exercises/bob/.meta/tests.toml
@@ -1,0 +1,76 @@
+[canonical-tests]
+
+# stating something
+"e162fead-606f-437a-a166-d051915cea8e" = true
+
+# shouting
+"73a966dc-8017-47d6-bb32-cf07d1a5fcd9" = true
+
+# shouting gibberish
+"d6c98afd-df35-4806-b55e-2c457c3ab748" = true
+
+# asking a question
+"8a2e771d-d6f1-4e3f-b6c6-b41495556e37" = true
+
+# asking a numeric question
+"81080c62-4e4d-4066-b30a-48d8d76920d9" = true
+
+# asking gibberish
+"2a02716d-685b-4e2e-a804-2adaf281c01e" = true
+
+# talking forcefully
+"c02f9179-ab16-4aa7-a8dc-940145c385f7" = true
+
+# using acronyms in regular speech
+"153c0e25-9bb5-4ec5-966e-598463658bcd" = true
+
+# forceful question
+"a5193c61-4a92-4f68-93e2-f554eb385ec6" = true
+
+# shouting numbers
+"a20e0c54-2224-4dde-8b10-bd2cdd4f61bc" = true
+
+# no letters
+"f7bc4b92-bdff-421e-a238-ae97f230ccac" = true
+
+# question with no letters
+"bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2" = true
+
+# shouting with special characters
+"496143c8-1c31-4c01-8a08-88427af85c66" = true
+
+# shouting with no exclamation mark
+"e6793c1c-43bd-4b8d-bc11-499aea73925f" = true
+
+# statement containing question mark
+"aa8097cc-c548-4951-8856-14a404dd236a" = true
+
+# non-letters with question
+"9bfc677d-ea3a-45f2-be44-35bc8fa3753e" = true
+
+# prattling on
+"8608c508-f7de-4b17-985b-811878b3cf45" = true
+
+# silence
+"bc39f7c6-f543-41be-9a43-fd1c2f753fc0" = true
+
+# prolonged silence
+"d6c47565-372b-4b09-b1dd-c40552b8378b" = true
+
+# alternate silence
+"4428f28d-4100-4d85-a902-e5a78cb0ecd3" = true
+
+# multiple line question
+"66953780-165b-4e7e-8ce3-4bcb80b6385a" = true
+
+# starting with whitespace
+"5371ef75-d9ea-4103-bcfa-2da973ddec1b" = true
+
+# ending with whitespace
+"05b304d6-f83b-46e7-81e0-4cd3ca647900" = true
+
+# other whitespace
+"72bd5ad3-9b2f-4931-a988-dce1f5771de2" = true
+
+# non-question ending with whitespace
+"12983553-8601-46a8-92fa-fcaa3bc4a2a0" = true

--- a/exercises/bob/.meta/tests.toml
+++ b/exercises/bob/.meta/tests.toml
@@ -1,76 +1,76 @@
 [canonical-tests]
 
 # stating something
-e162fead-606f-437a-a166-d051915cea8e = false
+"e162fead-606f-437a-a166-d051915cea8e" = false
 
 # shouting
-73a966dc-8017-47d6-bb32-cf07d1a5fcd9 = false
+"73a966dc-8017-47d6-bb32-cf07d1a5fcd9" = false
 
 # shouting gibberish
-d6c98afd-df35-4806-b55e-2c457c3ab748 = false
+"d6c98afd-df35-4806-b55e-2c457c3ab748" = false
 
 # asking a question
-8a2e771d-d6f1-4e3f-b6c6-b41495556e37 = false
+"8a2e771d-d6f1-4e3f-b6c6-b41495556e37" = false
 
 # asking a numeric question
-81080c62-4e4d-4066-b30a-48d8d76920d9 = false
+"81080c62-4e4d-4066-b30a-48d8d76920d9" = false
 
 # asking gibberish
-2a02716d-685b-4e2e-a804-2adaf281c01e = false
+"2a02716d-685b-4e2e-a804-2adaf281c01e" = false
 
 # talking forcefully
-c02f9179-ab16-4aa7-a8dc-940145c385f7 = false
+"c02f9179-ab16-4aa7-a8dc-940145c385f7" = false
 
 # using acronyms in regular speech
-153c0e25-9bb5-4ec5-966e-598463658bcd = false
+"153c0e25-9bb5-4ec5-966e-598463658bcd" = false
 
 # forceful question
-a5193c61-4a92-4f68-93e2-f554eb385ec6 = false
+"a5193c61-4a92-4f68-93e2-f554eb385ec6" = false
 
 # shouting numbers
-a20e0c54-2224-4dde-8b10-bd2cdd4f61bc = false
+"a20e0c54-2224-4dde-8b10-bd2cdd4f61bc" = false
 
 # no letters
-f7bc4b92-bdff-421e-a238-ae97f230ccac = false
+"f7bc4b92-bdff-421e-a238-ae97f230ccac" = false
 
 # question with no letters
-bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2 = false
+"bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2" = false
 
 # shouting with special characters
-496143c8-1c31-4c01-8a08-88427af85c66 = false
+"496143c8-1c31-4c01-8a08-88427af85c66" = false
 
 # shouting with no exclamation mark
-e6793c1c-43bd-4b8d-bc11-499aea73925f = false
+"e6793c1c-43bd-4b8d-bc11-499aea73925f" = false
 
 # statement containing question mark
-aa8097cc-c548-4951-8856-14a404dd236a = false
+"aa8097cc-c548-4951-8856-14a404dd236a" = false
 
 # non-letters with question
-9bfc677d-ea3a-45f2-be44-35bc8fa3753e = false
+"9bfc677d-ea3a-45f2-be44-35bc8fa3753e" = false
 
 # prattling on
-8608c508-f7de-4b17-985b-811878b3cf45 = false
+"8608c508-f7de-4b17-985b-811878b3cf45" = false
 
 # silence
-bc39f7c6-f543-41be-9a43-fd1c2f753fc0 = false
+"bc39f7c6-f543-41be-9a43-fd1c2f753fc0" = false
 
 # prolonged silence
-d6c47565-372b-4b09-b1dd-c40552b8378b = false
+"d6c47565-372b-4b09-b1dd-c40552b8378b" = false
 
 # alternate silence
-4428f28d-4100-4d85-a902-e5a78cb0ecd3 = false
+"4428f28d-4100-4d85-a902-e5a78cb0ecd3" = false
 
 # multiple line question
-66953780-165b-4e7e-8ce3-4bcb80b6385a = false
+"66953780-165b-4e7e-8ce3-4bcb80b6385a" = false
 
 # starting with whitespace
-5371ef75-d9ea-4103-bcfa-2da973ddec1b = false
+"5371ef75-d9ea-4103-bcfa-2da973ddec1b" = false
 
 # ending with whitespace
-05b304d6-f83b-46e7-81e0-4cd3ca647900 = false
+"05b304d6-f83b-46e7-81e0-4cd3ca647900" = false
 
 # other whitespace
-72bd5ad3-9b2f-4931-a988-dce1f5771de2 = false
+"72bd5ad3-9b2f-4931-a988-dce1f5771de2" = false
 
 # non-question ending with whitespace
-12983553-8601-46a8-92fa-fcaa3bc4a2a0 = false
+"12983553-8601-46a8-92fa-fcaa3bc4a2a0" = false

--- a/exercises/bob/.meta/tests.toml
+++ b/exercises/bob/.meta/tests.toml
@@ -1,76 +1,76 @@
 [canonical-tests]
 
 # stating something
-"e162fead-606f-437a-a166-d051915cea8e" = true
+e162fead-606f-437a-a166-d051915cea8e = false
 
 # shouting
-"73a966dc-8017-47d6-bb32-cf07d1a5fcd9" = true
+73a966dc-8017-47d6-bb32-cf07d1a5fcd9 = false
 
 # shouting gibberish
-"d6c98afd-df35-4806-b55e-2c457c3ab748" = true
+d6c98afd-df35-4806-b55e-2c457c3ab748 = false
 
 # asking a question
-"8a2e771d-d6f1-4e3f-b6c6-b41495556e37" = true
+8a2e771d-d6f1-4e3f-b6c6-b41495556e37 = false
 
 # asking a numeric question
-"81080c62-4e4d-4066-b30a-48d8d76920d9" = true
+81080c62-4e4d-4066-b30a-48d8d76920d9 = false
 
 # asking gibberish
-"2a02716d-685b-4e2e-a804-2adaf281c01e" = true
+2a02716d-685b-4e2e-a804-2adaf281c01e = false
 
 # talking forcefully
-"c02f9179-ab16-4aa7-a8dc-940145c385f7" = true
+c02f9179-ab16-4aa7-a8dc-940145c385f7 = false
 
 # using acronyms in regular speech
-"153c0e25-9bb5-4ec5-966e-598463658bcd" = true
+153c0e25-9bb5-4ec5-966e-598463658bcd = false
 
 # forceful question
-"a5193c61-4a92-4f68-93e2-f554eb385ec6" = true
+a5193c61-4a92-4f68-93e2-f554eb385ec6 = false
 
 # shouting numbers
-"a20e0c54-2224-4dde-8b10-bd2cdd4f61bc" = true
+a20e0c54-2224-4dde-8b10-bd2cdd4f61bc = false
 
 # no letters
-"f7bc4b92-bdff-421e-a238-ae97f230ccac" = true
+f7bc4b92-bdff-421e-a238-ae97f230ccac = false
 
 # question with no letters
-"bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2" = true
+bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2 = false
 
 # shouting with special characters
-"496143c8-1c31-4c01-8a08-88427af85c66" = true
+496143c8-1c31-4c01-8a08-88427af85c66 = false
 
 # shouting with no exclamation mark
-"e6793c1c-43bd-4b8d-bc11-499aea73925f" = true
+e6793c1c-43bd-4b8d-bc11-499aea73925f = false
 
 # statement containing question mark
-"aa8097cc-c548-4951-8856-14a404dd236a" = true
+aa8097cc-c548-4951-8856-14a404dd236a = false
 
 # non-letters with question
-"9bfc677d-ea3a-45f2-be44-35bc8fa3753e" = true
+9bfc677d-ea3a-45f2-be44-35bc8fa3753e = false
 
 # prattling on
-"8608c508-f7de-4b17-985b-811878b3cf45" = true
+8608c508-f7de-4b17-985b-811878b3cf45 = false
 
 # silence
-"bc39f7c6-f543-41be-9a43-fd1c2f753fc0" = true
+bc39f7c6-f543-41be-9a43-fd1c2f753fc0 = false
 
 # prolonged silence
-"d6c47565-372b-4b09-b1dd-c40552b8378b" = true
+d6c47565-372b-4b09-b1dd-c40552b8378b = false
 
 # alternate silence
-"4428f28d-4100-4d85-a902-e5a78cb0ecd3" = true
+4428f28d-4100-4d85-a902-e5a78cb0ecd3 = false
 
 # multiple line question
-"66953780-165b-4e7e-8ce3-4bcb80b6385a" = true
+66953780-165b-4e7e-8ce3-4bcb80b6385a = false
 
 # starting with whitespace
-"5371ef75-d9ea-4103-bcfa-2da973ddec1b" = true
+5371ef75-d9ea-4103-bcfa-2da973ddec1b = false
 
 # ending with whitespace
-"05b304d6-f83b-46e7-81e0-4cd3ca647900" = true
+05b304d6-f83b-46e7-81e0-4cd3ca647900 = false
 
 # other whitespace
-"72bd5ad3-9b2f-4931-a988-dce1f5771de2" = true
+72bd5ad3-9b2f-4931-a988-dce1f5771de2 = false
 
 # non-question ending with whitespace
-"12983553-8601-46a8-92fa-fcaa3bc4a2a0" = true
+12983553-8601-46a8-92fa-fcaa3bc4a2a0 = false

--- a/exercises/bob/.meta/tests.toml
+++ b/exercises/bob/.meta/tests.toml
@@ -4,7 +4,7 @@
 "e162fead-606f-437a-a166-d051915cea8e" = false
 
 # shouting
-"73a966dc-8017-47d6-bb32-cf07d1a5fcd9" = false
+"73a966dc-8017-47d6-bb32-cf07d1a5fcd9" = true
 
 # shouting gibberish
 "d6c98afd-df35-4806-b55e-2c457c3ab748" = false
@@ -52,7 +52,7 @@
 "8608c508-f7de-4b17-985b-811878b3cf45" = false
 
 # silence
-"bc39f7c6-f543-41be-9a43-fd1c2f753fc0" = false
+"bc39f7c6-f543-41be-9a43-fd1c2f753fc0" = true
 
 # prolonged silence
 "d6c47565-372b-4b09-b1dd-c40552b8378b" = false

--- a/exercises/book-store/.meta/tests.toml
+++ b/exercises/book-store/.meta/tests.toml
@@ -1,0 +1,46 @@
+[canonical-tests]
+
+# Only a single book
+"17146bd5-2e80-4557-ab4c-05632b6b0d01" = true
+
+# Two of the same book
+"cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce" = true
+
+# Empty basket
+"5a86eac0-45d2-46aa-bbf0-266b94393a1a" = true
+
+# Two different books
+"158bd19a-3db4-4468-ae85-e0638a688990" = true
+
+# Three different books
+"f3833f6b-9332-4a1f-ad98-6c3f8e30e163" = true
+
+# Four different books
+"1951a1db-2fb6-4cd1-a69a-f691b6dd30a2" = true
+
+# Five different books
+"d70f6682-3019-4c3f-aede-83c6a8c647a3" = true
+
+# Two groups of four is cheaper than group of five plus group of three
+"78cacb57-911a-45f1-be52-2a5bd428c634" = true
+
+# Two groups of four is cheaper than groups of five and three
+"f808b5a4-e01f-4c0d-881f-f7b90d9739da" = true
+
+# Group of four plus group of two is cheaper than two groups of three
+"fe96401c-5268-4be2-9d9e-19b76478007c" = true
+
+# Two each of first 4 books and 1 copy each of rest
+"68ea9b78-10ad-420e-a766-836a501d3633" = true
+
+# Two copies of each book
+"c0a779d5-a40c-47ae-9828-a340e936b866" = true
+
+# Three copies of first book and 2 each of remaining
+"18fd86fe-08f1-4b68-969b-392b8af20513" = true
+
+# Three each of first 2 books and 2 each of remaining books
+"0b19a24d-e4cf-4ec8-9db2-8899a41af0da" = true
+
+# Four groups of four are cheaper than two groups each of five and three
+"bb376344-4fb2-49ab-ab85-e38d8354a58d" = true

--- a/exercises/book-store/.meta/tests.toml
+++ b/exercises/book-store/.meta/tests.toml
@@ -1,46 +1,46 @@
 [canonical-tests]
 
 # Only a single book
-17146bd5-2e80-4557-ab4c-05632b6b0d01 = false
+"17146bd5-2e80-4557-ab4c-05632b6b0d01" = false
 
 # Two of the same book
-cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce = false
+"cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce" = false
 
 # Empty basket
-5a86eac0-45d2-46aa-bbf0-266b94393a1a = false
+"5a86eac0-45d2-46aa-bbf0-266b94393a1a" = false
 
 # Two different books
-158bd19a-3db4-4468-ae85-e0638a688990 = false
+"158bd19a-3db4-4468-ae85-e0638a688990" = false
 
 # Three different books
-f3833f6b-9332-4a1f-ad98-6c3f8e30e163 = false
+"f3833f6b-9332-4a1f-ad98-6c3f8e30e163" = false
 
 # Four different books
-1951a1db-2fb6-4cd1-a69a-f691b6dd30a2 = false
+"1951a1db-2fb6-4cd1-a69a-f691b6dd30a2" = false
 
 # Five different books
-d70f6682-3019-4c3f-aede-83c6a8c647a3 = false
+"d70f6682-3019-4c3f-aede-83c6a8c647a3" = false
 
 # Two groups of four is cheaper than group of five plus group of three
-78cacb57-911a-45f1-be52-2a5bd428c634 = false
+"78cacb57-911a-45f1-be52-2a5bd428c634" = false
 
 # Two groups of four is cheaper than groups of five and three
-f808b5a4-e01f-4c0d-881f-f7b90d9739da = false
+"f808b5a4-e01f-4c0d-881f-f7b90d9739da" = false
 
 # Group of four plus group of two is cheaper than two groups of three
-fe96401c-5268-4be2-9d9e-19b76478007c = false
+"fe96401c-5268-4be2-9d9e-19b76478007c" = false
 
 # Two each of first 4 books and 1 copy each of rest
-68ea9b78-10ad-420e-a766-836a501d3633 = false
+"68ea9b78-10ad-420e-a766-836a501d3633" = false
 
 # Two copies of each book
-c0a779d5-a40c-47ae-9828-a340e936b866 = false
+"c0a779d5-a40c-47ae-9828-a340e936b866" = false
 
 # Three copies of first book and 2 each of remaining
-18fd86fe-08f1-4b68-969b-392b8af20513 = false
+"18fd86fe-08f1-4b68-969b-392b8af20513" = false
 
 # Three each of first 2 books and 2 each of remaining books
-0b19a24d-e4cf-4ec8-9db2-8899a41af0da = false
+"0b19a24d-e4cf-4ec8-9db2-8899a41af0da" = false
 
 # Four groups of four are cheaper than two groups each of five and three
-bb376344-4fb2-49ab-ab85-e38d8354a58d = false
+"bb376344-4fb2-49ab-ab85-e38d8354a58d" = false

--- a/exercises/book-store/.meta/tests.toml
+++ b/exercises/book-store/.meta/tests.toml
@@ -1,46 +1,46 @@
 [canonical-tests]
 
 # Only a single book
-"17146bd5-2e80-4557-ab4c-05632b6b0d01" = true
+17146bd5-2e80-4557-ab4c-05632b6b0d01 = false
 
 # Two of the same book
-"cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce" = true
+cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce = false
 
 # Empty basket
-"5a86eac0-45d2-46aa-bbf0-266b94393a1a" = true
+5a86eac0-45d2-46aa-bbf0-266b94393a1a = false
 
 # Two different books
-"158bd19a-3db4-4468-ae85-e0638a688990" = true
+158bd19a-3db4-4468-ae85-e0638a688990 = false
 
 # Three different books
-"f3833f6b-9332-4a1f-ad98-6c3f8e30e163" = true
+f3833f6b-9332-4a1f-ad98-6c3f8e30e163 = false
 
 # Four different books
-"1951a1db-2fb6-4cd1-a69a-f691b6dd30a2" = true
+1951a1db-2fb6-4cd1-a69a-f691b6dd30a2 = false
 
 # Five different books
-"d70f6682-3019-4c3f-aede-83c6a8c647a3" = true
+d70f6682-3019-4c3f-aede-83c6a8c647a3 = false
 
 # Two groups of four is cheaper than group of five plus group of three
-"78cacb57-911a-45f1-be52-2a5bd428c634" = true
+78cacb57-911a-45f1-be52-2a5bd428c634 = false
 
 # Two groups of four is cheaper than groups of five and three
-"f808b5a4-e01f-4c0d-881f-f7b90d9739da" = true
+f808b5a4-e01f-4c0d-881f-f7b90d9739da = false
 
 # Group of four plus group of two is cheaper than two groups of three
-"fe96401c-5268-4be2-9d9e-19b76478007c" = true
+fe96401c-5268-4be2-9d9e-19b76478007c = false
 
 # Two each of first 4 books and 1 copy each of rest
-"68ea9b78-10ad-420e-a766-836a501d3633" = true
+68ea9b78-10ad-420e-a766-836a501d3633 = false
 
 # Two copies of each book
-"c0a779d5-a40c-47ae-9828-a340e936b866" = true
+c0a779d5-a40c-47ae-9828-a340e936b866 = false
 
 # Three copies of first book and 2 each of remaining
-"18fd86fe-08f1-4b68-969b-392b8af20513" = true
+18fd86fe-08f1-4b68-969b-392b8af20513 = false
 
 # Three each of first 2 books and 2 each of remaining books
-"0b19a24d-e4cf-4ec8-9db2-8899a41af0da" = true
+0b19a24d-e4cf-4ec8-9db2-8899a41af0da = false
 
 # Four groups of four are cheaper than two groups each of five and three
-"bb376344-4fb2-49ab-ab85-e38d8354a58d" = true
+bb376344-4fb2-49ab-ab85-e38d8354a58d = false

--- a/exercises/bowling/.meta/tests.toml
+++ b/exercises/bowling/.meta/tests.toml
@@ -1,0 +1,91 @@
+[canonical-tests]
+
+# should be able to score a game with all zeros
+"656ae006-25c2-438c-a549-f338e7ec7441" = true
+
+# should be able to score a game with no strikes or spares
+"f85dcc56-cd6b-4875-81b3-e50921e3597b" = true
+
+# a spare followed by zeros is worth ten points
+"d1f56305-3ac2-4fe0-8645-0b37e3073e20" = true
+
+# points scored in the roll after a spare are counted twice
+"0b8c8bb7-764a-4287-801a-f9e9012f8be4" = true
+
+# consecutive spares each get a one roll bonus
+"4d54d502-1565-4691-84cd-f29a09c65bea" = true
+
+# a spare in the last frame gets a one roll bonus that is counted once
+"e5c9cf3d-abbe-4b74-ad48-34051b2b08c0" = true
+
+# a strike earns ten points in a frame with a single roll
+"75269642-2b34-4b72-95a4-9be28ab16902" = true
+
+# points scored in the two rolls after a strike are counted twice as a bonus
+"037f978c-5d01-4e49-bdeb-9e20a2e6f9a6" = true
+
+# consecutive strikes each get the two roll bonus
+"1635e82b-14ec-4cd1-bce4-4ea14bd13a49" = true
+
+# a strike in the last frame gets a two roll bonus that is counted once
+"e483e8b6-cb4b-4959-b310-e3982030d766" = true
+
+# rolling a spare with the two roll bonus does not get a bonus roll
+"9d5c87db-84bc-4e01-8e95-53350c8af1f8" = true
+
+# strikes with the two roll bonus do not get bonus rolls
+"576faac1-7cff-4029-ad72-c16bcada79b5" = true
+
+# a strike with the one roll bonus after a spare in the last frame does not get a bonus
+"72e24404-b6c6-46af-b188-875514c0377b" = true
+
+# all strikes is a perfect game
+"62ee4c72-8ee8-4250-b794-234f1fec17b1" = true
+
+# rolls cannot score negative points
+"1245216b-19c6-422c-b34b-6e4012d7459f" = true
+
+# a roll cannot score more than 10 points
+"5fcbd206-782c-4faa-8f3a-be5c538ba841" = true
+
+# two rolls in a frame cannot score more than 10 points
+"fb023c31-d842-422d-ad7e-79ce1db23c21" = true
+
+# bonus roll after a strike in the last frame cannot score more than 10 points
+"6082d689-d677-4214-80d7-99940189381b" = true
+
+# two bonus rolls after a strike in the last frame cannot score more than 10 points
+"e9565fe6-510a-4675-ba6b-733a56767a45" = true
+
+# two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike
+"2f6acf99-448e-4282-8103-0b9c7df99c3d" = true
+
+# the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike
+"6380495a-8bc4-4cdb-a59f-5f0212dbed01" = true
+
+# second bonus roll after a strike in the last frame cannot score more than 10 points
+"2b2976ea-446c-47a3-9817-42777f09fe7e" = true
+
+# an unstarted game cannot be scored
+"29220245-ac8d-463d-bc19-98a94cfada8a" = true
+
+# an incomplete game cannot be scored
+"4473dc5d-1f86-486f-bf79-426a52ddc955" = true
+
+# cannot roll if game already has ten frames
+"2ccb8980-1b37-4988-b7d1-e5701c317df3" = true
+
+# bonus rolls for a strike in the last frame must be rolled before score can be calculated
+"4864f09b-9df3-4b65-9924-c595ed236f1b" = true
+
+# both bonus rolls for a strike in the last frame must be rolled before score can be calculated
+"537f4e37-4b51-4d1c-97e2-986eb37b2ac1" = true
+
+# bonus roll for a spare in the last frame must be rolled before score can be calculated
+"8134e8c1-4201-4197-bf9f-1431afcde4b9" = true
+
+# cannot roll after bonus roll for spare
+"9d4a9a55-134a-4bad-bae8-3babf84bd570" = true
+
+# cannot roll after bonus rolls for strike
+"d3e02652-a799-4ae3-b53b-68582cc604be" = true

--- a/exercises/bowling/.meta/tests.toml
+++ b/exercises/bowling/.meta/tests.toml
@@ -1,91 +1,91 @@
 [canonical-tests]
 
 # should be able to score a game with all zeros
-656ae006-25c2-438c-a549-f338e7ec7441 = false
+"656ae006-25c2-438c-a549-f338e7ec7441" = false
 
 # should be able to score a game with no strikes or spares
-f85dcc56-cd6b-4875-81b3-e50921e3597b = false
+"f85dcc56-cd6b-4875-81b3-e50921e3597b" = false
 
 # a spare followed by zeros is worth ten points
-d1f56305-3ac2-4fe0-8645-0b37e3073e20 = false
+"d1f56305-3ac2-4fe0-8645-0b37e3073e20" = false
 
 # points scored in the roll after a spare are counted twice
-0b8c8bb7-764a-4287-801a-f9e9012f8be4 = false
+"0b8c8bb7-764a-4287-801a-f9e9012f8be4" = false
 
 # consecutive spares each get a one roll bonus
-4d54d502-1565-4691-84cd-f29a09c65bea = true
+"4d54d502-1565-4691-84cd-f29a09c65bea" = true
 
 # a spare in the last frame gets a one roll bonus that is counted once
-e5c9cf3d-abbe-4b74-ad48-34051b2b08c0 = false
+"e5c9cf3d-abbe-4b74-ad48-34051b2b08c0" = false
 
 # a strike earns ten points in a frame with a single roll
-75269642-2b34-4b72-95a4-9be28ab16902 = true
+"75269642-2b34-4b72-95a4-9be28ab16902" = true
 
 # points scored in the two rolls after a strike are counted twice as a bonus
-037f978c-5d01-4e49-bdeb-9e20a2e6f9a6 = true
+"037f978c-5d01-4e49-bdeb-9e20a2e6f9a6" = true
 
 # consecutive strikes each get the two roll bonus
-1635e82b-14ec-4cd1-bce4-4ea14bd13a49 = true
+"1635e82b-14ec-4cd1-bce4-4ea14bd13a49" = true
 
 # a strike in the last frame gets a two roll bonus that is counted once
-e483e8b6-cb4b-4959-b310-e3982030d766 = false
+"e483e8b6-cb4b-4959-b310-e3982030d766" = false
 
 # rolling a spare with the two roll bonus does not get a bonus roll
-9d5c87db-84bc-4e01-8e95-53350c8af1f8 = false
+"9d5c87db-84bc-4e01-8e95-53350c8af1f8" = false
 
 # strikes with the two roll bonus do not get bonus rolls
-576faac1-7cff-4029-ad72-c16bcada79b5 = false
+"576faac1-7cff-4029-ad72-c16bcada79b5" = false
 
 # a strike with the one roll bonus after a spare in the last frame does not get a bonus
-72e24404-b6c6-46af-b188-875514c0377b = true
+"72e24404-b6c6-46af-b188-875514c0377b" = true
 
 # all strikes is a perfect game
-62ee4c72-8ee8-4250-b794-234f1fec17b1 = false
+"62ee4c72-8ee8-4250-b794-234f1fec17b1" = false
 
 # rolls cannot score negative points
-1245216b-19c6-422c-b34b-6e4012d7459f = false
+"1245216b-19c6-422c-b34b-6e4012d7459f" = false
 
 # a roll cannot score more than 10 points
-5fcbd206-782c-4faa-8f3a-be5c538ba841 = false
+"5fcbd206-782c-4faa-8f3a-be5c538ba841" = false
 
 # two rolls in a frame cannot score more than 10 points
-fb023c31-d842-422d-ad7e-79ce1db23c21 = false
+"fb023c31-d842-422d-ad7e-79ce1db23c21" = false
 
 # bonus roll after a strike in the last frame cannot score more than 10 points
-6082d689-d677-4214-80d7-99940189381b = false
+"6082d689-d677-4214-80d7-99940189381b" = false
 
 # two bonus rolls after a strike in the last frame cannot score more than 10 points
-e9565fe6-510a-4675-ba6b-733a56767a45 = false
+"e9565fe6-510a-4675-ba6b-733a56767a45" = false
 
 # two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike
-2f6acf99-448e-4282-8103-0b9c7df99c3d = false
+"2f6acf99-448e-4282-8103-0b9c7df99c3d" = false
 
 # the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike
-6380495a-8bc4-4cdb-a59f-5f0212dbed01 = false
+"6380495a-8bc4-4cdb-a59f-5f0212dbed01" = false
 
 # second bonus roll after a strike in the last frame cannot score more than 10 points
-2b2976ea-446c-47a3-9817-42777f09fe7e = false
+"2b2976ea-446c-47a3-9817-42777f09fe7e" = false
 
 # an unstarted game cannot be scored
-29220245-ac8d-463d-bc19-98a94cfada8a = false
+"29220245-ac8d-463d-bc19-98a94cfada8a" = false
 
 # an incomplete game cannot be scored
-4473dc5d-1f86-486f-bf79-426a52ddc955 = false
+"4473dc5d-1f86-486f-bf79-426a52ddc955" = false
 
 # cannot roll if game already has ten frames
-2ccb8980-1b37-4988-b7d1-e5701c317df3 = false
+"2ccb8980-1b37-4988-b7d1-e5701c317df3" = false
 
 # bonus rolls for a strike in the last frame must be rolled before score can be calculated
-4864f09b-9df3-4b65-9924-c595ed236f1b = false
+"4864f09b-9df3-4b65-9924-c595ed236f1b" = false
 
 # both bonus rolls for a strike in the last frame must be rolled before score can be calculated
-537f4e37-4b51-4d1c-97e2-986eb37b2ac1 = false
+"537f4e37-4b51-4d1c-97e2-986eb37b2ac1" = false
 
 # bonus roll for a spare in the last frame must be rolled before score can be calculated
-8134e8c1-4201-4197-bf9f-1431afcde4b9 = false
+"8134e8c1-4201-4197-bf9f-1431afcde4b9" = false
 
 # cannot roll after bonus roll for spare
-9d4a9a55-134a-4bad-bae8-3babf84bd570 = true
+"9d4a9a55-134a-4bad-bae8-3babf84bd570" = true
 
 # cannot roll after bonus rolls for strike
-d3e02652-a799-4ae3-b53b-68582cc604be = false
+"d3e02652-a799-4ae3-b53b-68582cc604be" = false

--- a/exercises/bowling/.meta/tests.toml
+++ b/exercises/bowling/.meta/tests.toml
@@ -1,91 +1,91 @@
 [canonical-tests]
 
 # should be able to score a game with all zeros
-"656ae006-25c2-438c-a549-f338e7ec7441" = true
+656ae006-25c2-438c-a549-f338e7ec7441 = false
 
 # should be able to score a game with no strikes or spares
-"f85dcc56-cd6b-4875-81b3-e50921e3597b" = true
+f85dcc56-cd6b-4875-81b3-e50921e3597b = false
 
 # a spare followed by zeros is worth ten points
-"d1f56305-3ac2-4fe0-8645-0b37e3073e20" = true
+d1f56305-3ac2-4fe0-8645-0b37e3073e20 = false
 
 # points scored in the roll after a spare are counted twice
-"0b8c8bb7-764a-4287-801a-f9e9012f8be4" = true
+0b8c8bb7-764a-4287-801a-f9e9012f8be4 = false
 
 # consecutive spares each get a one roll bonus
-"4d54d502-1565-4691-84cd-f29a09c65bea" = true
+4d54d502-1565-4691-84cd-f29a09c65bea = true
 
 # a spare in the last frame gets a one roll bonus that is counted once
-"e5c9cf3d-abbe-4b74-ad48-34051b2b08c0" = true
+e5c9cf3d-abbe-4b74-ad48-34051b2b08c0 = false
 
 # a strike earns ten points in a frame with a single roll
-"75269642-2b34-4b72-95a4-9be28ab16902" = true
+75269642-2b34-4b72-95a4-9be28ab16902 = true
 
 # points scored in the two rolls after a strike are counted twice as a bonus
-"037f978c-5d01-4e49-bdeb-9e20a2e6f9a6" = true
+037f978c-5d01-4e49-bdeb-9e20a2e6f9a6 = true
 
 # consecutive strikes each get the two roll bonus
-"1635e82b-14ec-4cd1-bce4-4ea14bd13a49" = true
+1635e82b-14ec-4cd1-bce4-4ea14bd13a49 = true
 
 # a strike in the last frame gets a two roll bonus that is counted once
-"e483e8b6-cb4b-4959-b310-e3982030d766" = true
+e483e8b6-cb4b-4959-b310-e3982030d766 = false
 
 # rolling a spare with the two roll bonus does not get a bonus roll
-"9d5c87db-84bc-4e01-8e95-53350c8af1f8" = true
+9d5c87db-84bc-4e01-8e95-53350c8af1f8 = false
 
 # strikes with the two roll bonus do not get bonus rolls
-"576faac1-7cff-4029-ad72-c16bcada79b5" = true
+576faac1-7cff-4029-ad72-c16bcada79b5 = false
 
 # a strike with the one roll bonus after a spare in the last frame does not get a bonus
-"72e24404-b6c6-46af-b188-875514c0377b" = true
+72e24404-b6c6-46af-b188-875514c0377b = true
 
 # all strikes is a perfect game
-"62ee4c72-8ee8-4250-b794-234f1fec17b1" = true
+62ee4c72-8ee8-4250-b794-234f1fec17b1 = false
 
 # rolls cannot score negative points
-"1245216b-19c6-422c-b34b-6e4012d7459f" = true
+1245216b-19c6-422c-b34b-6e4012d7459f = false
 
 # a roll cannot score more than 10 points
-"5fcbd206-782c-4faa-8f3a-be5c538ba841" = true
+5fcbd206-782c-4faa-8f3a-be5c538ba841 = false
 
 # two rolls in a frame cannot score more than 10 points
-"fb023c31-d842-422d-ad7e-79ce1db23c21" = true
+fb023c31-d842-422d-ad7e-79ce1db23c21 = false
 
 # bonus roll after a strike in the last frame cannot score more than 10 points
-"6082d689-d677-4214-80d7-99940189381b" = true
+6082d689-d677-4214-80d7-99940189381b = false
 
 # two bonus rolls after a strike in the last frame cannot score more than 10 points
-"e9565fe6-510a-4675-ba6b-733a56767a45" = true
+e9565fe6-510a-4675-ba6b-733a56767a45 = false
 
 # two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike
-"2f6acf99-448e-4282-8103-0b9c7df99c3d" = true
+2f6acf99-448e-4282-8103-0b9c7df99c3d = false
 
 # the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike
-"6380495a-8bc4-4cdb-a59f-5f0212dbed01" = true
+6380495a-8bc4-4cdb-a59f-5f0212dbed01 = false
 
 # second bonus roll after a strike in the last frame cannot score more than 10 points
-"2b2976ea-446c-47a3-9817-42777f09fe7e" = true
+2b2976ea-446c-47a3-9817-42777f09fe7e = false
 
 # an unstarted game cannot be scored
-"29220245-ac8d-463d-bc19-98a94cfada8a" = true
+29220245-ac8d-463d-bc19-98a94cfada8a = false
 
 # an incomplete game cannot be scored
-"4473dc5d-1f86-486f-bf79-426a52ddc955" = true
+4473dc5d-1f86-486f-bf79-426a52ddc955 = false
 
 # cannot roll if game already has ten frames
-"2ccb8980-1b37-4988-b7d1-e5701c317df3" = true
+2ccb8980-1b37-4988-b7d1-e5701c317df3 = false
 
 # bonus rolls for a strike in the last frame must be rolled before score can be calculated
-"4864f09b-9df3-4b65-9924-c595ed236f1b" = true
+4864f09b-9df3-4b65-9924-c595ed236f1b = false
 
 # both bonus rolls for a strike in the last frame must be rolled before score can be calculated
-"537f4e37-4b51-4d1c-97e2-986eb37b2ac1" = true
+537f4e37-4b51-4d1c-97e2-986eb37b2ac1 = false
 
 # bonus roll for a spare in the last frame must be rolled before score can be calculated
-"8134e8c1-4201-4197-bf9f-1431afcde4b9" = true
+8134e8c1-4201-4197-bf9f-1431afcde4b9 = false
 
 # cannot roll after bonus roll for spare
-"9d4a9a55-134a-4bad-bae8-3babf84bd570" = true
+9d4a9a55-134a-4bad-bae8-3babf84bd570 = true
 
 # cannot roll after bonus rolls for strike
-"d3e02652-a799-4ae3-b53b-68582cc604be" = true
+d3e02652-a799-4ae3-b53b-68582cc604be = false

--- a/exercises/circular-buffer/.meta/tests.toml
+++ b/exercises/circular-buffer/.meta/tests.toml
@@ -1,0 +1,43 @@
+[canonical-tests]
+
+# reading empty buffer should fail
+"28268ed4-4ff3-45f3-820e-895b44d53dfa" = true
+
+# can read an item just written
+"2e6db04a-58a1-425d-ade8-ac30b5f318f3" = true
+
+# each item may only be read once
+"90741fe8-a448-45ce-be2b-de009a24c144" = true
+
+# items are read in the order they are written
+"be0e62d5-da9c-47a8-b037-5db21827baa7" = true
+
+# full buffer can't be written to
+"2af22046-3e44-4235-bfe6-05ba60439d38" = true
+
+# a read frees up capacity for another write
+"547d192c-bbf0-4369-b8fa-fc37e71f2393" = true
+
+# read position is maintained even across multiple writes
+"04a56659-3a81-4113-816b-6ecb659b4471" = true
+
+# items cleared out of buffer can't be read
+"60c3a19a-81a7-43d7-bb0a-f07242b1111f" = true
+
+# clear frees up capacity for another write
+"45f3ae89-3470-49f3-b50e-362e4b330a59" = true
+
+# clear does nothing on empty buffer
+"e1ac5170-a026-4725-bfbe-0cf332eddecd" = true
+
+# overwrite acts like write on non-full buffer
+"9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b" = true
+
+# overwrite replaces the oldest item on full buffer
+"880f916b-5039-475c-bd5c-83463c36a147" = true
+
+# overwrite replaces the oldest item remaining in buffer following a read
+"bfecab5b-aca1-4fab-a2b0-cd4af2b053c3" = true
+
+# initial clear does not affect wrapping around
+"9cebe63a-c405-437b-8b62-e3fdc1ecec5a" = true

--- a/exercises/circular-buffer/.meta/tests.toml
+++ b/exercises/circular-buffer/.meta/tests.toml
@@ -1,43 +1,43 @@
 [canonical-tests]
 
 # reading empty buffer should fail
-28268ed4-4ff3-45f3-820e-895b44d53dfa = false
+"28268ed4-4ff3-45f3-820e-895b44d53dfa" = false
 
 # can read an item just written
-2e6db04a-58a1-425d-ade8-ac30b5f318f3 = false
+"2e6db04a-58a1-425d-ade8-ac30b5f318f3" = false
 
 # each item may only be read once
-90741fe8-a448-45ce-be2b-de009a24c144 = true
+"90741fe8-a448-45ce-be2b-de009a24c144" = true
 
 # items are read in the order they are written
-be0e62d5-da9c-47a8-b037-5db21827baa7 = true
+"be0e62d5-da9c-47a8-b037-5db21827baa7" = true
 
 # full buffer can't be written to
-2af22046-3e44-4235-bfe6-05ba60439d38 = false
+"2af22046-3e44-4235-bfe6-05ba60439d38" = false
 
 # a read frees up capacity for another write
-547d192c-bbf0-4369-b8fa-fc37e71f2393 = false
+"547d192c-bbf0-4369-b8fa-fc37e71f2393" = false
 
 # read position is maintained even across multiple writes
-04a56659-3a81-4113-816b-6ecb659b4471 = true
+"04a56659-3a81-4113-816b-6ecb659b4471" = true
 
 # items cleared out of buffer can't be read
-60c3a19a-81a7-43d7-bb0a-f07242b1111f = false
+"60c3a19a-81a7-43d7-bb0a-f07242b1111f" = false
 
 # clear frees up capacity for another write
-45f3ae89-3470-49f3-b50e-362e4b330a59 = true
+"45f3ae89-3470-49f3-b50e-362e4b330a59" = true
 
 # clear does nothing on empty buffer
-e1ac5170-a026-4725-bfbe-0cf332eddecd = true
+"e1ac5170-a026-4725-bfbe-0cf332eddecd" = true
 
 # overwrite acts like write on non-full buffer
-9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b = false
+"9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b" = false
 
 # overwrite replaces the oldest item on full buffer
-880f916b-5039-475c-bd5c-83463c36a147 = true
+"880f916b-5039-475c-bd5c-83463c36a147" = true
 
 # overwrite replaces the oldest item remaining in buffer following a read
-bfecab5b-aca1-4fab-a2b0-cd4af2b053c3 = true
+"bfecab5b-aca1-4fab-a2b0-cd4af2b053c3" = true
 
 # initial clear does not affect wrapping around
-9cebe63a-c405-437b-8b62-e3fdc1ecec5a = false
+"9cebe63a-c405-437b-8b62-e3fdc1ecec5a" = false

--- a/exercises/circular-buffer/.meta/tests.toml
+++ b/exercises/circular-buffer/.meta/tests.toml
@@ -1,43 +1,43 @@
 [canonical-tests]
 
 # reading empty buffer should fail
-"28268ed4-4ff3-45f3-820e-895b44d53dfa" = true
+28268ed4-4ff3-45f3-820e-895b44d53dfa = false
 
 # can read an item just written
-"2e6db04a-58a1-425d-ade8-ac30b5f318f3" = true
+2e6db04a-58a1-425d-ade8-ac30b5f318f3 = false
 
 # each item may only be read once
-"90741fe8-a448-45ce-be2b-de009a24c144" = true
+90741fe8-a448-45ce-be2b-de009a24c144 = true
 
 # items are read in the order they are written
-"be0e62d5-da9c-47a8-b037-5db21827baa7" = true
+be0e62d5-da9c-47a8-b037-5db21827baa7 = true
 
 # full buffer can't be written to
-"2af22046-3e44-4235-bfe6-05ba60439d38" = true
+2af22046-3e44-4235-bfe6-05ba60439d38 = false
 
 # a read frees up capacity for another write
-"547d192c-bbf0-4369-b8fa-fc37e71f2393" = true
+547d192c-bbf0-4369-b8fa-fc37e71f2393 = false
 
 # read position is maintained even across multiple writes
-"04a56659-3a81-4113-816b-6ecb659b4471" = true
+04a56659-3a81-4113-816b-6ecb659b4471 = true
 
 # items cleared out of buffer can't be read
-"60c3a19a-81a7-43d7-bb0a-f07242b1111f" = true
+60c3a19a-81a7-43d7-bb0a-f07242b1111f = false
 
 # clear frees up capacity for another write
-"45f3ae89-3470-49f3-b50e-362e4b330a59" = true
+45f3ae89-3470-49f3-b50e-362e4b330a59 = true
 
 # clear does nothing on empty buffer
-"e1ac5170-a026-4725-bfbe-0cf332eddecd" = true
+e1ac5170-a026-4725-bfbe-0cf332eddecd = true
 
 # overwrite acts like write on non-full buffer
-"9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b" = true
+9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b = false
 
 # overwrite replaces the oldest item on full buffer
-"880f916b-5039-475c-bd5c-83463c36a147" = true
+880f916b-5039-475c-bd5c-83463c36a147 = true
 
 # overwrite replaces the oldest item remaining in buffer following a read
-"bfecab5b-aca1-4fab-a2b0-cd4af2b053c3" = true
+bfecab5b-aca1-4fab-a2b0-cd4af2b053c3 = true
 
 # initial clear does not affect wrapping around
-"9cebe63a-c405-437b-8b62-e3fdc1ecec5a" = true
+9cebe63a-c405-437b-8b62-e3fdc1ecec5a = false

--- a/exercises/circular-buffer/.meta/tests.toml
+++ b/exercises/circular-buffer/.meta/tests.toml
@@ -13,7 +13,7 @@
 "be0e62d5-da9c-47a8-b037-5db21827baa7" = true
 
 # full buffer can't be written to
-"2af22046-3e44-4235-bfe6-05ba60439d38" = false
+"2af22046-3e44-4235-bfe6-05ba60439d38" = true
 
 # a read frees up capacity for another write
 "547d192c-bbf0-4369-b8fa-fc37e71f2393" = false
@@ -22,7 +22,7 @@
 "04a56659-3a81-4113-816b-6ecb659b4471" = true
 
 # items cleared out of buffer can't be read
-"60c3a19a-81a7-43d7-bb0a-f07242b1111f" = false
+"60c3a19a-81a7-43d7-bb0a-f07242b1111f" = true
 
 # clear frees up capacity for another write
 "45f3ae89-3470-49f3-b50e-362e4b330a59" = true

--- a/exercises/clock/.meta/tests.toml
+++ b/exercises/clock/.meta/tests.toml
@@ -1,0 +1,157 @@
+[canonical-tests]
+
+# on the hour
+"a577bacc-106b-496e-9792-b3083ea8705e" = true
+
+# past the hour
+"b5d0c360-3b88-489b-8e84-68a1c7a4fa23" = true
+
+# midnight is zero hours
+"473223f4-65f3-46ff-a9f7-7663c7e59440" = true
+
+# hour rolls over
+"ca95d24a-5924-447d-9a96-b91c8334725c" = true
+
+# hour rolls over continuously
+"f3826de0-0925-4d69-8ac8-89aea7e52b78" = true
+
+# sixty minutes is next hour
+"a02f7edf-dfd4-4b11-b21a-86de3cc6a95c" = true
+
+# minutes roll over
+"8f520df6-b816-444d-b90f-8a477789beb5" = true
+
+# minutes roll over continuously
+"c75c091b-47ac-4655-8d40-643767fc4eed" = true
+
+# hour and minutes roll over
+"06343ecb-cf39-419d-a3f5-dcbae0cc4c57" = true
+
+# hour and minutes roll over continuously
+"be60810e-f5d9-4b58-9351-a9d1e90e660c" = true
+
+# hour and minutes roll over to exactly midnight
+"1689107b-0b5c-4bea-aad3-65ec9859368a" = true
+
+# negative hour
+"d3088ee8-91b7-4446-9e9d-5e2ad6219d91" = true
+
+# negative hour rolls over
+"77ef6921-f120-4d29-bade-80d54aa43b54" = true
+
+# negative hour rolls over continuously
+"359294b5-972f-4546-bb9a-a85559065234" = true
+
+# negative minutes
+"509db8b7-ac19-47cc-bd3a-a9d2f30b03c0" = true
+
+# negative minutes roll over
+"5d6bb225-130f-4084-84fd-9e0df8996f2a" = true
+
+# negative minutes roll over continuously
+"d483ceef-b520-4f0c-b94a-8d2d58cf0484" = true
+
+# negative sixty minutes is previous hour
+"1cd19447-19c6-44bf-9d04-9f8305ccb9ea" = true
+
+# negative hour and minutes both roll over
+"9d3053aa-4f47-4afc-bd45-d67a72cef4dc" = true
+
+# negative hour and minutes both roll over continuously
+"51d41fcf-491e-4ca0-9cae-2aa4f0163ad4" = true
+
+# add minutes
+"d098e723-ad29-4ef9-997a-2693c4c9d89a" = true
+
+# add no minutes
+"b6ec8f38-e53e-4b22-92a7-60dab1f485f4" = true
+
+# add to next hour
+"efd349dd-0785-453e-9ff8-d7452a8e7269" = true
+
+# add more than one hour
+"749890f7-aba9-4702-acce-87becf4ef9fe" = true
+
+# add more than two hours with carry
+"da63e4c1-1584-46e3-8d18-c9dc802c1713" = true
+
+# add across midnight
+"be167a32-3d33-4cec-a8bc-accd47ddbb71" = true
+
+# add more than one day (1500 min = 25 hrs)
+"6672541e-cdae-46e4-8be7-a820cc3be2a8" = true
+
+# add more than two days
+"1918050d-c79b-4cb7-b707-b607e2745c7e" = true
+
+# subtract minutes
+"37336cac-5ede-43a5-9026-d426cbe40354" = true
+
+# subtract to previous hour
+"0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b" = true
+
+# subtract more than an hour
+"9b4e809c-612f-4b15-aae0-1df0acb801b9" = true
+
+# subtract across midnight
+"8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6" = true
+
+# subtract more than two hours
+"07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9" = true
+
+# subtract more than two hours with borrow
+"90ac8a1b-761c-4342-9c9c-cdc3ed5db097" = true
+
+# subtract more than one day (1500 min = 25 hrs)
+"2149f985-7136-44ad-9b29-ec023a97a2b7" = true
+
+# subtract more than two days
+"ba11dbf0-ac27-4acb-ada9-3b853ec08c97" = true
+
+# clocks with same time
+"f2fdad51-499f-4c9b-a791-b28c9282e311" = true
+
+# clocks a minute apart
+"5d409d4b-f862-4960-901e-ec430160b768" = true
+
+# clocks an hour apart
+"a6045fcf-2b52-4a47-8bb2-ef10a064cba5" = true
+
+# clocks with hour overflow
+"66b12758-0be5-448b-a13c-6a44bce83527" = true
+
+# clocks with hour overflow by several days
+"2b19960c-212e-4a71-9aac-c581592f8111" = true
+
+# clocks with negative hour
+"6f8c6541-afac-4a92-b0c2-b10d4e50269f" = true
+
+# clocks with negative hour that wraps
+"bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d" = true
+
+# clocks with negative hour that wraps multiple times
+"56c0326d-565b-4d19-a26f-63b3205778b7" = true
+
+# clocks with minute overflow
+"c90b9de8-ddff-4ffe-9858-da44a40fdbc2" = true
+
+# clocks with minute overflow by several days
+"533a3dc5-59a7-491b-b728-a7a34fe325de" = true
+
+# clocks with negative minute
+"fff49e15-f7b7-4692-a204-0f6052d62636" = true
+
+# clocks with negative minute that wraps
+"605c65bb-21bd-43eb-8f04-878edf508366" = true
+
+# clocks with negative minute that wraps multiple times
+"b87e64ed-212a-4335-91fd-56da8421d077" = true
+
+# clocks with negative hours and minutes
+"822fbf26-1f3b-4b13-b9bf-c914816b53dd" = true
+
+# clocks with negative hours and minutes that wrap
+"e787bccd-cf58-4a1d-841c-ff80eaaccfaa" = true
+
+# full clock and zeroed clock
+"96969ca8-875a-48a1-86ae-257a528c44f5" = true

--- a/exercises/clock/.meta/tests.toml
+++ b/exercises/clock/.meta/tests.toml
@@ -1,157 +1,157 @@
 [canonical-tests]
 
 # on the hour
-"a577bacc-106b-496e-9792-b3083ea8705e" = true
+a577bacc-106b-496e-9792-b3083ea8705e = false
 
 # past the hour
-"b5d0c360-3b88-489b-8e84-68a1c7a4fa23" = true
+b5d0c360-3b88-489b-8e84-68a1c7a4fa23 = false
 
 # midnight is zero hours
-"473223f4-65f3-46ff-a9f7-7663c7e59440" = true
+473223f4-65f3-46ff-a9f7-7663c7e59440 = false
 
 # hour rolls over
-"ca95d24a-5924-447d-9a96-b91c8334725c" = true
+ca95d24a-5924-447d-9a96-b91c8334725c = false
 
 # hour rolls over continuously
-"f3826de0-0925-4d69-8ac8-89aea7e52b78" = true
+f3826de0-0925-4d69-8ac8-89aea7e52b78 = false
 
 # sixty minutes is next hour
-"a02f7edf-dfd4-4b11-b21a-86de3cc6a95c" = true
+a02f7edf-dfd4-4b11-b21a-86de3cc6a95c = false
 
 # minutes roll over
-"8f520df6-b816-444d-b90f-8a477789beb5" = true
+8f520df6-b816-444d-b90f-8a477789beb5 = false
 
 # minutes roll over continuously
-"c75c091b-47ac-4655-8d40-643767fc4eed" = true
+c75c091b-47ac-4655-8d40-643767fc4eed = false
 
 # hour and minutes roll over
-"06343ecb-cf39-419d-a3f5-dcbae0cc4c57" = true
+06343ecb-cf39-419d-a3f5-dcbae0cc4c57 = false
 
 # hour and minutes roll over continuously
-"be60810e-f5d9-4b58-9351-a9d1e90e660c" = true
+be60810e-f5d9-4b58-9351-a9d1e90e660c = false
 
 # hour and minutes roll over to exactly midnight
-"1689107b-0b5c-4bea-aad3-65ec9859368a" = true
+1689107b-0b5c-4bea-aad3-65ec9859368a = false
 
 # negative hour
-"d3088ee8-91b7-4446-9e9d-5e2ad6219d91" = true
+d3088ee8-91b7-4446-9e9d-5e2ad6219d91 = false
 
 # negative hour rolls over
-"77ef6921-f120-4d29-bade-80d54aa43b54" = true
+77ef6921-f120-4d29-bade-80d54aa43b54 = false
 
 # negative hour rolls over continuously
-"359294b5-972f-4546-bb9a-a85559065234" = true
+359294b5-972f-4546-bb9a-a85559065234 = false
 
 # negative minutes
-"509db8b7-ac19-47cc-bd3a-a9d2f30b03c0" = true
+509db8b7-ac19-47cc-bd3a-a9d2f30b03c0 = false
 
 # negative minutes roll over
-"5d6bb225-130f-4084-84fd-9e0df8996f2a" = true
+5d6bb225-130f-4084-84fd-9e0df8996f2a = false
 
 # negative minutes roll over continuously
-"d483ceef-b520-4f0c-b94a-8d2d58cf0484" = true
+d483ceef-b520-4f0c-b94a-8d2d58cf0484 = false
 
 # negative sixty minutes is previous hour
-"1cd19447-19c6-44bf-9d04-9f8305ccb9ea" = true
+1cd19447-19c6-44bf-9d04-9f8305ccb9ea = false
 
 # negative hour and minutes both roll over
-"9d3053aa-4f47-4afc-bd45-d67a72cef4dc" = true
+9d3053aa-4f47-4afc-bd45-d67a72cef4dc = false
 
 # negative hour and minutes both roll over continuously
-"51d41fcf-491e-4ca0-9cae-2aa4f0163ad4" = true
+51d41fcf-491e-4ca0-9cae-2aa4f0163ad4 = false
 
 # add minutes
-"d098e723-ad29-4ef9-997a-2693c4c9d89a" = true
+d098e723-ad29-4ef9-997a-2693c4c9d89a = false
 
 # add no minutes
-"b6ec8f38-e53e-4b22-92a7-60dab1f485f4" = true
+b6ec8f38-e53e-4b22-92a7-60dab1f485f4 = false
 
 # add to next hour
-"efd349dd-0785-453e-9ff8-d7452a8e7269" = true
+efd349dd-0785-453e-9ff8-d7452a8e7269 = false
 
 # add more than one hour
-"749890f7-aba9-4702-acce-87becf4ef9fe" = true
+749890f7-aba9-4702-acce-87becf4ef9fe = false
 
 # add more than two hours with carry
-"da63e4c1-1584-46e3-8d18-c9dc802c1713" = true
+da63e4c1-1584-46e3-8d18-c9dc802c1713 = false
 
 # add across midnight
-"be167a32-3d33-4cec-a8bc-accd47ddbb71" = true
+be167a32-3d33-4cec-a8bc-accd47ddbb71 = false
 
 # add more than one day (1500 min = 25 hrs)
-"6672541e-cdae-46e4-8be7-a820cc3be2a8" = true
+6672541e-cdae-46e4-8be7-a820cc3be2a8 = false
 
 # add more than two days
-"1918050d-c79b-4cb7-b707-b607e2745c7e" = true
+1918050d-c79b-4cb7-b707-b607e2745c7e = false
 
 # subtract minutes
-"37336cac-5ede-43a5-9026-d426cbe40354" = true
+37336cac-5ede-43a5-9026-d426cbe40354 = false
 
 # subtract to previous hour
-"0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b" = true
+0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b = false
 
 # subtract more than an hour
-"9b4e809c-612f-4b15-aae0-1df0acb801b9" = true
+9b4e809c-612f-4b15-aae0-1df0acb801b9 = false
 
 # subtract across midnight
-"8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6" = true
+8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6 = false
 
 # subtract more than two hours
-"07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9" = true
+07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9 = false
 
 # subtract more than two hours with borrow
-"90ac8a1b-761c-4342-9c9c-cdc3ed5db097" = true
+90ac8a1b-761c-4342-9c9c-cdc3ed5db097 = false
 
 # subtract more than one day (1500 min = 25 hrs)
-"2149f985-7136-44ad-9b29-ec023a97a2b7" = true
+2149f985-7136-44ad-9b29-ec023a97a2b7 = false
 
 # subtract more than two days
-"ba11dbf0-ac27-4acb-ada9-3b853ec08c97" = true
+ba11dbf0-ac27-4acb-ada9-3b853ec08c97 = false
 
 # clocks with same time
-"f2fdad51-499f-4c9b-a791-b28c9282e311" = true
+f2fdad51-499f-4c9b-a791-b28c9282e311 = false
 
 # clocks a minute apart
-"5d409d4b-f862-4960-901e-ec430160b768" = true
+5d409d4b-f862-4960-901e-ec430160b768 = false
 
 # clocks an hour apart
-"a6045fcf-2b52-4a47-8bb2-ef10a064cba5" = true
+a6045fcf-2b52-4a47-8bb2-ef10a064cba5 = false
 
 # clocks with hour overflow
-"66b12758-0be5-448b-a13c-6a44bce83527" = true
+66b12758-0be5-448b-a13c-6a44bce83527 = false
 
 # clocks with hour overflow by several days
-"2b19960c-212e-4a71-9aac-c581592f8111" = true
+2b19960c-212e-4a71-9aac-c581592f8111 = false
 
 # clocks with negative hour
-"6f8c6541-afac-4a92-b0c2-b10d4e50269f" = true
+6f8c6541-afac-4a92-b0c2-b10d4e50269f = false
 
 # clocks with negative hour that wraps
-"bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d" = true
+bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d = false
 
 # clocks with negative hour that wraps multiple times
-"56c0326d-565b-4d19-a26f-63b3205778b7" = true
+56c0326d-565b-4d19-a26f-63b3205778b7 = false
 
 # clocks with minute overflow
-"c90b9de8-ddff-4ffe-9858-da44a40fdbc2" = true
+c90b9de8-ddff-4ffe-9858-da44a40fdbc2 = false
 
 # clocks with minute overflow by several days
-"533a3dc5-59a7-491b-b728-a7a34fe325de" = true
+533a3dc5-59a7-491b-b728-a7a34fe325de = false
 
 # clocks with negative minute
-"fff49e15-f7b7-4692-a204-0f6052d62636" = true
+fff49e15-f7b7-4692-a204-0f6052d62636 = false
 
 # clocks with negative minute that wraps
-"605c65bb-21bd-43eb-8f04-878edf508366" = true
+605c65bb-21bd-43eb-8f04-878edf508366 = false
 
 # clocks with negative minute that wraps multiple times
-"b87e64ed-212a-4335-91fd-56da8421d077" = true
+b87e64ed-212a-4335-91fd-56da8421d077 = false
 
 # clocks with negative hours and minutes
-"822fbf26-1f3b-4b13-b9bf-c914816b53dd" = true
+822fbf26-1f3b-4b13-b9bf-c914816b53dd = false
 
 # clocks with negative hours and minutes that wrap
-"e787bccd-cf58-4a1d-841c-ff80eaaccfaa" = true
+e787bccd-cf58-4a1d-841c-ff80eaaccfaa = false
 
 # full clock and zeroed clock
-"96969ca8-875a-48a1-86ae-257a528c44f5" = true
+96969ca8-875a-48a1-86ae-257a528c44f5 = false

--- a/exercises/clock/.meta/tests.toml
+++ b/exercises/clock/.meta/tests.toml
@@ -1,157 +1,157 @@
 [canonical-tests]
 
 # on the hour
-a577bacc-106b-496e-9792-b3083ea8705e = false
+"a577bacc-106b-496e-9792-b3083ea8705e" = false
 
 # past the hour
-b5d0c360-3b88-489b-8e84-68a1c7a4fa23 = false
+"b5d0c360-3b88-489b-8e84-68a1c7a4fa23" = false
 
 # midnight is zero hours
-473223f4-65f3-46ff-a9f7-7663c7e59440 = false
+"473223f4-65f3-46ff-a9f7-7663c7e59440" = false
 
 # hour rolls over
-ca95d24a-5924-447d-9a96-b91c8334725c = false
+"ca95d24a-5924-447d-9a96-b91c8334725c" = false
 
 # hour rolls over continuously
-f3826de0-0925-4d69-8ac8-89aea7e52b78 = false
+"f3826de0-0925-4d69-8ac8-89aea7e52b78" = false
 
 # sixty minutes is next hour
-a02f7edf-dfd4-4b11-b21a-86de3cc6a95c = false
+"a02f7edf-dfd4-4b11-b21a-86de3cc6a95c" = false
 
 # minutes roll over
-8f520df6-b816-444d-b90f-8a477789beb5 = false
+"8f520df6-b816-444d-b90f-8a477789beb5" = false
 
 # minutes roll over continuously
-c75c091b-47ac-4655-8d40-643767fc4eed = false
+"c75c091b-47ac-4655-8d40-643767fc4eed" = false
 
 # hour and minutes roll over
-06343ecb-cf39-419d-a3f5-dcbae0cc4c57 = false
+"06343ecb-cf39-419d-a3f5-dcbae0cc4c57" = false
 
 # hour and minutes roll over continuously
-be60810e-f5d9-4b58-9351-a9d1e90e660c = false
+"be60810e-f5d9-4b58-9351-a9d1e90e660c" = false
 
 # hour and minutes roll over to exactly midnight
-1689107b-0b5c-4bea-aad3-65ec9859368a = false
+"1689107b-0b5c-4bea-aad3-65ec9859368a" = false
 
 # negative hour
-d3088ee8-91b7-4446-9e9d-5e2ad6219d91 = false
+"d3088ee8-91b7-4446-9e9d-5e2ad6219d91" = false
 
 # negative hour rolls over
-77ef6921-f120-4d29-bade-80d54aa43b54 = false
+"77ef6921-f120-4d29-bade-80d54aa43b54" = false
 
 # negative hour rolls over continuously
-359294b5-972f-4546-bb9a-a85559065234 = false
+"359294b5-972f-4546-bb9a-a85559065234" = false
 
 # negative minutes
-509db8b7-ac19-47cc-bd3a-a9d2f30b03c0 = false
+"509db8b7-ac19-47cc-bd3a-a9d2f30b03c0" = false
 
 # negative minutes roll over
-5d6bb225-130f-4084-84fd-9e0df8996f2a = false
+"5d6bb225-130f-4084-84fd-9e0df8996f2a" = false
 
 # negative minutes roll over continuously
-d483ceef-b520-4f0c-b94a-8d2d58cf0484 = false
+"d483ceef-b520-4f0c-b94a-8d2d58cf0484" = false
 
 # negative sixty minutes is previous hour
-1cd19447-19c6-44bf-9d04-9f8305ccb9ea = false
+"1cd19447-19c6-44bf-9d04-9f8305ccb9ea" = false
 
 # negative hour and minutes both roll over
-9d3053aa-4f47-4afc-bd45-d67a72cef4dc = false
+"9d3053aa-4f47-4afc-bd45-d67a72cef4dc" = false
 
 # negative hour and minutes both roll over continuously
-51d41fcf-491e-4ca0-9cae-2aa4f0163ad4 = false
+"51d41fcf-491e-4ca0-9cae-2aa4f0163ad4" = false
 
 # add minutes
-d098e723-ad29-4ef9-997a-2693c4c9d89a = false
+"d098e723-ad29-4ef9-997a-2693c4c9d89a" = false
 
 # add no minutes
-b6ec8f38-e53e-4b22-92a7-60dab1f485f4 = false
+"b6ec8f38-e53e-4b22-92a7-60dab1f485f4" = false
 
 # add to next hour
-efd349dd-0785-453e-9ff8-d7452a8e7269 = false
+"efd349dd-0785-453e-9ff8-d7452a8e7269" = false
 
 # add more than one hour
-749890f7-aba9-4702-acce-87becf4ef9fe = false
+"749890f7-aba9-4702-acce-87becf4ef9fe" = false
 
 # add more than two hours with carry
-da63e4c1-1584-46e3-8d18-c9dc802c1713 = false
+"da63e4c1-1584-46e3-8d18-c9dc802c1713" = false
 
 # add across midnight
-be167a32-3d33-4cec-a8bc-accd47ddbb71 = false
+"be167a32-3d33-4cec-a8bc-accd47ddbb71" = false
 
 # add more than one day (1500 min = 25 hrs)
-6672541e-cdae-46e4-8be7-a820cc3be2a8 = false
+"6672541e-cdae-46e4-8be7-a820cc3be2a8" = false
 
 # add more than two days
-1918050d-c79b-4cb7-b707-b607e2745c7e = false
+"1918050d-c79b-4cb7-b707-b607e2745c7e" = false
 
 # subtract minutes
-37336cac-5ede-43a5-9026-d426cbe40354 = false
+"37336cac-5ede-43a5-9026-d426cbe40354" = false
 
 # subtract to previous hour
-0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b = false
+"0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b" = false
 
 # subtract more than an hour
-9b4e809c-612f-4b15-aae0-1df0acb801b9 = false
+"9b4e809c-612f-4b15-aae0-1df0acb801b9" = false
 
 # subtract across midnight
-8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6 = false
+"8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6" = false
 
 # subtract more than two hours
-07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9 = false
+"07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9" = false
 
 # subtract more than two hours with borrow
-90ac8a1b-761c-4342-9c9c-cdc3ed5db097 = false
+"90ac8a1b-761c-4342-9c9c-cdc3ed5db097" = false
 
 # subtract more than one day (1500 min = 25 hrs)
-2149f985-7136-44ad-9b29-ec023a97a2b7 = false
+"2149f985-7136-44ad-9b29-ec023a97a2b7" = false
 
 # subtract more than two days
-ba11dbf0-ac27-4acb-ada9-3b853ec08c97 = false
+"ba11dbf0-ac27-4acb-ada9-3b853ec08c97" = false
 
 # clocks with same time
-f2fdad51-499f-4c9b-a791-b28c9282e311 = false
+"f2fdad51-499f-4c9b-a791-b28c9282e311" = false
 
 # clocks a minute apart
-5d409d4b-f862-4960-901e-ec430160b768 = false
+"5d409d4b-f862-4960-901e-ec430160b768" = false
 
 # clocks an hour apart
-a6045fcf-2b52-4a47-8bb2-ef10a064cba5 = false
+"a6045fcf-2b52-4a47-8bb2-ef10a064cba5" = false
 
 # clocks with hour overflow
-66b12758-0be5-448b-a13c-6a44bce83527 = false
+"66b12758-0be5-448b-a13c-6a44bce83527" = false
 
 # clocks with hour overflow by several days
-2b19960c-212e-4a71-9aac-c581592f8111 = false
+"2b19960c-212e-4a71-9aac-c581592f8111" = false
 
 # clocks with negative hour
-6f8c6541-afac-4a92-b0c2-b10d4e50269f = false
+"6f8c6541-afac-4a92-b0c2-b10d4e50269f" = false
 
 # clocks with negative hour that wraps
-bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d = false
+"bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d" = false
 
 # clocks with negative hour that wraps multiple times
-56c0326d-565b-4d19-a26f-63b3205778b7 = false
+"56c0326d-565b-4d19-a26f-63b3205778b7" = false
 
 # clocks with minute overflow
-c90b9de8-ddff-4ffe-9858-da44a40fdbc2 = false
+"c90b9de8-ddff-4ffe-9858-da44a40fdbc2" = false
 
 # clocks with minute overflow by several days
-533a3dc5-59a7-491b-b728-a7a34fe325de = false
+"533a3dc5-59a7-491b-b728-a7a34fe325de" = false
 
 # clocks with negative minute
-fff49e15-f7b7-4692-a204-0f6052d62636 = false
+"fff49e15-f7b7-4692-a204-0f6052d62636" = false
 
 # clocks with negative minute that wraps
-605c65bb-21bd-43eb-8f04-878edf508366 = false
+"605c65bb-21bd-43eb-8f04-878edf508366" = false
 
 # clocks with negative minute that wraps multiple times
-b87e64ed-212a-4335-91fd-56da8421d077 = false
+"b87e64ed-212a-4335-91fd-56da8421d077" = false
 
 # clocks with negative hours and minutes
-822fbf26-1f3b-4b13-b9bf-c914816b53dd = false
+"822fbf26-1f3b-4b13-b9bf-c914816b53dd" = false
 
 # clocks with negative hours and minutes that wrap
-e787bccd-cf58-4a1d-841c-ff80eaaccfaa = false
+"e787bccd-cf58-4a1d-841c-ff80eaaccfaa" = false
 
 # full clock and zeroed clock
-96969ca8-875a-48a1-86ae-257a528c44f5 = false
+"96969ca8-875a-48a1-86ae-257a528c44f5" = false

--- a/exercises/collatz-conjecture/.meta/tests.toml
+++ b/exercises/collatz-conjecture/.meta/tests.toml
@@ -1,0 +1,19 @@
+[canonical-tests]
+
+# zero steps for one
+"540a3d51-e7a6-47a5-92a3-4ad1838f0bfd" = true
+
+# divide if even
+"3d76a0a6-ea84-444a-821a-f7857c2c1859" = true
+
+# even and odd steps
+"754dea81-123c-429e-b8bc-db20b05a87b9" = true
+
+# large number of even and odd steps
+"ecfd0210-6f85-44f6-8280-f65534892ff6" = true
+
+# zero is an error
+"7d4750e6-def9-4b86-aec7-9f7eb44f95a3" = true
+
+# negative value is an error
+"c6c795bf-a288-45e9-86a1-841359ad426d" = true

--- a/exercises/collatz-conjecture/.meta/tests.toml
+++ b/exercises/collatz-conjecture/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # zero steps for one
-540a3d51-e7a6-47a5-92a3-4ad1838f0bfd = false
+"540a3d51-e7a6-47a5-92a3-4ad1838f0bfd" = false
 
 # divide if even
-3d76a0a6-ea84-444a-821a-f7857c2c1859 = false
+"3d76a0a6-ea84-444a-821a-f7857c2c1859" = false
 
 # even and odd steps
-754dea81-123c-429e-b8bc-db20b05a87b9 = false
+"754dea81-123c-429e-b8bc-db20b05a87b9" = false
 
 # large number of even and odd steps
-ecfd0210-6f85-44f6-8280-f65534892ff6 = false
+"ecfd0210-6f85-44f6-8280-f65534892ff6" = false
 
 # zero is an error
-7d4750e6-def9-4b86-aec7-9f7eb44f95a3 = false
+"7d4750e6-def9-4b86-aec7-9f7eb44f95a3" = false
 
 # negative value is an error
-c6c795bf-a288-45e9-86a1-841359ad426d = false
+"c6c795bf-a288-45e9-86a1-841359ad426d" = false

--- a/exercises/collatz-conjecture/.meta/tests.toml
+++ b/exercises/collatz-conjecture/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # zero steps for one
-"540a3d51-e7a6-47a5-92a3-4ad1838f0bfd" = true
+540a3d51-e7a6-47a5-92a3-4ad1838f0bfd = false
 
 # divide if even
-"3d76a0a6-ea84-444a-821a-f7857c2c1859" = true
+3d76a0a6-ea84-444a-821a-f7857c2c1859 = false
 
 # even and odd steps
-"754dea81-123c-429e-b8bc-db20b05a87b9" = true
+754dea81-123c-429e-b8bc-db20b05a87b9 = false
 
 # large number of even and odd steps
-"ecfd0210-6f85-44f6-8280-f65534892ff6" = true
+ecfd0210-6f85-44f6-8280-f65534892ff6 = false
 
 # zero is an error
-"7d4750e6-def9-4b86-aec7-9f7eb44f95a3" = true
+7d4750e6-def9-4b86-aec7-9f7eb44f95a3 = false
 
 # negative value is an error
-"c6c795bf-a288-45e9-86a1-841359ad426d" = true
+c6c795bf-a288-45e9-86a1-841359ad426d = false

--- a/exercises/crypto-square/.meta/tests.toml
+++ b/exercises/crypto-square/.meta/tests.toml
@@ -1,0 +1,22 @@
+[canonical-tests]
+
+# empty plaintext results in an empty ciphertext
+"407c3837-9aa7-4111-ab63-ec54b58e8e9f" = true
+
+# Lowercase
+"64131d65-6fd9-4f58-bdd8-4a2370fb481d" = true
+
+# Remove spaces
+"63a4b0ed-1e3c-41ea-a999-f6f26ba447d6" = true
+
+# Remove punctuation
+"1b5348a1-7893-44c1-8197-42d48d18756c" = true
+
+# 9 character plaintext results in 3 chunks of 3 characters
+"8574a1d3-4a08-4cec-a7c7-de93a164f41a" = true
+
+# 8 character plaintext results in 3 chunks, the last one with a trailing space
+"a65d3fa1-9e09-43f9-bcec-7a672aec3eae" = true
+
+# 54 character plaintext results in 7 chunks, the last two with trailing spaces
+"fbcb0c6d-4c39-4a31-83f6-c473baa6af80" = true

--- a/exercises/crypto-square/.meta/tests.toml
+++ b/exercises/crypto-square/.meta/tests.toml
@@ -1,22 +1,22 @@
 [canonical-tests]
 
 # empty plaintext results in an empty ciphertext
-"407c3837-9aa7-4111-ab63-ec54b58e8e9f" = true
+407c3837-9aa7-4111-ab63-ec54b58e8e9f = false
 
 # Lowercase
-"64131d65-6fd9-4f58-bdd8-4a2370fb481d" = true
+64131d65-6fd9-4f58-bdd8-4a2370fb481d = false
 
 # Remove spaces
-"63a4b0ed-1e3c-41ea-a999-f6f26ba447d6" = true
+63a4b0ed-1e3c-41ea-a999-f6f26ba447d6 = false
 
 # Remove punctuation
-"1b5348a1-7893-44c1-8197-42d48d18756c" = true
+1b5348a1-7893-44c1-8197-42d48d18756c = false
 
 # 9 character plaintext results in 3 chunks of 3 characters
-"8574a1d3-4a08-4cec-a7c7-de93a164f41a" = true
+8574a1d3-4a08-4cec-a7c7-de93a164f41a = false
 
 # 8 character plaintext results in 3 chunks, the last one with a trailing space
-"a65d3fa1-9e09-43f9-bcec-7a672aec3eae" = true
+a65d3fa1-9e09-43f9-bcec-7a672aec3eae = false
 
 # 54 character plaintext results in 7 chunks, the last two with trailing spaces
-"fbcb0c6d-4c39-4a31-83f6-c473baa6af80" = true
+fbcb0c6d-4c39-4a31-83f6-c473baa6af80 = false

--- a/exercises/crypto-square/.meta/tests.toml
+++ b/exercises/crypto-square/.meta/tests.toml
@@ -1,22 +1,22 @@
 [canonical-tests]
 
 # empty plaintext results in an empty ciphertext
-407c3837-9aa7-4111-ab63-ec54b58e8e9f = false
+"407c3837-9aa7-4111-ab63-ec54b58e8e9f" = false
 
 # Lowercase
-64131d65-6fd9-4f58-bdd8-4a2370fb481d = false
+"64131d65-6fd9-4f58-bdd8-4a2370fb481d" = false
 
 # Remove spaces
-63a4b0ed-1e3c-41ea-a999-f6f26ba447d6 = false
+"63a4b0ed-1e3c-41ea-a999-f6f26ba447d6" = false
 
 # Remove punctuation
-1b5348a1-7893-44c1-8197-42d48d18756c = false
+"1b5348a1-7893-44c1-8197-42d48d18756c" = false
 
 # 9 character plaintext results in 3 chunks of 3 characters
-8574a1d3-4a08-4cec-a7c7-de93a164f41a = false
+"8574a1d3-4a08-4cec-a7c7-de93a164f41a" = false
 
 # 8 character plaintext results in 3 chunks, the last one with a trailing space
-a65d3fa1-9e09-43f9-bcec-7a672aec3eae = false
+"a65d3fa1-9e09-43f9-bcec-7a672aec3eae" = false
 
 # 54 character plaintext results in 7 chunks, the last two with trailing spaces
-fbcb0c6d-4c39-4a31-83f6-c473baa6af80 = false
+"fbcb0c6d-4c39-4a31-83f6-c473baa6af80" = false

--- a/exercises/custom-set/.meta/tests.toml
+++ b/exercises/custom-set/.meta/tests.toml
@@ -1,0 +1,115 @@
+[canonical-tests]
+
+# sets with no elements are empty
+"20c5f855-f83a-44a7-abdd-fe75c6cf022b" = true
+
+# sets with elements are not empty
+"d506485d-5706-40db-b7d8-5ceb5acf88d2" = true
+
+# nothing is contained in an empty set
+"759b9740-3417-44c3-8ca3-262b3c281043" = true
+
+# when the element is in the set
+"f83cd2d1-2a85-41bc-b6be-80adbff4be49" = true
+
+# when the element is not in the set
+"93423fc0-44d0-4bc0-a2ac-376de8d7af34" = true
+
+# empty set is a subset of another empty set
+"c392923a-637b-4495-b28e-34742cd6157a" = true
+
+# empty set is a subset of non-empty set
+"5635b113-be8c-4c6f-b9a9-23c485193917" = true
+
+# non-empty set is not a subset of empty set
+"832eda58-6d6e-44e2-92c2-be8cf0173cee" = true
+
+# set is a subset of set with exact same elements
+"c830c578-8f97-4036-b082-89feda876131" = true
+
+# set is a subset of larger set with same elements
+"476a4a1c-0fd1-430f-aa65-5b70cbc810c5" = true
+
+# set is not a subset of set that does not contain its elements
+"d2498999-3e46-48e4-9660-1e20c3329d3d" = true
+
+# the empty set is disjoint with itself
+"7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc" = true
+
+# empty set is disjoint with non-empty set
+"7a2b3938-64b6-4b32-901a-fe16891998a6" = true
+
+# non-empty set is disjoint with empty set
+"589574a0-8b48-48ea-88b0-b652c5fe476f" = true
+
+# sets are not disjoint if they share an element
+"febeaf4f-f180-4499-91fa-59165955a523" = true
+
+# sets are disjoint if they share no elements
+"0de20d2f-c952-468a-88c8-5e056740f020" = true
+
+# empty sets are equal
+"4bd24adb-45da-4320-9ff6-38c044e9dff8" = true
+
+# empty set is not equal to non-empty set
+"f65c0a0e-6632-4b2d-b82c-b7c6da2ec224" = true
+
+# non-empty set is not equal to empty set
+"81e53307-7683-4b1e-a30c-7e49155fe3ca" = true
+
+# sets with the same elements are equal
+"d57c5d7c-a7f3-48cc-a162-6b488c0fbbd0" = true
+
+# sets with different elements are not equal
+"dd61bafc-6653-42cc-961a-ab071ee0ee85" = true
+
+# set is not equal to larger set with same elements
+"06059caf-9bf4-425e-aaff-88966cb3ea14" = true
+
+# add to empty set
+"8a677c3c-a658-4d39-bb88-5b5b1a9659f4" = true
+
+# add to non-empty set
+"0903dd45-904d-4cf2-bddd-0905e1a8d125" = true
+
+# adding an existing element does not change the set
+"b0eb7bb7-5e5d-4733-b582-af771476cb99" = true
+
+# intersection of two empty sets is an empty set
+"893d5333-33b8-4151-a3d4-8f273358208a" = true
+
+# intersection of an empty set and non-empty set is an empty set
+"d739940e-def2-41ab-a7bb-aaf60f7d782c" = true
+
+# intersection of a non-empty set and an empty set is an empty set
+"3607d9d8-c895-4d6f-ac16-a14956e0a4b7" = true
+
+# intersection of two sets with no shared elements is an empty set
+"b5120abf-5b5e-41ab-aede-4de2ad85c34e" = true
+
+# intersection of two sets with shared elements is a set of the shared elements
+"af21ca1b-fac9-499c-81c0-92a591653d49" = true
+
+# difference of two empty sets is an empty set
+"c5e6e2e4-50e9-4bc2-b89f-c518f015b57e" = true
+
+# difference of empty set and non-empty set is an empty set
+"2024cc92-5c26-44ed-aafd-e6ca27d6fcd2" = true
+
+# difference of a non-empty set and an empty set is the non-empty set
+"e79edee7-08aa-4c19-9382-f6820974b43e" = true
+
+# difference of two non-empty sets is a set of elements that are only in the first set
+"c5ac673e-d707-4db5-8d69-7082c3a5437e" = true
+
+# union of empty sets is an empty set
+"c45aed16-5494-455a-9033-5d4c93589dc6" = true
+
+# union of an empty set and non-empty set is the non-empty set
+"9d258545-33c2-4fcb-a340-9f8aa69e7a41" = true
+
+# union of a non-empty set and empty set is the non-empty set
+"3aade50c-80c7-4db8-853d-75bac5818b83" = true
+
+# union of non-empty sets contains all unique elements
+"a00bb91f-c4b4-4844-8f77-c73e2e9df77c" = true

--- a/exercises/custom-set/.meta/tests.toml
+++ b/exercises/custom-set/.meta/tests.toml
@@ -1,115 +1,115 @@
 [canonical-tests]
 
 # sets with no elements are empty
-"20c5f855-f83a-44a7-abdd-fe75c6cf022b" = true
+20c5f855-f83a-44a7-abdd-fe75c6cf022b = true
 
 # sets with elements are not empty
-"d506485d-5706-40db-b7d8-5ceb5acf88d2" = true
+d506485d-5706-40db-b7d8-5ceb5acf88d2 = true
 
 # nothing is contained in an empty set
-"759b9740-3417-44c3-8ca3-262b3c281043" = true
+759b9740-3417-44c3-8ca3-262b3c281043 = true
 
 # when the element is in the set
-"f83cd2d1-2a85-41bc-b6be-80adbff4be49" = true
+f83cd2d1-2a85-41bc-b6be-80adbff4be49 = false
 
 # when the element is not in the set
-"93423fc0-44d0-4bc0-a2ac-376de8d7af34" = true
+93423fc0-44d0-4bc0-a2ac-376de8d7af34 = false
 
 # empty set is a subset of another empty set
-"c392923a-637b-4495-b28e-34742cd6157a" = true
+c392923a-637b-4495-b28e-34742cd6157a = false
 
 # empty set is a subset of non-empty set
-"5635b113-be8c-4c6f-b9a9-23c485193917" = true
+5635b113-be8c-4c6f-b9a9-23c485193917 = false
 
 # non-empty set is not a subset of empty set
-"832eda58-6d6e-44e2-92c2-be8cf0173cee" = true
+832eda58-6d6e-44e2-92c2-be8cf0173cee = false
 
 # set is a subset of set with exact same elements
-"c830c578-8f97-4036-b082-89feda876131" = true
+c830c578-8f97-4036-b082-89feda876131 = false
 
 # set is a subset of larger set with same elements
-"476a4a1c-0fd1-430f-aa65-5b70cbc810c5" = true
+476a4a1c-0fd1-430f-aa65-5b70cbc810c5 = false
 
 # set is not a subset of set that does not contain its elements
-"d2498999-3e46-48e4-9660-1e20c3329d3d" = true
+d2498999-3e46-48e4-9660-1e20c3329d3d = false
 
 # the empty set is disjoint with itself
-"7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc" = true
+7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc = false
 
 # empty set is disjoint with non-empty set
-"7a2b3938-64b6-4b32-901a-fe16891998a6" = true
+7a2b3938-64b6-4b32-901a-fe16891998a6 = false
 
 # non-empty set is disjoint with empty set
-"589574a0-8b48-48ea-88b0-b652c5fe476f" = true
+589574a0-8b48-48ea-88b0-b652c5fe476f = false
 
 # sets are not disjoint if they share an element
-"febeaf4f-f180-4499-91fa-59165955a523" = true
+febeaf4f-f180-4499-91fa-59165955a523 = false
 
 # sets are disjoint if they share no elements
-"0de20d2f-c952-468a-88c8-5e056740f020" = true
+0de20d2f-c952-468a-88c8-5e056740f020 = false
 
 # empty sets are equal
-"4bd24adb-45da-4320-9ff6-38c044e9dff8" = true
+4bd24adb-45da-4320-9ff6-38c044e9dff8 = true
 
 # empty set is not equal to non-empty set
-"f65c0a0e-6632-4b2d-b82c-b7c6da2ec224" = true
+f65c0a0e-6632-4b2d-b82c-b7c6da2ec224 = false
 
 # non-empty set is not equal to empty set
-"81e53307-7683-4b1e-a30c-7e49155fe3ca" = true
+81e53307-7683-4b1e-a30c-7e49155fe3ca = false
 
 # sets with the same elements are equal
-"d57c5d7c-a7f3-48cc-a162-6b488c0fbbd0" = true
+d57c5d7c-a7f3-48cc-a162-6b488c0fbbd0 = true
 
 # sets with different elements are not equal
-"dd61bafc-6653-42cc-961a-ab071ee0ee85" = true
+dd61bafc-6653-42cc-961a-ab071ee0ee85 = true
 
 # set is not equal to larger set with same elements
-"06059caf-9bf4-425e-aaff-88966cb3ea14" = true
+06059caf-9bf4-425e-aaff-88966cb3ea14 = false
 
 # add to empty set
-"8a677c3c-a658-4d39-bb88-5b5b1a9659f4" = true
+8a677c3c-a658-4d39-bb88-5b5b1a9659f4 = true
 
 # add to non-empty set
-"0903dd45-904d-4cf2-bddd-0905e1a8d125" = true
+0903dd45-904d-4cf2-bddd-0905e1a8d125 = false
 
 # adding an existing element does not change the set
-"b0eb7bb7-5e5d-4733-b582-af771476cb99" = true
+b0eb7bb7-5e5d-4733-b582-af771476cb99 = false
 
 # intersection of two empty sets is an empty set
-"893d5333-33b8-4151-a3d4-8f273358208a" = true
+893d5333-33b8-4151-a3d4-8f273358208a = false
 
 # intersection of an empty set and non-empty set is an empty set
-"d739940e-def2-41ab-a7bb-aaf60f7d782c" = true
+d739940e-def2-41ab-a7bb-aaf60f7d782c = false
 
 # intersection of a non-empty set and an empty set is an empty set
-"3607d9d8-c895-4d6f-ac16-a14956e0a4b7" = true
+3607d9d8-c895-4d6f-ac16-a14956e0a4b7 = false
 
 # intersection of two sets with no shared elements is an empty set
-"b5120abf-5b5e-41ab-aede-4de2ad85c34e" = true
+b5120abf-5b5e-41ab-aede-4de2ad85c34e = true
 
 # intersection of two sets with shared elements is a set of the shared elements
-"af21ca1b-fac9-499c-81c0-92a591653d49" = true
+af21ca1b-fac9-499c-81c0-92a591653d49 = true
 
 # difference of two empty sets is an empty set
-"c5e6e2e4-50e9-4bc2-b89f-c518f015b57e" = true
+c5e6e2e4-50e9-4bc2-b89f-c518f015b57e = false
 
 # difference of empty set and non-empty set is an empty set
-"2024cc92-5c26-44ed-aafd-e6ca27d6fcd2" = true
+2024cc92-5c26-44ed-aafd-e6ca27d6fcd2 = false
 
 # difference of a non-empty set and an empty set is the non-empty set
-"e79edee7-08aa-4c19-9382-f6820974b43e" = true
+e79edee7-08aa-4c19-9382-f6820974b43e = false
 
 # difference of two non-empty sets is a set of elements that are only in the first set
-"c5ac673e-d707-4db5-8d69-7082c3a5437e" = true
+c5ac673e-d707-4db5-8d69-7082c3a5437e = false
 
 # union of empty sets is an empty set
-"c45aed16-5494-455a-9033-5d4c93589dc6" = true
+c45aed16-5494-455a-9033-5d4c93589dc6 = false
 
 # union of an empty set and non-empty set is the non-empty set
-"9d258545-33c2-4fcb-a340-9f8aa69e7a41" = true
+9d258545-33c2-4fcb-a340-9f8aa69e7a41 = false
 
 # union of a non-empty set and empty set is the non-empty set
-"3aade50c-80c7-4db8-853d-75bac5818b83" = true
+3aade50c-80c7-4db8-853d-75bac5818b83 = false
 
 # union of non-empty sets contains all unique elements
-"a00bb91f-c4b4-4844-8f77-c73e2e9df77c" = true
+a00bb91f-c4b4-4844-8f77-c73e2e9df77c = false

--- a/exercises/custom-set/.meta/tests.toml
+++ b/exercises/custom-set/.meta/tests.toml
@@ -1,115 +1,115 @@
 [canonical-tests]
 
 # sets with no elements are empty
-20c5f855-f83a-44a7-abdd-fe75c6cf022b = true
+"20c5f855-f83a-44a7-abdd-fe75c6cf022b" = true
 
 # sets with elements are not empty
-d506485d-5706-40db-b7d8-5ceb5acf88d2 = true
+"d506485d-5706-40db-b7d8-5ceb5acf88d2" = true
 
 # nothing is contained in an empty set
-759b9740-3417-44c3-8ca3-262b3c281043 = true
+"759b9740-3417-44c3-8ca3-262b3c281043" = true
 
 # when the element is in the set
-f83cd2d1-2a85-41bc-b6be-80adbff4be49 = false
+"f83cd2d1-2a85-41bc-b6be-80adbff4be49" = false
 
 # when the element is not in the set
-93423fc0-44d0-4bc0-a2ac-376de8d7af34 = false
+"93423fc0-44d0-4bc0-a2ac-376de8d7af34" = false
 
 # empty set is a subset of another empty set
-c392923a-637b-4495-b28e-34742cd6157a = false
+"c392923a-637b-4495-b28e-34742cd6157a" = false
 
 # empty set is a subset of non-empty set
-5635b113-be8c-4c6f-b9a9-23c485193917 = false
+"5635b113-be8c-4c6f-b9a9-23c485193917" = false
 
 # non-empty set is not a subset of empty set
-832eda58-6d6e-44e2-92c2-be8cf0173cee = false
+"832eda58-6d6e-44e2-92c2-be8cf0173cee" = false
 
 # set is a subset of set with exact same elements
-c830c578-8f97-4036-b082-89feda876131 = false
+"c830c578-8f97-4036-b082-89feda876131" = false
 
 # set is a subset of larger set with same elements
-476a4a1c-0fd1-430f-aa65-5b70cbc810c5 = false
+"476a4a1c-0fd1-430f-aa65-5b70cbc810c5" = false
 
 # set is not a subset of set that does not contain its elements
-d2498999-3e46-48e4-9660-1e20c3329d3d = false
+"d2498999-3e46-48e4-9660-1e20c3329d3d" = false
 
 # the empty set is disjoint with itself
-7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc = false
+"7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc" = false
 
 # empty set is disjoint with non-empty set
-7a2b3938-64b6-4b32-901a-fe16891998a6 = false
+"7a2b3938-64b6-4b32-901a-fe16891998a6" = false
 
 # non-empty set is disjoint with empty set
-589574a0-8b48-48ea-88b0-b652c5fe476f = false
+"589574a0-8b48-48ea-88b0-b652c5fe476f" = false
 
 # sets are not disjoint if they share an element
-febeaf4f-f180-4499-91fa-59165955a523 = false
+"febeaf4f-f180-4499-91fa-59165955a523" = false
 
 # sets are disjoint if they share no elements
-0de20d2f-c952-468a-88c8-5e056740f020 = false
+"0de20d2f-c952-468a-88c8-5e056740f020" = false
 
 # empty sets are equal
-4bd24adb-45da-4320-9ff6-38c044e9dff8 = true
+"4bd24adb-45da-4320-9ff6-38c044e9dff8" = true
 
 # empty set is not equal to non-empty set
-f65c0a0e-6632-4b2d-b82c-b7c6da2ec224 = false
+"f65c0a0e-6632-4b2d-b82c-b7c6da2ec224" = false
 
 # non-empty set is not equal to empty set
-81e53307-7683-4b1e-a30c-7e49155fe3ca = false
+"81e53307-7683-4b1e-a30c-7e49155fe3ca" = false
 
 # sets with the same elements are equal
-d57c5d7c-a7f3-48cc-a162-6b488c0fbbd0 = true
+"d57c5d7c-a7f3-48cc-a162-6b488c0fbbd0" = true
 
 # sets with different elements are not equal
-dd61bafc-6653-42cc-961a-ab071ee0ee85 = true
+"dd61bafc-6653-42cc-961a-ab071ee0ee85" = true
 
 # set is not equal to larger set with same elements
-06059caf-9bf4-425e-aaff-88966cb3ea14 = false
+"06059caf-9bf4-425e-aaff-88966cb3ea14" = false
 
 # add to empty set
-8a677c3c-a658-4d39-bb88-5b5b1a9659f4 = true
+"8a677c3c-a658-4d39-bb88-5b5b1a9659f4" = true
 
 # add to non-empty set
-0903dd45-904d-4cf2-bddd-0905e1a8d125 = false
+"0903dd45-904d-4cf2-bddd-0905e1a8d125" = false
 
 # adding an existing element does not change the set
-b0eb7bb7-5e5d-4733-b582-af771476cb99 = false
+"b0eb7bb7-5e5d-4733-b582-af771476cb99" = false
 
 # intersection of two empty sets is an empty set
-893d5333-33b8-4151-a3d4-8f273358208a = false
+"893d5333-33b8-4151-a3d4-8f273358208a" = false
 
 # intersection of an empty set and non-empty set is an empty set
-d739940e-def2-41ab-a7bb-aaf60f7d782c = false
+"d739940e-def2-41ab-a7bb-aaf60f7d782c" = false
 
 # intersection of a non-empty set and an empty set is an empty set
-3607d9d8-c895-4d6f-ac16-a14956e0a4b7 = false
+"3607d9d8-c895-4d6f-ac16-a14956e0a4b7" = false
 
 # intersection of two sets with no shared elements is an empty set
-b5120abf-5b5e-41ab-aede-4de2ad85c34e = true
+"b5120abf-5b5e-41ab-aede-4de2ad85c34e" = true
 
 # intersection of two sets with shared elements is a set of the shared elements
-af21ca1b-fac9-499c-81c0-92a591653d49 = true
+"af21ca1b-fac9-499c-81c0-92a591653d49" = true
 
 # difference of two empty sets is an empty set
-c5e6e2e4-50e9-4bc2-b89f-c518f015b57e = false
+"c5e6e2e4-50e9-4bc2-b89f-c518f015b57e" = false
 
 # difference of empty set and non-empty set is an empty set
-2024cc92-5c26-44ed-aafd-e6ca27d6fcd2 = false
+"2024cc92-5c26-44ed-aafd-e6ca27d6fcd2" = false
 
 # difference of a non-empty set and an empty set is the non-empty set
-e79edee7-08aa-4c19-9382-f6820974b43e = false
+"e79edee7-08aa-4c19-9382-f6820974b43e" = false
 
 # difference of two non-empty sets is a set of elements that are only in the first set
-c5ac673e-d707-4db5-8d69-7082c3a5437e = false
+"c5ac673e-d707-4db5-8d69-7082c3a5437e" = false
 
 # union of empty sets is an empty set
-c45aed16-5494-455a-9033-5d4c93589dc6 = false
+"c45aed16-5494-455a-9033-5d4c93589dc6" = false
 
 # union of an empty set and non-empty set is the non-empty set
-9d258545-33c2-4fcb-a340-9f8aa69e7a41 = false
+"9d258545-33c2-4fcb-a340-9f8aa69e7a41" = false
 
 # union of a non-empty set and empty set is the non-empty set
-3aade50c-80c7-4db8-853d-75bac5818b83 = false
+"3aade50c-80c7-4db8-853d-75bac5818b83" = false
 
 # union of non-empty sets contains all unique elements
-a00bb91f-c4b4-4844-8f77-c73e2e9df77c = false
+"a00bb91f-c4b4-4844-8f77-c73e2e9df77c" = false

--- a/exercises/diamond/.meta/tests.toml
+++ b/exercises/diamond/.meta/tests.toml
@@ -1,0 +1,16 @@
+[canonical-tests]
+
+# Degenerate case with a single 'A' row
+"202fb4cc-6a38-4883-9193-a29d5cb92076" = true
+
+# Degenerate case with no row containing 3 distinct groups of spaces
+"bd6a6d78-9302-42e9-8f60-ac1461e9abae" = true
+
+# Smallest non-degenerate case with odd diamond side length
+"af8efb49-14ed-447f-8944-4cc59ce3fd76" = true
+
+# Smallest non-degenerate case with even diamond side length
+"e0c19a95-9888-4d05-86a0-fa81b9e70d1d" = true
+
+# Largest possible diamond
+"82ea9aa9-4c0e-442a-b07e-40204e925944" = true

--- a/exercises/diamond/.meta/tests.toml
+++ b/exercises/diamond/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # Degenerate case with a single 'A' row
-"202fb4cc-6a38-4883-9193-a29d5cb92076" = true
+202fb4cc-6a38-4883-9193-a29d5cb92076 = false
 
 # Degenerate case with no row containing 3 distinct groups of spaces
-"bd6a6d78-9302-42e9-8f60-ac1461e9abae" = true
+bd6a6d78-9302-42e9-8f60-ac1461e9abae = false
 
 # Smallest non-degenerate case with odd diamond side length
-"af8efb49-14ed-447f-8944-4cc59ce3fd76" = true
+af8efb49-14ed-447f-8944-4cc59ce3fd76 = false
 
 # Smallest non-degenerate case with even diamond side length
-"e0c19a95-9888-4d05-86a0-fa81b9e70d1d" = true
+e0c19a95-9888-4d05-86a0-fa81b9e70d1d = false
 
 # Largest possible diamond
-"82ea9aa9-4c0e-442a-b07e-40204e925944" = true
+82ea9aa9-4c0e-442a-b07e-40204e925944 = false

--- a/exercises/diamond/.meta/tests.toml
+++ b/exercises/diamond/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # Degenerate case with a single 'A' row
-202fb4cc-6a38-4883-9193-a29d5cb92076 = false
+"202fb4cc-6a38-4883-9193-a29d5cb92076" = false
 
 # Degenerate case with no row containing 3 distinct groups of spaces
-bd6a6d78-9302-42e9-8f60-ac1461e9abae = false
+"bd6a6d78-9302-42e9-8f60-ac1461e9abae" = false
 
 # Smallest non-degenerate case with odd diamond side length
-af8efb49-14ed-447f-8944-4cc59ce3fd76 = false
+"af8efb49-14ed-447f-8944-4cc59ce3fd76" = false
 
 # Smallest non-degenerate case with even diamond side length
-e0c19a95-9888-4d05-86a0-fa81b9e70d1d = false
+"e0c19a95-9888-4d05-86a0-fa81b9e70d1d" = false
 
 # Largest possible diamond
-82ea9aa9-4c0e-442a-b07e-40204e925944 = false
+"82ea9aa9-4c0e-442a-b07e-40204e925944" = false

--- a/exercises/difference-of-squares/.meta/tests.toml
+++ b/exercises/difference-of-squares/.meta/tests.toml
@@ -1,0 +1,28 @@
+[canonical-tests]
+
+# square of sum 1
+"e46c542b-31fc-4506-bcae-6b62b3268537" = true
+
+# square of sum 5
+"9b3f96cb-638d-41ee-99b7-b4f9c0622948" = true
+
+# square of sum 100
+"54ba043f-3c35-4d43-86ff-3a41625d5e86" = true
+
+# sum of squares 1
+"01d84507-b03e-4238-9395-dd61d03074b5" = true
+
+# sum of squares 5
+"c93900cd-8cc2-4ca4-917b-dd3027023499" = true
+
+# sum of squares 100
+"94807386-73e4-4d9e-8dec-69eb135b19e4" = true
+
+# difference of squares 1
+"44f72ae6-31a7-437f-858d-2c0837adabb6" = true
+
+# difference of squares 5
+"005cb2bf-a0c8-46f3-ae25-924029f8b00b" = true
+
+# difference of squares 100
+"b1bf19de-9a16-41c0-a62b-1f02ecc0b036" = true

--- a/exercises/difference-of-squares/.meta/tests.toml
+++ b/exercises/difference-of-squares/.meta/tests.toml
@@ -1,28 +1,28 @@
 [canonical-tests]
 
 # square of sum 1
-e46c542b-31fc-4506-bcae-6b62b3268537 = false
+"e46c542b-31fc-4506-bcae-6b62b3268537" = false
 
 # square of sum 5
-9b3f96cb-638d-41ee-99b7-b4f9c0622948 = false
+"9b3f96cb-638d-41ee-99b7-b4f9c0622948" = false
 
 # square of sum 100
-54ba043f-3c35-4d43-86ff-3a41625d5e86 = false
+"54ba043f-3c35-4d43-86ff-3a41625d5e86" = false
 
 # sum of squares 1
-01d84507-b03e-4238-9395-dd61d03074b5 = false
+"01d84507-b03e-4238-9395-dd61d03074b5" = false
 
 # sum of squares 5
-c93900cd-8cc2-4ca4-917b-dd3027023499 = false
+"c93900cd-8cc2-4ca4-917b-dd3027023499" = false
 
 # sum of squares 100
-94807386-73e4-4d9e-8dec-69eb135b19e4 = false
+"94807386-73e4-4d9e-8dec-69eb135b19e4" = false
 
 # difference of squares 1
-44f72ae6-31a7-437f-858d-2c0837adabb6 = false
+"44f72ae6-31a7-437f-858d-2c0837adabb6" = false
 
 # difference of squares 5
-005cb2bf-a0c8-46f3-ae25-924029f8b00b = false
+"005cb2bf-a0c8-46f3-ae25-924029f8b00b" = false
 
 # difference of squares 100
-b1bf19de-9a16-41c0-a62b-1f02ecc0b036 = false
+"b1bf19de-9a16-41c0-a62b-1f02ecc0b036" = false

--- a/exercises/difference-of-squares/.meta/tests.toml
+++ b/exercises/difference-of-squares/.meta/tests.toml
@@ -1,28 +1,28 @@
 [canonical-tests]
 
 # square of sum 1
-"e46c542b-31fc-4506-bcae-6b62b3268537" = true
+e46c542b-31fc-4506-bcae-6b62b3268537 = false
 
 # square of sum 5
-"9b3f96cb-638d-41ee-99b7-b4f9c0622948" = true
+9b3f96cb-638d-41ee-99b7-b4f9c0622948 = false
 
 # square of sum 100
-"54ba043f-3c35-4d43-86ff-3a41625d5e86" = true
+54ba043f-3c35-4d43-86ff-3a41625d5e86 = false
 
 # sum of squares 1
-"01d84507-b03e-4238-9395-dd61d03074b5" = true
+01d84507-b03e-4238-9395-dd61d03074b5 = false
 
 # sum of squares 5
-"c93900cd-8cc2-4ca4-917b-dd3027023499" = true
+c93900cd-8cc2-4ca4-917b-dd3027023499 = false
 
 # sum of squares 100
-"94807386-73e4-4d9e-8dec-69eb135b19e4" = true
+94807386-73e4-4d9e-8dec-69eb135b19e4 = false
 
 # difference of squares 1
-"44f72ae6-31a7-437f-858d-2c0837adabb6" = true
+44f72ae6-31a7-437f-858d-2c0837adabb6 = false
 
 # difference of squares 5
-"005cb2bf-a0c8-46f3-ae25-924029f8b00b" = true
+005cb2bf-a0c8-46f3-ae25-924029f8b00b = false
 
 # difference of squares 100
-"b1bf19de-9a16-41c0-a62b-1f02ecc0b036" = true
+b1bf19de-9a16-41c0-a62b-1f02ecc0b036 = false

--- a/exercises/diffie-hellman/.meta/tests.toml
+++ b/exercises/diffie-hellman/.meta/tests.toml
@@ -1,0 +1,16 @@
+[canonical-tests]
+
+# private key is in range 1 .. p
+"1b97bf38-4307-418e-bfd2-446ffc77588d" = true
+
+# private key is random
+"68b2a5f7-7755-44c3-97b2-d28d21f014a9" = true
+
+# can calculate public key using private key
+"b4161d8e-53a1-4241-ae8f-48cc86527f22" = true
+
+# can calculate secret using other party's public key
+"cd02ad45-3f52-4510-99cc-5161dad948a8" = true
+
+# key exchange
+"17f13c61-a111-4075-9a1f-c2d4636dfa60" = true

--- a/exercises/diffie-hellman/.meta/tests.toml
+++ b/exercises/diffie-hellman/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # private key is in range 1 .. p
-1b97bf38-4307-418e-bfd2-446ffc77588d = false
+"1b97bf38-4307-418e-bfd2-446ffc77588d" = false
 
 # private key is random
-68b2a5f7-7755-44c3-97b2-d28d21f014a9 = false
+"68b2a5f7-7755-44c3-97b2-d28d21f014a9" = false
 
 # can calculate public key using private key
-b4161d8e-53a1-4241-ae8f-48cc86527f22 = false
+"b4161d8e-53a1-4241-ae8f-48cc86527f22" = false
 
 # can calculate secret using other party's public key
-cd02ad45-3f52-4510-99cc-5161dad948a8 = false
+"cd02ad45-3f52-4510-99cc-5161dad948a8" = false
 
 # key exchange
-17f13c61-a111-4075-9a1f-c2d4636dfa60 = false
+"17f13c61-a111-4075-9a1f-c2d4636dfa60" = false

--- a/exercises/diffie-hellman/.meta/tests.toml
+++ b/exercises/diffie-hellman/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # private key is in range 1 .. p
-"1b97bf38-4307-418e-bfd2-446ffc77588d" = true
+1b97bf38-4307-418e-bfd2-446ffc77588d = false
 
 # private key is random
-"68b2a5f7-7755-44c3-97b2-d28d21f014a9" = true
+68b2a5f7-7755-44c3-97b2-d28d21f014a9 = false
 
 # can calculate public key using private key
-"b4161d8e-53a1-4241-ae8f-48cc86527f22" = true
+b4161d8e-53a1-4241-ae8f-48cc86527f22 = false
 
 # can calculate secret using other party's public key
-"cd02ad45-3f52-4510-99cc-5161dad948a8" = true
+cd02ad45-3f52-4510-99cc-5161dad948a8 = false
 
 # key exchange
-"17f13c61-a111-4075-9a1f-c2d4636dfa60" = true
+17f13c61-a111-4075-9a1f-c2d4636dfa60 = false

--- a/exercises/dominoes/.meta/tests.toml
+++ b/exercises/dominoes/.meta/tests.toml
@@ -1,0 +1,37 @@
+[canonical-tests]
+
+# empty input = empty output
+"31a673f2-5e54-49fe-bd79-1c1dae476c9c" = true
+
+# singleton input = singleton output
+"4f99b933-367b-404b-8c6d-36d5923ee476" = true
+
+# singleton that can't be chained
+"91122d10-5ec7-47cb-b759-033756375869" = true
+
+# three elements
+"be8bc26b-fd3d-440b-8e9f-d698a0623be3" = true
+
+# can reverse dominoes
+"99e615c6-c059-401c-9e87-ad7af11fea5c" = true
+
+# can't be chained
+"51f0c291-5d43-40c5-b316-0429069528c9" = true
+
+# disconnected - simple
+"9a75e078-a025-4c23-8c3a-238553657f39" = true
+
+# disconnected - double loop
+"0da0c7fe-d492-445d-b9ef-1f111f07a301" = true
+
+# disconnected - single isolated
+"b6087ff0-f555-4ea0-a71c-f9d707c5994a" = true
+
+# need backtrack
+"2174fbdc-8b48-4bac-9914-8090d06ef978" = true
+
+# separate loops
+"167bb480-dfd1-4318-a20d-4f90adb4a09f" = true
+
+# nine elements
+"cd061538-6046-45a7-ace9-6708fe8f6504" = true

--- a/exercises/dominoes/.meta/tests.toml
+++ b/exercises/dominoes/.meta/tests.toml
@@ -1,37 +1,37 @@
 [canonical-tests]
 
 # empty input = empty output
-"31a673f2-5e54-49fe-bd79-1c1dae476c9c" = true
+31a673f2-5e54-49fe-bd79-1c1dae476c9c = false
 
 # singleton input = singleton output
-"4f99b933-367b-404b-8c6d-36d5923ee476" = true
+4f99b933-367b-404b-8c6d-36d5923ee476 = false
 
 # singleton that can't be chained
-"91122d10-5ec7-47cb-b759-033756375869" = true
+91122d10-5ec7-47cb-b759-033756375869 = false
 
 # three elements
-"be8bc26b-fd3d-440b-8e9f-d698a0623be3" = true
+be8bc26b-fd3d-440b-8e9f-d698a0623be3 = false
 
 # can reverse dominoes
-"99e615c6-c059-401c-9e87-ad7af11fea5c" = true
+99e615c6-c059-401c-9e87-ad7af11fea5c = true
 
 # can't be chained
-"51f0c291-5d43-40c5-b316-0429069528c9" = true
+51f0c291-5d43-40c5-b316-0429069528c9 = false
 
 # disconnected - simple
-"9a75e078-a025-4c23-8c3a-238553657f39" = true
+9a75e078-a025-4c23-8c3a-238553657f39 = false
 
 # disconnected - double loop
-"0da0c7fe-d492-445d-b9ef-1f111f07a301" = true
+0da0c7fe-d492-445d-b9ef-1f111f07a301 = false
 
 # disconnected - single isolated
-"b6087ff0-f555-4ea0-a71c-f9d707c5994a" = true
+b6087ff0-f555-4ea0-a71c-f9d707c5994a = false
 
 # need backtrack
-"2174fbdc-8b48-4bac-9914-8090d06ef978" = true
+2174fbdc-8b48-4bac-9914-8090d06ef978 = true
 
 # separate loops
-"167bb480-dfd1-4318-a20d-4f90adb4a09f" = true
+167bb480-dfd1-4318-a20d-4f90adb4a09f = true
 
 # nine elements
-"cd061538-6046-45a7-ace9-6708fe8f6504" = true
+cd061538-6046-45a7-ace9-6708fe8f6504 = true

--- a/exercises/dominoes/.meta/tests.toml
+++ b/exercises/dominoes/.meta/tests.toml
@@ -7,7 +7,7 @@
 "4f99b933-367b-404b-8c6d-36d5923ee476" = false
 
 # singleton that can't be chained
-"91122d10-5ec7-47cb-b759-033756375869" = false
+"91122d10-5ec7-47cb-b759-033756375869" = true
 
 # three elements
 "be8bc26b-fd3d-440b-8e9f-d698a0623be3" = false

--- a/exercises/dominoes/.meta/tests.toml
+++ b/exercises/dominoes/.meta/tests.toml
@@ -1,37 +1,37 @@
 [canonical-tests]
 
 # empty input = empty output
-31a673f2-5e54-49fe-bd79-1c1dae476c9c = false
+"31a673f2-5e54-49fe-bd79-1c1dae476c9c" = false
 
 # singleton input = singleton output
-4f99b933-367b-404b-8c6d-36d5923ee476 = false
+"4f99b933-367b-404b-8c6d-36d5923ee476" = false
 
 # singleton that can't be chained
-91122d10-5ec7-47cb-b759-033756375869 = false
+"91122d10-5ec7-47cb-b759-033756375869" = false
 
 # three elements
-be8bc26b-fd3d-440b-8e9f-d698a0623be3 = false
+"be8bc26b-fd3d-440b-8e9f-d698a0623be3" = false
 
 # can reverse dominoes
-99e615c6-c059-401c-9e87-ad7af11fea5c = true
+"99e615c6-c059-401c-9e87-ad7af11fea5c" = true
 
 # can't be chained
-51f0c291-5d43-40c5-b316-0429069528c9 = false
+"51f0c291-5d43-40c5-b316-0429069528c9" = false
 
 # disconnected - simple
-9a75e078-a025-4c23-8c3a-238553657f39 = false
+"9a75e078-a025-4c23-8c3a-238553657f39" = false
 
 # disconnected - double loop
-0da0c7fe-d492-445d-b9ef-1f111f07a301 = false
+"0da0c7fe-d492-445d-b9ef-1f111f07a301" = false
 
 # disconnected - single isolated
-b6087ff0-f555-4ea0-a71c-f9d707c5994a = false
+"b6087ff0-f555-4ea0-a71c-f9d707c5994a" = false
 
 # need backtrack
-2174fbdc-8b48-4bac-9914-8090d06ef978 = true
+"2174fbdc-8b48-4bac-9914-8090d06ef978" = true
 
 # separate loops
-167bb480-dfd1-4318-a20d-4f90adb4a09f = true
+"167bb480-dfd1-4318-a20d-4f90adb4a09f" = true
 
 # nine elements
-cd061538-6046-45a7-ace9-6708fe8f6504 = true
+"cd061538-6046-45a7-ace9-6708fe8f6504" = true

--- a/exercises/etl/.meta/tests.toml
+++ b/exercises/etl/.meta/tests.toml
@@ -1,0 +1,13 @@
+[canonical-tests]
+
+# single letter
+"78a7a9f9-4490-4a47-8ee9-5a38bb47d28f" = true
+
+# single score with multiple letters
+"60dbd000-451d-44c7-bdbb-97c73ac1f497" = true
+
+# multiple scores with multiple letters
+"f5c5de0c-301f-4fdd-a0e5-df97d4214f54" = true
+
+# multiple scores with differing numbers of letters
+"5db8ea89-ecb4-4dcd-902f-2b418cc87b9d" = true

--- a/exercises/etl/.meta/tests.toml
+++ b/exercises/etl/.meta/tests.toml
@@ -1,13 +1,13 @@
 [canonical-tests]
 
 # single letter
-78a7a9f9-4490-4a47-8ee9-5a38bb47d28f = false
+"78a7a9f9-4490-4a47-8ee9-5a38bb47d28f" = false
 
 # single score with multiple letters
-60dbd000-451d-44c7-bdbb-97c73ac1f497 = false
+"60dbd000-451d-44c7-bdbb-97c73ac1f497" = false
 
 # multiple scores with multiple letters
-f5c5de0c-301f-4fdd-a0e5-df97d4214f54 = false
+"f5c5de0c-301f-4fdd-a0e5-df97d4214f54" = false
 
 # multiple scores with differing numbers of letters
-5db8ea89-ecb4-4dcd-902f-2b418cc87b9d = false
+"5db8ea89-ecb4-4dcd-902f-2b418cc87b9d" = false

--- a/exercises/etl/.meta/tests.toml
+++ b/exercises/etl/.meta/tests.toml
@@ -1,13 +1,13 @@
 [canonical-tests]
 
 # single letter
-"78a7a9f9-4490-4a47-8ee9-5a38bb47d28f" = true
+78a7a9f9-4490-4a47-8ee9-5a38bb47d28f = false
 
 # single score with multiple letters
-"60dbd000-451d-44c7-bdbb-97c73ac1f497" = true
+60dbd000-451d-44c7-bdbb-97c73ac1f497 = false
 
 # multiple scores with multiple letters
-"f5c5de0c-301f-4fdd-a0e5-df97d4214f54" = true
+f5c5de0c-301f-4fdd-a0e5-df97d4214f54 = false
 
 # multiple scores with differing numbers of letters
-"5db8ea89-ecb4-4dcd-902f-2b418cc87b9d" = true
+5db8ea89-ecb4-4dcd-902f-2b418cc87b9d = false

--- a/exercises/forth/.meta/tests.toml
+++ b/exercises/forth/.meta/tests.toml
@@ -1,0 +1,139 @@
+[canonical-tests]
+
+# numbers just get pushed onto the stack
+"9962203f-f00a-4a85-b404-8a8ecbcec09d" = true
+
+# can add two numbers
+"9e69588e-a3d8-41a3-a371-ea02206c1e6e" = true
+
+# errors if there is nothing on the stack
+"52336dd3-30da-4e5c-8523-bdf9a3427657" = true
+
+# errors if there is only one value on the stack
+"06efb9a4-817a-435e-b509-06166993c1b8" = true
+
+# can subtract two numbers
+"09687c99-7bbc-44af-8526-e402f997ccbf" = true
+
+# errors if there is nothing on the stack
+"5d63eee2-1f7d-4538-b475-e27682ab8032" = true
+
+# errors if there is only one value on the stack
+"b3cee1b2-9159-418a-b00d-a1bb3765c23b" = true
+
+# can multiply two numbers
+"5df0ceb5-922e-401f-974d-8287427dbf21" = true
+
+# errors if there is nothing on the stack
+"9e004339-15ac-4063-8ec1-5720f4e75046" = true
+
+# errors if there is only one value on the stack
+"8ba4b432-9f94-41e0-8fae-3b3712bd51b3" = true
+
+# can divide two numbers
+"e74c2204-b057-4cff-9aa9-31c7c97a93f5" = true
+
+# performs integer division
+"54f6711c-4b14-4bb0-98ad-d974a22c4620" = true
+
+# errors if dividing by zero
+"a5df3219-29b4-4d2f-b427-81f82f42a3f1" = true
+
+# errors if there is nothing on the stack
+"1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a" = true
+
+# errors if there is only one value on the stack
+"d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d" = true
+
+# addition and subtraction
+"ee28d729-6692-4a30-b9be-0d830c52a68c" = true
+
+# multiplication and division
+"40b197da-fa4b-4aca-a50b-f000d19422c1" = true
+
+# copies a value on the stack
+"c5758235-6eef-4bf6-ab62-c878e50b9957" = true
+
+# copies the top value on the stack
+"f6889006-5a40-41e7-beb3-43b09e5a22f4" = true
+
+# errors if there is nothing on the stack
+"40b7569c-8401-4bd4-a30d-9adf70d11bc4" = true
+
+# removes the top value on the stack if it is the only one
+"1971da68-1df2-4569-927a-72bf5bb7263c" = true
+
+# removes the top value on the stack if it is not the only one
+"8929d9f2-4a78-4e0f-90ad-be1a0f313fd9" = true
+
+# errors if there is nothing on the stack
+"6dd31873-6dd7-4cb8-9e90-7daa33ba045c" = true
+
+# swaps the top two values on the stack if they are the only ones
+"3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3" = true
+
+# swaps the top two values on the stack if they are not the only ones
+"8ce869d5-a503-44e4-ab55-1da36816ff1c" = true
+
+# errors if there is nothing on the stack
+"74ba5b2a-b028-4759-9176-c5c0e7b2b154" = true
+
+# errors if there is only one value on the stack
+"dd52e154-5d0d-4a5c-9e5d-73eb36052bc8" = true
+
+# copies the second element if there are only two
+"a2654074-ba68-4f93-b014-6b12693a8b50" = true
+
+# copies the second element if there are more than two
+"c5b51097-741a-4da7-8736-5c93fa856339" = true
+
+# errors if there is nothing on the stack
+"6e1703a6-5963-4a03-abba-02e77e3181fd" = true
+
+# errors if there is only one value on the stack
+"ee574dc4-ef71-46f6-8c6a-b4af3a10c45f" = true
+
+# can consist of built-in words
+"ed45cbbf-4dbf-4901-825b-54b20dbee53b" = true
+
+# execute in the right order
+"2726ea44-73e4-436b-bc2b-5ff0c6aa014b" = true
+
+# can override other user-defined words
+"9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33" = true
+
+# can override built-in words
+"669db3f3-5bd6-4be0-83d1-618cd6e4984b" = true
+
+# can override built-in operators
+"588de2f0-c56e-4c68-be0b-0bb1e603c500" = true
+
+# can use different words with the same name
+"ac12aaaf-26c6-4a10-8b3c-1c958fa2914c" = true
+
+# can define word that uses word with the same name
+"53f82ef0-2750-4ccb-ac04-5d8c1aefabb1" = true
+
+# cannot redefine numbers
+"35958cee-a976-4a0f-9378-f678518fa322" = true
+
+# errors if executing a non-existent word
+"5180f261-89dd-491e-b230-62737e09806f" = true
+
+# DUP is case-insensitive
+"7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6" = true
+
+# DROP is case-insensitive
+"339ed30b-f5b4-47ff-ab1c-67591a9cd336" = true
+
+# SWAP is case-insensitive
+"ee1af31e-1355-4b1b-bb95-f9d0b2961b87" = true
+
+# OVER is case-insensitive
+"acdc3a49-14c8-4cc2-945d-11edee6408fa" = true
+
+# user-defined words are case-insensitive
+"5934454f-a24f-4efc-9fdd-5794e5f0c23c" = true
+
+# definitions are case-insensitive
+"037d4299-195f-4be7-a46d-f07ca6280a06" = true

--- a/exercises/forth/.meta/tests.toml
+++ b/exercises/forth/.meta/tests.toml
@@ -1,139 +1,139 @@
 [canonical-tests]
 
 # numbers just get pushed onto the stack
-9962203f-f00a-4a85-b404-8a8ecbcec09d = true
+"9962203f-f00a-4a85-b404-8a8ecbcec09d" = true
 
 # can add two numbers
-9e69588e-a3d8-41a3-a371-ea02206c1e6e = true
+"9e69588e-a3d8-41a3-a371-ea02206c1e6e" = true
 
 # errors if there is nothing on the stack
-52336dd3-30da-4e5c-8523-bdf9a3427657 = false
+"52336dd3-30da-4e5c-8523-bdf9a3427657" = false
 
 # errors if there is only one value on the stack
-06efb9a4-817a-435e-b509-06166993c1b8 = false
+"06efb9a4-817a-435e-b509-06166993c1b8" = false
 
 # can subtract two numbers
-09687c99-7bbc-44af-8526-e402f997ccbf = true
+"09687c99-7bbc-44af-8526-e402f997ccbf" = true
 
 # errors if there is nothing on the stack
-5d63eee2-1f7d-4538-b475-e27682ab8032 = false
+"5d63eee2-1f7d-4538-b475-e27682ab8032" = false
 
 # errors if there is only one value on the stack
-b3cee1b2-9159-418a-b00d-a1bb3765c23b = false
+"b3cee1b2-9159-418a-b00d-a1bb3765c23b" = false
 
 # can multiply two numbers
-5df0ceb5-922e-401f-974d-8287427dbf21 = true
+"5df0ceb5-922e-401f-974d-8287427dbf21" = true
 
 # errors if there is nothing on the stack
-9e004339-15ac-4063-8ec1-5720f4e75046 = false
+"9e004339-15ac-4063-8ec1-5720f4e75046" = false
 
 # errors if there is only one value on the stack
-8ba4b432-9f94-41e0-8fae-3b3712bd51b3 = false
+"8ba4b432-9f94-41e0-8fae-3b3712bd51b3" = false
 
 # can divide two numbers
-e74c2204-b057-4cff-9aa9-31c7c97a93f5 = true
+"e74c2204-b057-4cff-9aa9-31c7c97a93f5" = true
 
 # performs integer division
-54f6711c-4b14-4bb0-98ad-d974a22c4620 = true
+"54f6711c-4b14-4bb0-98ad-d974a22c4620" = true
 
 # errors if dividing by zero
-a5df3219-29b4-4d2f-b427-81f82f42a3f1 = true
+"a5df3219-29b4-4d2f-b427-81f82f42a3f1" = true
 
 # errors if there is nothing on the stack
-1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a = false
+"1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a" = false
 
 # errors if there is only one value on the stack
-d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d = false
+"d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d" = false
 
 # addition and subtraction
-ee28d729-6692-4a30-b9be-0d830c52a68c = true
+"ee28d729-6692-4a30-b9be-0d830c52a68c" = true
 
 # multiplication and division
-40b197da-fa4b-4aca-a50b-f000d19422c1 = true
+"40b197da-fa4b-4aca-a50b-f000d19422c1" = true
 
 # copies a value on the stack
-c5758235-6eef-4bf6-ab62-c878e50b9957 = false
+"c5758235-6eef-4bf6-ab62-c878e50b9957" = false
 
 # copies the top value on the stack
-f6889006-5a40-41e7-beb3-43b09e5a22f4 = false
+"f6889006-5a40-41e7-beb3-43b09e5a22f4" = false
 
 # errors if there is nothing on the stack
-40b7569c-8401-4bd4-a30d-9adf70d11bc4 = false
+"40b7569c-8401-4bd4-a30d-9adf70d11bc4" = false
 
 # removes the top value on the stack if it is the only one
-1971da68-1df2-4569-927a-72bf5bb7263c = false
+"1971da68-1df2-4569-927a-72bf5bb7263c" = false
 
 # removes the top value on the stack if it is not the only one
-8929d9f2-4a78-4e0f-90ad-be1a0f313fd9 = false
+"8929d9f2-4a78-4e0f-90ad-be1a0f313fd9" = false
 
 # errors if there is nothing on the stack
-6dd31873-6dd7-4cb8-9e90-7daa33ba045c = false
+"6dd31873-6dd7-4cb8-9e90-7daa33ba045c" = false
 
 # swaps the top two values on the stack if they are the only ones
-3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3 = false
+"3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3" = false
 
 # swaps the top two values on the stack if they are not the only ones
-8ce869d5-a503-44e4-ab55-1da36816ff1c = false
+"8ce869d5-a503-44e4-ab55-1da36816ff1c" = false
 
 # errors if there is nothing on the stack
-74ba5b2a-b028-4759-9176-c5c0e7b2b154 = false
+"74ba5b2a-b028-4759-9176-c5c0e7b2b154" = false
 
 # errors if there is only one value on the stack
-dd52e154-5d0d-4a5c-9e5d-73eb36052bc8 = false
+"dd52e154-5d0d-4a5c-9e5d-73eb36052bc8" = false
 
 # copies the second element if there are only two
-a2654074-ba68-4f93-b014-6b12693a8b50 = false
+"a2654074-ba68-4f93-b014-6b12693a8b50" = false
 
 # copies the second element if there are more than two
-c5b51097-741a-4da7-8736-5c93fa856339 = false
+"c5b51097-741a-4da7-8736-5c93fa856339" = false
 
 # errors if there is nothing on the stack
-6e1703a6-5963-4a03-abba-02e77e3181fd = false
+"6e1703a6-5963-4a03-abba-02e77e3181fd" = false
 
 # errors if there is only one value on the stack
-ee574dc4-ef71-46f6-8c6a-b4af3a10c45f = false
+"ee574dc4-ef71-46f6-8c6a-b4af3a10c45f" = false
 
 # can consist of built-in words
-ed45cbbf-4dbf-4901-825b-54b20dbee53b = false
+"ed45cbbf-4dbf-4901-825b-54b20dbee53b" = false
 
 # execute in the right order
-2726ea44-73e4-436b-bc2b-5ff0c6aa014b = true
+"2726ea44-73e4-436b-bc2b-5ff0c6aa014b" = true
 
 # can override other user-defined words
-9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33 = false
+"9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33" = false
 
 # can override built-in words
-669db3f3-5bd6-4be0-83d1-618cd6e4984b = false
+"669db3f3-5bd6-4be0-83d1-618cd6e4984b" = false
 
 # can override built-in operators
-588de2f0-c56e-4c68-be0b-0bb1e603c500 = false
+"588de2f0-c56e-4c68-be0b-0bb1e603c500" = false
 
 # can use different words with the same name
-ac12aaaf-26c6-4a10-8b3c-1c958fa2914c = true
+"ac12aaaf-26c6-4a10-8b3c-1c958fa2914c" = true
 
 # can define word that uses word with the same name
-53f82ef0-2750-4ccb-ac04-5d8c1aefabb1 = true
+"53f82ef0-2750-4ccb-ac04-5d8c1aefabb1" = true
 
 # cannot redefine numbers
-35958cee-a976-4a0f-9378-f678518fa322 = false
+"35958cee-a976-4a0f-9378-f678518fa322" = false
 
 # errors if executing a non-existent word
-5180f261-89dd-491e-b230-62737e09806f = false
+"5180f261-89dd-491e-b230-62737e09806f" = false
 
 # DUP is case-insensitive
-7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6 = false
+"7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6" = false
 
 # DROP is case-insensitive
-339ed30b-f5b4-47ff-ab1c-67591a9cd336 = false
+"339ed30b-f5b4-47ff-ab1c-67591a9cd336" = false
 
 # SWAP is case-insensitive
-ee1af31e-1355-4b1b-bb95-f9d0b2961b87 = false
+"ee1af31e-1355-4b1b-bb95-f9d0b2961b87" = false
 
 # OVER is case-insensitive
-acdc3a49-14c8-4cc2-945d-11edee6408fa = false
+"acdc3a49-14c8-4cc2-945d-11edee6408fa" = false
 
 # user-defined words are case-insensitive
-5934454f-a24f-4efc-9fdd-5794e5f0c23c = false
+"5934454f-a24f-4efc-9fdd-5794e5f0c23c" = false
 
 # definitions are case-insensitive
-037d4299-195f-4be7-a46d-f07ca6280a06 = false
+"037d4299-195f-4be7-a46d-f07ca6280a06" = false

--- a/exercises/forth/.meta/tests.toml
+++ b/exercises/forth/.meta/tests.toml
@@ -1,139 +1,139 @@
 [canonical-tests]
 
 # numbers just get pushed onto the stack
-"9962203f-f00a-4a85-b404-8a8ecbcec09d" = true
+9962203f-f00a-4a85-b404-8a8ecbcec09d = true
 
 # can add two numbers
-"9e69588e-a3d8-41a3-a371-ea02206c1e6e" = true
+9e69588e-a3d8-41a3-a371-ea02206c1e6e = true
 
 # errors if there is nothing on the stack
-"52336dd3-30da-4e5c-8523-bdf9a3427657" = true
+52336dd3-30da-4e5c-8523-bdf9a3427657 = false
 
 # errors if there is only one value on the stack
-"06efb9a4-817a-435e-b509-06166993c1b8" = true
+06efb9a4-817a-435e-b509-06166993c1b8 = false
 
 # can subtract two numbers
-"09687c99-7bbc-44af-8526-e402f997ccbf" = true
+09687c99-7bbc-44af-8526-e402f997ccbf = true
 
 # errors if there is nothing on the stack
-"5d63eee2-1f7d-4538-b475-e27682ab8032" = true
+5d63eee2-1f7d-4538-b475-e27682ab8032 = false
 
 # errors if there is only one value on the stack
-"b3cee1b2-9159-418a-b00d-a1bb3765c23b" = true
+b3cee1b2-9159-418a-b00d-a1bb3765c23b = false
 
 # can multiply two numbers
-"5df0ceb5-922e-401f-974d-8287427dbf21" = true
+5df0ceb5-922e-401f-974d-8287427dbf21 = true
 
 # errors if there is nothing on the stack
-"9e004339-15ac-4063-8ec1-5720f4e75046" = true
+9e004339-15ac-4063-8ec1-5720f4e75046 = false
 
 # errors if there is only one value on the stack
-"8ba4b432-9f94-41e0-8fae-3b3712bd51b3" = true
+8ba4b432-9f94-41e0-8fae-3b3712bd51b3 = false
 
 # can divide two numbers
-"e74c2204-b057-4cff-9aa9-31c7c97a93f5" = true
+e74c2204-b057-4cff-9aa9-31c7c97a93f5 = true
 
 # performs integer division
-"54f6711c-4b14-4bb0-98ad-d974a22c4620" = true
+54f6711c-4b14-4bb0-98ad-d974a22c4620 = true
 
 # errors if dividing by zero
-"a5df3219-29b4-4d2f-b427-81f82f42a3f1" = true
+a5df3219-29b4-4d2f-b427-81f82f42a3f1 = true
 
 # errors if there is nothing on the stack
-"1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a" = true
+1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a = false
 
 # errors if there is only one value on the stack
-"d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d" = true
+d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d = false
 
 # addition and subtraction
-"ee28d729-6692-4a30-b9be-0d830c52a68c" = true
+ee28d729-6692-4a30-b9be-0d830c52a68c = true
 
 # multiplication and division
-"40b197da-fa4b-4aca-a50b-f000d19422c1" = true
+40b197da-fa4b-4aca-a50b-f000d19422c1 = true
 
 # copies a value on the stack
-"c5758235-6eef-4bf6-ab62-c878e50b9957" = true
+c5758235-6eef-4bf6-ab62-c878e50b9957 = false
 
 # copies the top value on the stack
-"f6889006-5a40-41e7-beb3-43b09e5a22f4" = true
+f6889006-5a40-41e7-beb3-43b09e5a22f4 = false
 
 # errors if there is nothing on the stack
-"40b7569c-8401-4bd4-a30d-9adf70d11bc4" = true
+40b7569c-8401-4bd4-a30d-9adf70d11bc4 = false
 
 # removes the top value on the stack if it is the only one
-"1971da68-1df2-4569-927a-72bf5bb7263c" = true
+1971da68-1df2-4569-927a-72bf5bb7263c = false
 
 # removes the top value on the stack if it is not the only one
-"8929d9f2-4a78-4e0f-90ad-be1a0f313fd9" = true
+8929d9f2-4a78-4e0f-90ad-be1a0f313fd9 = false
 
 # errors if there is nothing on the stack
-"6dd31873-6dd7-4cb8-9e90-7daa33ba045c" = true
+6dd31873-6dd7-4cb8-9e90-7daa33ba045c = false
 
 # swaps the top two values on the stack if they are the only ones
-"3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3" = true
+3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3 = false
 
 # swaps the top two values on the stack if they are not the only ones
-"8ce869d5-a503-44e4-ab55-1da36816ff1c" = true
+8ce869d5-a503-44e4-ab55-1da36816ff1c = false
 
 # errors if there is nothing on the stack
-"74ba5b2a-b028-4759-9176-c5c0e7b2b154" = true
+74ba5b2a-b028-4759-9176-c5c0e7b2b154 = false
 
 # errors if there is only one value on the stack
-"dd52e154-5d0d-4a5c-9e5d-73eb36052bc8" = true
+dd52e154-5d0d-4a5c-9e5d-73eb36052bc8 = false
 
 # copies the second element if there are only two
-"a2654074-ba68-4f93-b014-6b12693a8b50" = true
+a2654074-ba68-4f93-b014-6b12693a8b50 = false
 
 # copies the second element if there are more than two
-"c5b51097-741a-4da7-8736-5c93fa856339" = true
+c5b51097-741a-4da7-8736-5c93fa856339 = false
 
 # errors if there is nothing on the stack
-"6e1703a6-5963-4a03-abba-02e77e3181fd" = true
+6e1703a6-5963-4a03-abba-02e77e3181fd = false
 
 # errors if there is only one value on the stack
-"ee574dc4-ef71-46f6-8c6a-b4af3a10c45f" = true
+ee574dc4-ef71-46f6-8c6a-b4af3a10c45f = false
 
 # can consist of built-in words
-"ed45cbbf-4dbf-4901-825b-54b20dbee53b" = true
+ed45cbbf-4dbf-4901-825b-54b20dbee53b = false
 
 # execute in the right order
-"2726ea44-73e4-436b-bc2b-5ff0c6aa014b" = true
+2726ea44-73e4-436b-bc2b-5ff0c6aa014b = true
 
 # can override other user-defined words
-"9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33" = true
+9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33 = false
 
 # can override built-in words
-"669db3f3-5bd6-4be0-83d1-618cd6e4984b" = true
+669db3f3-5bd6-4be0-83d1-618cd6e4984b = false
 
 # can override built-in operators
-"588de2f0-c56e-4c68-be0b-0bb1e603c500" = true
+588de2f0-c56e-4c68-be0b-0bb1e603c500 = false
 
 # can use different words with the same name
-"ac12aaaf-26c6-4a10-8b3c-1c958fa2914c" = true
+ac12aaaf-26c6-4a10-8b3c-1c958fa2914c = true
 
 # can define word that uses word with the same name
-"53f82ef0-2750-4ccb-ac04-5d8c1aefabb1" = true
+53f82ef0-2750-4ccb-ac04-5d8c1aefabb1 = true
 
 # cannot redefine numbers
-"35958cee-a976-4a0f-9378-f678518fa322" = true
+35958cee-a976-4a0f-9378-f678518fa322 = false
 
 # errors if executing a non-existent word
-"5180f261-89dd-491e-b230-62737e09806f" = true
+5180f261-89dd-491e-b230-62737e09806f = false
 
 # DUP is case-insensitive
-"7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6" = true
+7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6 = false
 
 # DROP is case-insensitive
-"339ed30b-f5b4-47ff-ab1c-67591a9cd336" = true
+339ed30b-f5b4-47ff-ab1c-67591a9cd336 = false
 
 # SWAP is case-insensitive
-"ee1af31e-1355-4b1b-bb95-f9d0b2961b87" = true
+ee1af31e-1355-4b1b-bb95-f9d0b2961b87 = false
 
 # OVER is case-insensitive
-"acdc3a49-14c8-4cc2-945d-11edee6408fa" = true
+acdc3a49-14c8-4cc2-945d-11edee6408fa = false
 
 # user-defined words are case-insensitive
-"5934454f-a24f-4efc-9fdd-5794e5f0c23c" = true
+5934454f-a24f-4efc-9fdd-5794e5f0c23c = false
 
 # definitions are case-insensitive
-"037d4299-195f-4be7-a46d-f07ca6280a06" = true
+037d4299-195f-4be7-a46d-f07ca6280a06 = false

--- a/exercises/gigasecond/.meta/tests.toml
+++ b/exercises/gigasecond/.meta/tests.toml
@@ -1,0 +1,16 @@
+[canonical-tests]
+
+# date only specification of time
+"92fbe71c-ea52-4fac-bd77-be38023cacf7" = true
+
+# second test for date only specification of time
+"6d86dd16-6f7a-47be-9e58-bb9fb2ae1433" = true
+
+# third test for date only specification of time
+"77eb8502-2bca-4d92-89d9-7b39ace28dd5" = true
+
+# full time specified
+"c9d89a7d-06f8-4e28-a305-64f1b2abc693" = true
+
+# full time with day roll-over
+"09d4e30e-728a-4b52-9005-be44a58d9eba" = true

--- a/exercises/gigasecond/.meta/tests.toml
+++ b/exercises/gigasecond/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # date only specification of time
-"92fbe71c-ea52-4fac-bd77-be38023cacf7" = true
+92fbe71c-ea52-4fac-bd77-be38023cacf7 = false
 
 # second test for date only specification of time
-"6d86dd16-6f7a-47be-9e58-bb9fb2ae1433" = true
+6d86dd16-6f7a-47be-9e58-bb9fb2ae1433 = false
 
 # third test for date only specification of time
-"77eb8502-2bca-4d92-89d9-7b39ace28dd5" = true
+77eb8502-2bca-4d92-89d9-7b39ace28dd5 = false
 
 # full time specified
-"c9d89a7d-06f8-4e28-a305-64f1b2abc693" = true
+c9d89a7d-06f8-4e28-a305-64f1b2abc693 = false
 
 # full time with day roll-over
-"09d4e30e-728a-4b52-9005-be44a58d9eba" = true
+09d4e30e-728a-4b52-9005-be44a58d9eba = false

--- a/exercises/gigasecond/.meta/tests.toml
+++ b/exercises/gigasecond/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # date only specification of time
-92fbe71c-ea52-4fac-bd77-be38023cacf7 = false
+"92fbe71c-ea52-4fac-bd77-be38023cacf7" = false
 
 # second test for date only specification of time
-6d86dd16-6f7a-47be-9e58-bb9fb2ae1433 = false
+"6d86dd16-6f7a-47be-9e58-bb9fb2ae1433" = false
 
 # third test for date only specification of time
-77eb8502-2bca-4d92-89d9-7b39ace28dd5 = false
+"77eb8502-2bca-4d92-89d9-7b39ace28dd5" = false
 
 # full time specified
-c9d89a7d-06f8-4e28-a305-64f1b2abc693 = false
+"c9d89a7d-06f8-4e28-a305-64f1b2abc693" = false
 
 # full time with day roll-over
-09d4e30e-728a-4b52-9005-be44a58d9eba = false
+"09d4e30e-728a-4b52-9005-be44a58d9eba" = false

--- a/exercises/grade-school/.meta/tests.toml
+++ b/exercises/grade-school/.meta/tests.toml
@@ -1,0 +1,22 @@
+[canonical-tests]
+
+# Adding a student adds them to the sorted roster
+"6d0a30e4-1b4e-472e-8e20-c41702125667" = true
+
+# Adding more student adds them to the sorted roster
+"233be705-dd58-4968-889d-fb3c7954c9cc" = true
+
+# Adding students to different grades adds them to the same sorted roster
+"75a51579-d1d7-407c-a2f8-2166e984e8ab" = true
+
+# Roster returns an empty list if there are no students enrolled
+"a3f0fb58-f240-4723-8ddc-e644666b85cc" = true
+
+# Student names with grades are displayed in the same sorted roster
+"180a8ff9-5b94-43fc-9db1-d46b4a8c93b6" = true
+
+# Grade returns the students in that grade in alphabetical order
+"1bfbcef1-e4a3-49e8-8d22-f6f9f386187e" = true
+
+# Grade returns an empty list if there are no students in that grade
+"5e67aa3c-a3c6-4407-a183-d8fe59cd1630" = true

--- a/exercises/grade-school/.meta/tests.toml
+++ b/exercises/grade-school/.meta/tests.toml
@@ -1,22 +1,22 @@
 [canonical-tests]
 
 # Adding a student adds them to the sorted roster
-"6d0a30e4-1b4e-472e-8e20-c41702125667" = true
+6d0a30e4-1b4e-472e-8e20-c41702125667 = false
 
 # Adding more student adds them to the sorted roster
-"233be705-dd58-4968-889d-fb3c7954c9cc" = true
+233be705-dd58-4968-889d-fb3c7954c9cc = false
 
 # Adding students to different grades adds them to the same sorted roster
-"75a51579-d1d7-407c-a2f8-2166e984e8ab" = true
+75a51579-d1d7-407c-a2f8-2166e984e8ab = false
 
 # Roster returns an empty list if there are no students enrolled
-"a3f0fb58-f240-4723-8ddc-e644666b85cc" = true
+a3f0fb58-f240-4723-8ddc-e644666b85cc = false
 
 # Student names with grades are displayed in the same sorted roster
-"180a8ff9-5b94-43fc-9db1-d46b4a8c93b6" = true
+180a8ff9-5b94-43fc-9db1-d46b4a8c93b6 = false
 
 # Grade returns the students in that grade in alphabetical order
-"1bfbcef1-e4a3-49e8-8d22-f6f9f386187e" = true
+1bfbcef1-e4a3-49e8-8d22-f6f9f386187e = false
 
 # Grade returns an empty list if there are no students in that grade
-"5e67aa3c-a3c6-4407-a183-d8fe59cd1630" = true
+5e67aa3c-a3c6-4407-a183-d8fe59cd1630 = false

--- a/exercises/grade-school/.meta/tests.toml
+++ b/exercises/grade-school/.meta/tests.toml
@@ -1,22 +1,22 @@
 [canonical-tests]
 
 # Adding a student adds them to the sorted roster
-6d0a30e4-1b4e-472e-8e20-c41702125667 = false
+"6d0a30e4-1b4e-472e-8e20-c41702125667" = false
 
 # Adding more student adds them to the sorted roster
-233be705-dd58-4968-889d-fb3c7954c9cc = false
+"233be705-dd58-4968-889d-fb3c7954c9cc" = false
 
 # Adding students to different grades adds them to the same sorted roster
-75a51579-d1d7-407c-a2f8-2166e984e8ab = false
+"75a51579-d1d7-407c-a2f8-2166e984e8ab" = false
 
 # Roster returns an empty list if there are no students enrolled
-a3f0fb58-f240-4723-8ddc-e644666b85cc = false
+"a3f0fb58-f240-4723-8ddc-e644666b85cc" = false
 
 # Student names with grades are displayed in the same sorted roster
-180a8ff9-5b94-43fc-9db1-d46b4a8c93b6 = false
+"180a8ff9-5b94-43fc-9db1-d46b4a8c93b6" = false
 
 # Grade returns the students in that grade in alphabetical order
-1bfbcef1-e4a3-49e8-8d22-f6f9f386187e = false
+"1bfbcef1-e4a3-49e8-8d22-f6f9f386187e" = false
 
 # Grade returns an empty list if there are no students in that grade
-5e67aa3c-a3c6-4407-a183-d8fe59cd1630 = false
+"5e67aa3c-a3c6-4407-a183-d8fe59cd1630" = false

--- a/exercises/grep/.meta/tests.toml
+++ b/exercises/grep/.meta/tests.toml
@@ -1,0 +1,76 @@
+[canonical-tests]
+
+# One file, one match, no flags
+"9049fdfd-53a7-4480-a390-375203837d09" = true
+
+# One file, one match, print line numbers flag
+"76519cce-98e3-46cd-b287-aac31b1d77d6" = true
+
+# One file, one match, case-insensitive flag
+"af0b6d3c-e0e8-475e-a112-c0fc10a1eb30" = true
+
+# One file, one match, print file names flag
+"ff7af839-d1b8-4856-a53e-99283579b672" = true
+
+# One file, one match, match entire lines flag
+"8625238a-720c-4a16-81f2-924ec8e222cb" = true
+
+# One file, one match, multiple flags
+"2a6266b3-a60f-475c-a5f5-f5008a717d3e" = true
+
+# One file, several matches, no flags
+"842222da-32e8-4646-89df-0d38220f77a1" = true
+
+# One file, several matches, print line numbers flag
+"4d84f45f-a1d8-4c2e-a00e-0b292233828c" = true
+
+# One file, several matches, match entire lines flag
+"0a483b66-315b-45f5-bc85-3ce353a22539" = true
+
+# One file, several matches, case-insensitive flag
+"3d2ca86a-edd7-494c-8938-8eeed1c61cfa" = true
+
+# One file, several matches, inverted flag
+"1f52001f-f224-4521-9456-11120cad4432" = true
+
+# One file, no matches, various flags
+"7a6ede7f-7dd5-4364-8bf8-0697c53a09fe" = true
+
+# One file, one match, file flag takes precedence over line flag
+"3d3dfc23-8f2a-4e34-abd6-7b7d140291dc" = true
+
+# One file, several matches, inverted and match entire lines flags
+"87b21b24-b788-4d6e-a68b-7afe9ca141fe" = true
+
+# Multiple files, one match, no flags
+"ba496a23-6149-41c6-a027-28064ed533e5" = true
+
+# Multiple files, several matches, no flags
+"4539bd36-6daa-4bc3-8e45-051f69f5aa95" = true
+
+# Multiple files, several matches, print line numbers flag
+"9fb4cc67-78e2-4761-8e6b-a4b57aba1938" = true
+
+# Multiple files, one match, print file names flag
+"aeee1ef3-93c7-4cd5-af10-876f8c9ccc73" = true
+
+# Multiple files, several matches, case-insensitive flag
+"d69f3606-7d15-4ddf-89ae-01df198e6b6c" = true
+
+# Multiple files, several matches, inverted flag
+"82ef739d-6701-4086-b911-007d1a3deb21" = true
+
+# Multiple files, one match, match entire lines flag
+"77b2eb07-2921-4ea0-8971-7636b44f5d29" = true
+
+# Multiple files, one match, multiple flags
+"e53a2842-55bb-4078-9bb5-04ac38929989" = true
+
+# Multiple files, no matches, various flags
+"9c4f7f9a-a555-4e32-bb06-4b8f8869b2cb" = true
+
+# Multiple files, several matches, file flag takes precedence over line number flag
+"ba5a540d-bffd-481b-bd0c-d9a30f225e01" = true
+
+# Multiple files, several matches, inverted and match entire lines flags
+"ff406330-2f0b-4b17-9ee4-4b71c31dd6d2" = true

--- a/exercises/grep/.meta/tests.toml
+++ b/exercises/grep/.meta/tests.toml
@@ -1,76 +1,76 @@
 [canonical-tests]
 
 # One file, one match, no flags
-9049fdfd-53a7-4480-a390-375203837d09 = false
+"9049fdfd-53a7-4480-a390-375203837d09" = false
 
 # One file, one match, print line numbers flag
-76519cce-98e3-46cd-b287-aac31b1d77d6 = false
+"76519cce-98e3-46cd-b287-aac31b1d77d6" = false
 
 # One file, one match, case-insensitive flag
-af0b6d3c-e0e8-475e-a112-c0fc10a1eb30 = false
+"af0b6d3c-e0e8-475e-a112-c0fc10a1eb30" = false
 
 # One file, one match, print file names flag
-ff7af839-d1b8-4856-a53e-99283579b672 = false
+"ff7af839-d1b8-4856-a53e-99283579b672" = false
 
 # One file, one match, match entire lines flag
-8625238a-720c-4a16-81f2-924ec8e222cb = false
+"8625238a-720c-4a16-81f2-924ec8e222cb" = false
 
 # One file, one match, multiple flags
-2a6266b3-a60f-475c-a5f5-f5008a717d3e = false
+"2a6266b3-a60f-475c-a5f5-f5008a717d3e" = false
 
 # One file, several matches, no flags
-842222da-32e8-4646-89df-0d38220f77a1 = false
+"842222da-32e8-4646-89df-0d38220f77a1" = false
 
 # One file, several matches, print line numbers flag
-4d84f45f-a1d8-4c2e-a00e-0b292233828c = false
+"4d84f45f-a1d8-4c2e-a00e-0b292233828c" = false
 
 # One file, several matches, match entire lines flag
-0a483b66-315b-45f5-bc85-3ce353a22539 = false
+"0a483b66-315b-45f5-bc85-3ce353a22539" = false
 
 # One file, several matches, case-insensitive flag
-3d2ca86a-edd7-494c-8938-8eeed1c61cfa = false
+"3d2ca86a-edd7-494c-8938-8eeed1c61cfa" = false
 
 # One file, several matches, inverted flag
-1f52001f-f224-4521-9456-11120cad4432 = false
+"1f52001f-f224-4521-9456-11120cad4432" = false
 
 # One file, no matches, various flags
-7a6ede7f-7dd5-4364-8bf8-0697c53a09fe = false
+"7a6ede7f-7dd5-4364-8bf8-0697c53a09fe" = false
 
 # One file, one match, file flag takes precedence over line flag
-3d3dfc23-8f2a-4e34-abd6-7b7d140291dc = false
+"3d3dfc23-8f2a-4e34-abd6-7b7d140291dc" = false
 
 # One file, several matches, inverted and match entire lines flags
-87b21b24-b788-4d6e-a68b-7afe9ca141fe = false
+"87b21b24-b788-4d6e-a68b-7afe9ca141fe" = false
 
 # Multiple files, one match, no flags
-ba496a23-6149-41c6-a027-28064ed533e5 = false
+"ba496a23-6149-41c6-a027-28064ed533e5" = false
 
 # Multiple files, several matches, no flags
-4539bd36-6daa-4bc3-8e45-051f69f5aa95 = false
+"4539bd36-6daa-4bc3-8e45-051f69f5aa95" = false
 
 # Multiple files, several matches, print line numbers flag
-9fb4cc67-78e2-4761-8e6b-a4b57aba1938 = false
+"9fb4cc67-78e2-4761-8e6b-a4b57aba1938" = false
 
 # Multiple files, one match, print file names flag
-aeee1ef3-93c7-4cd5-af10-876f8c9ccc73 = false
+"aeee1ef3-93c7-4cd5-af10-876f8c9ccc73" = false
 
 # Multiple files, several matches, case-insensitive flag
-d69f3606-7d15-4ddf-89ae-01df198e6b6c = false
+"d69f3606-7d15-4ddf-89ae-01df198e6b6c" = false
 
 # Multiple files, several matches, inverted flag
-82ef739d-6701-4086-b911-007d1a3deb21 = false
+"82ef739d-6701-4086-b911-007d1a3deb21" = false
 
 # Multiple files, one match, match entire lines flag
-77b2eb07-2921-4ea0-8971-7636b44f5d29 = false
+"77b2eb07-2921-4ea0-8971-7636b44f5d29" = false
 
 # Multiple files, one match, multiple flags
-e53a2842-55bb-4078-9bb5-04ac38929989 = false
+"e53a2842-55bb-4078-9bb5-04ac38929989" = false
 
 # Multiple files, no matches, various flags
-9c4f7f9a-a555-4e32-bb06-4b8f8869b2cb = false
+"9c4f7f9a-a555-4e32-bb06-4b8f8869b2cb" = false
 
 # Multiple files, several matches, file flag takes precedence over line number flag
-ba5a540d-bffd-481b-bd0c-d9a30f225e01 = false
+"ba5a540d-bffd-481b-bd0c-d9a30f225e01" = false
 
 # Multiple files, several matches, inverted and match entire lines flags
-ff406330-2f0b-4b17-9ee4-4b71c31dd6d2 = false
+"ff406330-2f0b-4b17-9ee4-4b71c31dd6d2" = false

--- a/exercises/grep/.meta/tests.toml
+++ b/exercises/grep/.meta/tests.toml
@@ -1,76 +1,76 @@
 [canonical-tests]
 
 # One file, one match, no flags
-"9049fdfd-53a7-4480-a390-375203837d09" = true
+9049fdfd-53a7-4480-a390-375203837d09 = false
 
 # One file, one match, print line numbers flag
-"76519cce-98e3-46cd-b287-aac31b1d77d6" = true
+76519cce-98e3-46cd-b287-aac31b1d77d6 = false
 
 # One file, one match, case-insensitive flag
-"af0b6d3c-e0e8-475e-a112-c0fc10a1eb30" = true
+af0b6d3c-e0e8-475e-a112-c0fc10a1eb30 = false
 
 # One file, one match, print file names flag
-"ff7af839-d1b8-4856-a53e-99283579b672" = true
+ff7af839-d1b8-4856-a53e-99283579b672 = false
 
 # One file, one match, match entire lines flag
-"8625238a-720c-4a16-81f2-924ec8e222cb" = true
+8625238a-720c-4a16-81f2-924ec8e222cb = false
 
 # One file, one match, multiple flags
-"2a6266b3-a60f-475c-a5f5-f5008a717d3e" = true
+2a6266b3-a60f-475c-a5f5-f5008a717d3e = false
 
 # One file, several matches, no flags
-"842222da-32e8-4646-89df-0d38220f77a1" = true
+842222da-32e8-4646-89df-0d38220f77a1 = false
 
 # One file, several matches, print line numbers flag
-"4d84f45f-a1d8-4c2e-a00e-0b292233828c" = true
+4d84f45f-a1d8-4c2e-a00e-0b292233828c = false
 
 # One file, several matches, match entire lines flag
-"0a483b66-315b-45f5-bc85-3ce353a22539" = true
+0a483b66-315b-45f5-bc85-3ce353a22539 = false
 
 # One file, several matches, case-insensitive flag
-"3d2ca86a-edd7-494c-8938-8eeed1c61cfa" = true
+3d2ca86a-edd7-494c-8938-8eeed1c61cfa = false
 
 # One file, several matches, inverted flag
-"1f52001f-f224-4521-9456-11120cad4432" = true
+1f52001f-f224-4521-9456-11120cad4432 = false
 
 # One file, no matches, various flags
-"7a6ede7f-7dd5-4364-8bf8-0697c53a09fe" = true
+7a6ede7f-7dd5-4364-8bf8-0697c53a09fe = false
 
 # One file, one match, file flag takes precedence over line flag
-"3d3dfc23-8f2a-4e34-abd6-7b7d140291dc" = true
+3d3dfc23-8f2a-4e34-abd6-7b7d140291dc = false
 
 # One file, several matches, inverted and match entire lines flags
-"87b21b24-b788-4d6e-a68b-7afe9ca141fe" = true
+87b21b24-b788-4d6e-a68b-7afe9ca141fe = false
 
 # Multiple files, one match, no flags
-"ba496a23-6149-41c6-a027-28064ed533e5" = true
+ba496a23-6149-41c6-a027-28064ed533e5 = false
 
 # Multiple files, several matches, no flags
-"4539bd36-6daa-4bc3-8e45-051f69f5aa95" = true
+4539bd36-6daa-4bc3-8e45-051f69f5aa95 = false
 
 # Multiple files, several matches, print line numbers flag
-"9fb4cc67-78e2-4761-8e6b-a4b57aba1938" = true
+9fb4cc67-78e2-4761-8e6b-a4b57aba1938 = false
 
 # Multiple files, one match, print file names flag
-"aeee1ef3-93c7-4cd5-af10-876f8c9ccc73" = true
+aeee1ef3-93c7-4cd5-af10-876f8c9ccc73 = false
 
 # Multiple files, several matches, case-insensitive flag
-"d69f3606-7d15-4ddf-89ae-01df198e6b6c" = true
+d69f3606-7d15-4ddf-89ae-01df198e6b6c = false
 
 # Multiple files, several matches, inverted flag
-"82ef739d-6701-4086-b911-007d1a3deb21" = true
+82ef739d-6701-4086-b911-007d1a3deb21 = false
 
 # Multiple files, one match, match entire lines flag
-"77b2eb07-2921-4ea0-8971-7636b44f5d29" = true
+77b2eb07-2921-4ea0-8971-7636b44f5d29 = false
 
 # Multiple files, one match, multiple flags
-"e53a2842-55bb-4078-9bb5-04ac38929989" = true
+e53a2842-55bb-4078-9bb5-04ac38929989 = false
 
 # Multiple files, no matches, various flags
-"9c4f7f9a-a555-4e32-bb06-4b8f8869b2cb" = true
+9c4f7f9a-a555-4e32-bb06-4b8f8869b2cb = false
 
 # Multiple files, several matches, file flag takes precedence over line number flag
-"ba5a540d-bffd-481b-bd0c-d9a30f225e01" = true
+ba5a540d-bffd-481b-bd0c-d9a30f225e01 = false
 
 # Multiple files, several matches, inverted and match entire lines flags
-"ff406330-2f0b-4b17-9ee4-4b71c31dd6d2" = true
+ff406330-2f0b-4b17-9ee4-4b71c31dd6d2 = false

--- a/exercises/hamming/.meta/tests.toml
+++ b/exercises/hamming/.meta/tests.toml
@@ -1,0 +1,28 @@
+[canonical-tests]
+
+# empty strands
+"f6dcb64f-03b0-4b60-81b1-3c9dbf47e887" = true
+
+# single letter identical strands
+"54681314-eee2-439a-9db0-b0636c656156" = true
+
+# single letter different strands
+"294479a3-a4c8-478f-8d63-6209815a827b" = true
+
+# long identical strands
+"9aed5f34-5693-4344-9b31-40c692fb5592" = true
+
+# long different strands
+"cd2273a5-c576-46c8-a52b-dee251c3e6e5" = true
+
+# disallow first strand longer
+"919f8ef0-b767-4d1b-8516-6379d07fcb28" = true
+
+# disallow second strand longer
+"8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e" = true
+
+# disallow left empty strand
+"5dce058b-28d4-4ca7-aa64-adfe4e17784c" = true
+
+# disallow right empty strand
+"38826d4b-16fb-4639-ac3e-ba027dec8b5f" = true

--- a/exercises/hamming/.meta/tests.toml
+++ b/exercises/hamming/.meta/tests.toml
@@ -1,28 +1,28 @@
 [canonical-tests]
 
 # empty strands
-f6dcb64f-03b0-4b60-81b1-3c9dbf47e887 = false
+"f6dcb64f-03b0-4b60-81b1-3c9dbf47e887" = false
 
 # single letter identical strands
-54681314-eee2-439a-9db0-b0636c656156 = false
+"54681314-eee2-439a-9db0-b0636c656156" = false
 
 # single letter different strands
-294479a3-a4c8-478f-8d63-6209815a827b = false
+"294479a3-a4c8-478f-8d63-6209815a827b" = false
 
 # long identical strands
-9aed5f34-5693-4344-9b31-40c692fb5592 = false
+"9aed5f34-5693-4344-9b31-40c692fb5592" = false
 
 # long different strands
-cd2273a5-c576-46c8-a52b-dee251c3e6e5 = false
+"cd2273a5-c576-46c8-a52b-dee251c3e6e5" = false
 
 # disallow first strand longer
-919f8ef0-b767-4d1b-8516-6379d07fcb28 = false
+"919f8ef0-b767-4d1b-8516-6379d07fcb28" = false
 
 # disallow second strand longer
-8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e = false
+"8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e" = false
 
 # disallow left empty strand
-5dce058b-28d4-4ca7-aa64-adfe4e17784c = false
+"5dce058b-28d4-4ca7-aa64-adfe4e17784c" = false
 
 # disallow right empty strand
-38826d4b-16fb-4639-ac3e-ba027dec8b5f = false
+"38826d4b-16fb-4639-ac3e-ba027dec8b5f" = false

--- a/exercises/hamming/.meta/tests.toml
+++ b/exercises/hamming/.meta/tests.toml
@@ -1,28 +1,28 @@
 [canonical-tests]
 
 # empty strands
-"f6dcb64f-03b0-4b60-81b1-3c9dbf47e887" = true
+f6dcb64f-03b0-4b60-81b1-3c9dbf47e887 = false
 
 # single letter identical strands
-"54681314-eee2-439a-9db0-b0636c656156" = true
+54681314-eee2-439a-9db0-b0636c656156 = false
 
 # single letter different strands
-"294479a3-a4c8-478f-8d63-6209815a827b" = true
+294479a3-a4c8-478f-8d63-6209815a827b = false
 
 # long identical strands
-"9aed5f34-5693-4344-9b31-40c692fb5592" = true
+9aed5f34-5693-4344-9b31-40c692fb5592 = false
 
 # long different strands
-"cd2273a5-c576-46c8-a52b-dee251c3e6e5" = true
+cd2273a5-c576-46c8-a52b-dee251c3e6e5 = false
 
 # disallow first strand longer
-"919f8ef0-b767-4d1b-8516-6379d07fcb28" = true
+919f8ef0-b767-4d1b-8516-6379d07fcb28 = false
 
 # disallow second strand longer
-"8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e" = true
+8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e = false
 
 # disallow left empty strand
-"5dce058b-28d4-4ca7-aa64-adfe4e17784c" = true
+5dce058b-28d4-4ca7-aa64-adfe4e17784c = false
 
 # disallow right empty strand
-"38826d4b-16fb-4639-ac3e-ba027dec8b5f" = true
+38826d4b-16fb-4639-ac3e-ba027dec8b5f = false

--- a/exercises/hello-world/.meta/tests.toml
+++ b/exercises/hello-world/.meta/tests.toml
@@ -1,0 +1,4 @@
+[canonical-tests]
+
+# Say Hi!
+"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true

--- a/exercises/hello-world/.meta/tests.toml
+++ b/exercises/hello-world/.meta/tests.toml
@@ -1,4 +1,4 @@
 [canonical-tests]
 
 # Say Hi!
-af9ffe10-dc13-42d8-a742-e7bdafac449d = false
+"af9ffe10-dc13-42d8-a742-e7bdafac449d" = false

--- a/exercises/hello-world/.meta/tests.toml
+++ b/exercises/hello-world/.meta/tests.toml
@@ -1,4 +1,4 @@
 [canonical-tests]
 
 # Say Hi!
-"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true
+af9ffe10-dc13-42d8-a742-e7bdafac449d = false

--- a/exercises/high-scores/.meta/tests.toml
+++ b/exercises/high-scores/.meta/tests.toml
@@ -1,0 +1,25 @@
+[canonical-tests]
+
+# List of scores
+"1035eb93-2208-4c22-bab8-fef06769a73c" = true
+
+# Latest score
+"6aa5dbf5-78fa-4375-b22c-ffaa989732d2" = true
+
+# Personal best
+"b661a2e1-aebf-4f50-9139-0fb817dd12c6" = true
+
+# Personal top three from a list of scores
+"3d996a97-c81c-4642-9afc-80b80dc14015" = true
+
+# Personal top highest to lowest
+"1084ecb5-3eb4-46fe-a816-e40331a4e83a" = true
+
+# Personal top when there is a tie
+"e6465b6b-5a11-4936-bfe3-35241c4f4f16" = true
+
+# Personal top when there are less than 3
+"f73b02af-c8fd-41c9-91b9-c86eaa86bce2" = true
+
+# Personal top when there is only one
+"16608eae-f60f-4a88-800e-aabce5df2865" = true

--- a/exercises/high-scores/.meta/tests.toml
+++ b/exercises/high-scores/.meta/tests.toml
@@ -1,25 +1,25 @@
 [canonical-tests]
 
 # List of scores
-1035eb93-2208-4c22-bab8-fef06769a73c = false
+"1035eb93-2208-4c22-bab8-fef06769a73c" = false
 
 # Latest score
-6aa5dbf5-78fa-4375-b22c-ffaa989732d2 = false
+"6aa5dbf5-78fa-4375-b22c-ffaa989732d2" = false
 
 # Personal best
-b661a2e1-aebf-4f50-9139-0fb817dd12c6 = false
+"b661a2e1-aebf-4f50-9139-0fb817dd12c6" = false
 
 # Personal top three from a list of scores
-3d996a97-c81c-4642-9afc-80b80dc14015 = false
+"3d996a97-c81c-4642-9afc-80b80dc14015" = false
 
 # Personal top highest to lowest
-1084ecb5-3eb4-46fe-a816-e40331a4e83a = false
+"1084ecb5-3eb4-46fe-a816-e40331a4e83a" = false
 
 # Personal top when there is a tie
-e6465b6b-5a11-4936-bfe3-35241c4f4f16 = false
+"e6465b6b-5a11-4936-bfe3-35241c4f4f16" = false
 
 # Personal top when there are less than 3
-f73b02af-c8fd-41c9-91b9-c86eaa86bce2 = false
+"f73b02af-c8fd-41c9-91b9-c86eaa86bce2" = false
 
 # Personal top when there is only one
-16608eae-f60f-4a88-800e-aabce5df2865 = false
+"16608eae-f60f-4a88-800e-aabce5df2865" = false

--- a/exercises/high-scores/.meta/tests.toml
+++ b/exercises/high-scores/.meta/tests.toml
@@ -1,25 +1,25 @@
 [canonical-tests]
 
 # List of scores
-"1035eb93-2208-4c22-bab8-fef06769a73c" = true
+1035eb93-2208-4c22-bab8-fef06769a73c = false
 
 # Latest score
-"6aa5dbf5-78fa-4375-b22c-ffaa989732d2" = true
+6aa5dbf5-78fa-4375-b22c-ffaa989732d2 = false
 
 # Personal best
-"b661a2e1-aebf-4f50-9139-0fb817dd12c6" = true
+b661a2e1-aebf-4f50-9139-0fb817dd12c6 = false
 
 # Personal top three from a list of scores
-"3d996a97-c81c-4642-9afc-80b80dc14015" = true
+3d996a97-c81c-4642-9afc-80b80dc14015 = false
 
 # Personal top highest to lowest
-"1084ecb5-3eb4-46fe-a816-e40331a4e83a" = true
+1084ecb5-3eb4-46fe-a816-e40331a4e83a = false
 
 # Personal top when there is a tie
-"e6465b6b-5a11-4936-bfe3-35241c4f4f16" = true
+e6465b6b-5a11-4936-bfe3-35241c4f4f16 = false
 
 # Personal top when there are less than 3
-"f73b02af-c8fd-41c9-91b9-c86eaa86bce2" = true
+f73b02af-c8fd-41c9-91b9-c86eaa86bce2 = false
 
 # Personal top when there is only one
-"16608eae-f60f-4a88-800e-aabce5df2865" = true
+16608eae-f60f-4a88-800e-aabce5df2865 = false

--- a/exercises/isbn-verifier/.meta/tests.toml
+++ b/exercises/isbn-verifier/.meta/tests.toml
@@ -1,0 +1,52 @@
+[canonical-tests]
+
+# valid isbn number
+"0caa3eac-d2e3-4c29-8df8-b188bc8c9292" = true
+
+# invalid isbn check digit
+"19f76b53-7c24-45f8-87b8-4604d0ccd248" = true
+
+# valid isbn number with a check digit of 10
+"4164bfee-fb0a-4a1c-9f70-64c6a1903dcd" = true
+
+# check digit is a character other than X
+"3ed50db1-8982-4423-a993-93174a20825c" = true
+
+# invalid character in isbn
+"c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec" = true
+
+# X is only valid as a check digit
+"28025280-2c39-4092-9719-f3234b89c627" = true
+
+# valid isbn without separating dashes
+"f6294e61-7e79-46b3-977b-f48789a4945b" = true
+
+# isbn without separating dashes and X as check digit
+"185ab99b-3a1b-45f3-aeec-b80d80b07f0b" = true
+
+# isbn without check digit and dashes
+"7725a837-ec8e-4528-a92a-d981dd8cf3e2" = true
+
+# too long isbn and no dashes
+"47e4dfba-9c20-46ed-9958-4d3190630bdf" = true
+
+# too short isbn
+"737f4e91-cbba-4175-95bf-ae630b41fb60" = true
+
+# isbn without check digit
+"5458a128-a9b6-4ff8-8afb-674e74567cef" = true
+
+# check digit of X should not be used for 0
+"70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7" = true
+
+# empty isbn
+"94610459-55ab-4c35-9b93-ff6ea1a8e562" = true
+
+# input is 9 characters
+"7bff28d4-d770-48cc-80d6-b20b3a0fb46c" = true
+
+# invalid characters are not ignored
+"ed6e8d1b-382c-4081-8326-8b772c581fec" = true
+
+# input is too long but contains a valid isbn
+"fb5e48d8-7c03-4bfb-a088-b101df16fdc3" = true

--- a/exercises/isbn-verifier/.meta/tests.toml
+++ b/exercises/isbn-verifier/.meta/tests.toml
@@ -1,52 +1,52 @@
 [canonical-tests]
 
 # valid isbn number
-"0caa3eac-d2e3-4c29-8df8-b188bc8c9292" = true
+0caa3eac-d2e3-4c29-8df8-b188bc8c9292 = false
 
 # invalid isbn check digit
-"19f76b53-7c24-45f8-87b8-4604d0ccd248" = true
+19f76b53-7c24-45f8-87b8-4604d0ccd248 = false
 
 # valid isbn number with a check digit of 10
-"4164bfee-fb0a-4a1c-9f70-64c6a1903dcd" = true
+4164bfee-fb0a-4a1c-9f70-64c6a1903dcd = false
 
 # check digit is a character other than X
-"3ed50db1-8982-4423-a993-93174a20825c" = true
+3ed50db1-8982-4423-a993-93174a20825c = false
 
 # invalid character in isbn
-"c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec" = true
+c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec = false
 
 # X is only valid as a check digit
-"28025280-2c39-4092-9719-f3234b89c627" = true
+28025280-2c39-4092-9719-f3234b89c627 = false
 
 # valid isbn without separating dashes
-"f6294e61-7e79-46b3-977b-f48789a4945b" = true
+f6294e61-7e79-46b3-977b-f48789a4945b = false
 
 # isbn without separating dashes and X as check digit
-"185ab99b-3a1b-45f3-aeec-b80d80b07f0b" = true
+185ab99b-3a1b-45f3-aeec-b80d80b07f0b = false
 
 # isbn without check digit and dashes
-"7725a837-ec8e-4528-a92a-d981dd8cf3e2" = true
+7725a837-ec8e-4528-a92a-d981dd8cf3e2 = false
 
 # too long isbn and no dashes
-"47e4dfba-9c20-46ed-9958-4d3190630bdf" = true
+47e4dfba-9c20-46ed-9958-4d3190630bdf = false
 
 # too short isbn
-"737f4e91-cbba-4175-95bf-ae630b41fb60" = true
+737f4e91-cbba-4175-95bf-ae630b41fb60 = true
 
 # isbn without check digit
-"5458a128-a9b6-4ff8-8afb-674e74567cef" = true
+5458a128-a9b6-4ff8-8afb-674e74567cef = false
 
 # check digit of X should not be used for 0
-"70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7" = true
+70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7 = false
 
 # empty isbn
-"94610459-55ab-4c35-9b93-ff6ea1a8e562" = true
+94610459-55ab-4c35-9b93-ff6ea1a8e562 = true
 
 # input is 9 characters
-"7bff28d4-d770-48cc-80d6-b20b3a0fb46c" = true
+7bff28d4-d770-48cc-80d6-b20b3a0fb46c = true
 
 # invalid characters are not ignored
-"ed6e8d1b-382c-4081-8326-8b772c581fec" = true
+ed6e8d1b-382c-4081-8326-8b772c581fec = true
 
 # input is too long but contains a valid isbn
-"fb5e48d8-7c03-4bfb-a088-b101df16fdc3" = true
+fb5e48d8-7c03-4bfb-a088-b101df16fdc3 = false

--- a/exercises/isbn-verifier/.meta/tests.toml
+++ b/exercises/isbn-verifier/.meta/tests.toml
@@ -1,52 +1,52 @@
 [canonical-tests]
 
 # valid isbn number
-0caa3eac-d2e3-4c29-8df8-b188bc8c9292 = false
+"0caa3eac-d2e3-4c29-8df8-b188bc8c9292" = false
 
 # invalid isbn check digit
-19f76b53-7c24-45f8-87b8-4604d0ccd248 = false
+"19f76b53-7c24-45f8-87b8-4604d0ccd248" = false
 
 # valid isbn number with a check digit of 10
-4164bfee-fb0a-4a1c-9f70-64c6a1903dcd = false
+"4164bfee-fb0a-4a1c-9f70-64c6a1903dcd" = false
 
 # check digit is a character other than X
-3ed50db1-8982-4423-a993-93174a20825c = false
+"3ed50db1-8982-4423-a993-93174a20825c" = false
 
 # invalid character in isbn
-c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec = false
+"c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec" = false
 
 # X is only valid as a check digit
-28025280-2c39-4092-9719-f3234b89c627 = false
+"28025280-2c39-4092-9719-f3234b89c627" = false
 
 # valid isbn without separating dashes
-f6294e61-7e79-46b3-977b-f48789a4945b = false
+"f6294e61-7e79-46b3-977b-f48789a4945b" = false
 
 # isbn without separating dashes and X as check digit
-185ab99b-3a1b-45f3-aeec-b80d80b07f0b = false
+"185ab99b-3a1b-45f3-aeec-b80d80b07f0b" = false
 
 # isbn without check digit and dashes
-7725a837-ec8e-4528-a92a-d981dd8cf3e2 = false
+"7725a837-ec8e-4528-a92a-d981dd8cf3e2" = false
 
 # too long isbn and no dashes
-47e4dfba-9c20-46ed-9958-4d3190630bdf = false
+"47e4dfba-9c20-46ed-9958-4d3190630bdf" = false
 
 # too short isbn
-737f4e91-cbba-4175-95bf-ae630b41fb60 = true
+"737f4e91-cbba-4175-95bf-ae630b41fb60" = true
 
 # isbn without check digit
-5458a128-a9b6-4ff8-8afb-674e74567cef = false
+"5458a128-a9b6-4ff8-8afb-674e74567cef" = false
 
 # check digit of X should not be used for 0
-70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7 = false
+"70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7" = false
 
 # empty isbn
-94610459-55ab-4c35-9b93-ff6ea1a8e562 = true
+"94610459-55ab-4c35-9b93-ff6ea1a8e562" = true
 
 # input is 9 characters
-7bff28d4-d770-48cc-80d6-b20b3a0fb46c = true
+"7bff28d4-d770-48cc-80d6-b20b3a0fb46c" = true
 
 # invalid characters are not ignored
-ed6e8d1b-382c-4081-8326-8b772c581fec = true
+"ed6e8d1b-382c-4081-8326-8b772c581fec" = true
 
 # input is too long but contains a valid isbn
-fb5e48d8-7c03-4bfb-a088-b101df16fdc3 = false
+"fb5e48d8-7c03-4bfb-a088-b101df16fdc3" = false

--- a/exercises/isogram/.meta/tests.toml
+++ b/exercises/isogram/.meta/tests.toml
@@ -1,0 +1,40 @@
+[canonical-tests]
+
+# empty string
+"a0e97d2d-669e-47c7-8134-518a1e2c4555" = true
+
+# isogram with only lower case characters
+"9a001b50-f194-4143-bc29-2af5ec1ef652" = true
+
+# word with one duplicated character
+"8ddb0ca3-276e-4f8b-89da-d95d5bae78a4" = true
+
+# word with one duplicated character from the end of the alphabet
+"6450b333-cbc2-4b24-a723-0b459b34fe18" = true
+
+# longest reported english isogram
+"a15ff557-dd04-4764-99e7-02cc1a385863" = true
+
+# word with duplicated character in mixed case
+"f1a7f6c7-a42f-4915-91d7-35b2ea11c92e" = true
+
+# word with duplicated character in mixed case, lowercase first
+"14a4f3c1-3b47-4695-b645-53d328298942" = true
+
+# hypothetical isogrammic word with hyphen
+"423b850c-7090-4a8a-b057-97f1cadd7c42" = true
+
+# hypothetical word with duplicated character following hyphen
+"93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2" = true
+
+# isogram with duplicated hyphen
+"36b30e5c-173f-49c6-a515-93a3e825553f" = true
+
+# made-up name that is an isogram
+"cdabafa0-c9f4-4c1f-b142-689c6ee17d93" = true
+
+# duplicated character in the middle
+"5fc61048-d74e-48fd-bc34-abfc21552d4d" = true
+
+# same first and last characters
+"310ac53d-8932-47bc-bbb4-b2b94f25a83e" = true

--- a/exercises/isogram/.meta/tests.toml
+++ b/exercises/isogram/.meta/tests.toml
@@ -1,40 +1,40 @@
 [canonical-tests]
 
 # empty string
-"a0e97d2d-669e-47c7-8134-518a1e2c4555" = true
+a0e97d2d-669e-47c7-8134-518a1e2c4555 = true
 
 # isogram with only lower case characters
-"9a001b50-f194-4143-bc29-2af5ec1ef652" = true
+9a001b50-f194-4143-bc29-2af5ec1ef652 = false
 
 # word with one duplicated character
-"8ddb0ca3-276e-4f8b-89da-d95d5bae78a4" = true
+8ddb0ca3-276e-4f8b-89da-d95d5bae78a4 = false
 
 # word with one duplicated character from the end of the alphabet
-"6450b333-cbc2-4b24-a723-0b459b34fe18" = true
+6450b333-cbc2-4b24-a723-0b459b34fe18 = false
 
 # longest reported english isogram
-"a15ff557-dd04-4764-99e7-02cc1a385863" = true
+a15ff557-dd04-4764-99e7-02cc1a385863 = true
 
 # word with duplicated character in mixed case
-"f1a7f6c7-a42f-4915-91d7-35b2ea11c92e" = true
+f1a7f6c7-a42f-4915-91d7-35b2ea11c92e = false
 
 # word with duplicated character in mixed case, lowercase first
-"14a4f3c1-3b47-4695-b645-53d328298942" = true
+14a4f3c1-3b47-4695-b645-53d328298942 = false
 
 # hypothetical isogrammic word with hyphen
-"423b850c-7090-4a8a-b057-97f1cadd7c42" = true
+423b850c-7090-4a8a-b057-97f1cadd7c42 = false
 
 # hypothetical word with duplicated character following hyphen
-"93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2" = true
+93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2 = false
 
 # isogram with duplicated hyphen
-"36b30e5c-173f-49c6-a515-93a3e825553f" = true
+36b30e5c-173f-49c6-a515-93a3e825553f = true
 
 # made-up name that is an isogram
-"cdabafa0-c9f4-4c1f-b142-689c6ee17d93" = true
+cdabafa0-c9f4-4c1f-b142-689c6ee17d93 = false
 
 # duplicated character in the middle
-"5fc61048-d74e-48fd-bc34-abfc21552d4d" = true
+5fc61048-d74e-48fd-bc34-abfc21552d4d = true
 
 # same first and last characters
-"310ac53d-8932-47bc-bbb4-b2b94f25a83e" = true
+310ac53d-8932-47bc-bbb4-b2b94f25a83e = false

--- a/exercises/isogram/.meta/tests.toml
+++ b/exercises/isogram/.meta/tests.toml
@@ -1,40 +1,40 @@
 [canonical-tests]
 
 # empty string
-a0e97d2d-669e-47c7-8134-518a1e2c4555 = true
+"a0e97d2d-669e-47c7-8134-518a1e2c4555" = true
 
 # isogram with only lower case characters
-9a001b50-f194-4143-bc29-2af5ec1ef652 = false
+"9a001b50-f194-4143-bc29-2af5ec1ef652" = false
 
 # word with one duplicated character
-8ddb0ca3-276e-4f8b-89da-d95d5bae78a4 = false
+"8ddb0ca3-276e-4f8b-89da-d95d5bae78a4" = false
 
 # word with one duplicated character from the end of the alphabet
-6450b333-cbc2-4b24-a723-0b459b34fe18 = false
+"6450b333-cbc2-4b24-a723-0b459b34fe18" = false
 
 # longest reported english isogram
-a15ff557-dd04-4764-99e7-02cc1a385863 = true
+"a15ff557-dd04-4764-99e7-02cc1a385863" = true
 
 # word with duplicated character in mixed case
-f1a7f6c7-a42f-4915-91d7-35b2ea11c92e = false
+"f1a7f6c7-a42f-4915-91d7-35b2ea11c92e" = false
 
 # word with duplicated character in mixed case, lowercase first
-14a4f3c1-3b47-4695-b645-53d328298942 = false
+"14a4f3c1-3b47-4695-b645-53d328298942" = false
 
 # hypothetical isogrammic word with hyphen
-423b850c-7090-4a8a-b057-97f1cadd7c42 = false
+"423b850c-7090-4a8a-b057-97f1cadd7c42" = false
 
 # hypothetical word with duplicated character following hyphen
-93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2 = false
+"93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2" = false
 
 # isogram with duplicated hyphen
-36b30e5c-173f-49c6-a515-93a3e825553f = true
+"36b30e5c-173f-49c6-a515-93a3e825553f" = true
 
 # made-up name that is an isogram
-cdabafa0-c9f4-4c1f-b142-689c6ee17d93 = false
+"cdabafa0-c9f4-4c1f-b142-689c6ee17d93" = false
 
 # duplicated character in the middle
-5fc61048-d74e-48fd-bc34-abfc21552d4d = true
+"5fc61048-d74e-48fd-bc34-abfc21552d4d" = true
 
 # same first and last characters
-310ac53d-8932-47bc-bbb4-b2b94f25a83e = false
+"310ac53d-8932-47bc-bbb4-b2b94f25a83e" = false

--- a/exercises/largest-series-product/.meta/tests.toml
+++ b/exercises/largest-series-product/.meta/tests.toml
@@ -1,0 +1,46 @@
+[canonical-tests]
+
+# finds the largest product if span equals length
+"7c82f8b7-e347-48ee-8a22-f672323324d4" = true
+
+# can find the largest product of 2 with numbers in order
+"88523f65-21ba-4458-a76a-b4aaf6e4cb5e" = true
+
+# can find the largest product of 2
+"f1376b48-1157-419d-92c2-1d7e36a70b8a" = true
+
+# can find the largest product of 3 with numbers in order
+"46356a67-7e02-489e-8fea-321c2fa7b4a4" = true
+
+# can find the largest product of 3
+"a2dcb54b-2b8f-4993-92dd-5ce56dece64a" = true
+
+# can find the largest product of 5 with numbers in order
+"673210a3-33cd-4708-940b-c482d7a88f9d" = true
+
+# can get the largest product of a big number
+"02acd5a6-3bbf-46df-8282-8b313a80a7c9" = true
+
+# reports zero if the only digits are zero
+"76dcc407-21e9-424c-a98e-609f269622b5" = true
+
+# reports zero if all spans include zero
+"6ef0df9f-52d4-4a5d-b210-f6fae5f20e19" = true
+
+# rejects span longer than string length
+"5d81aaf7-4f67-4125-bf33-11493cc7eab7" = true
+
+# reports 1 for empty string and empty product (0 span)
+"06bc8b90-0c51-4c54-ac22-3ec3893a079e" = true
+
+# reports 1 for nonempty string and empty product (0 span)
+"3ec0d92e-f2e2-4090-a380-70afee02f4c0" = true
+
+# rejects empty string and nonzero span
+"6d96c691-4374-4404-80ee-2ea8f3613dd4" = true
+
+# rejects invalid character in digits
+"7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74" = true
+
+# rejects negative span
+"5fe3c0e5-a945-49f2-b584-f0814b4dd1ef" = true

--- a/exercises/largest-series-product/.meta/tests.toml
+++ b/exercises/largest-series-product/.meta/tests.toml
@@ -1,46 +1,46 @@
 [canonical-tests]
 
 # finds the largest product if span equals length
-"7c82f8b7-e347-48ee-8a22-f672323324d4" = true
+7c82f8b7-e347-48ee-8a22-f672323324d4 = false
 
 # can find the largest product of 2 with numbers in order
-"88523f65-21ba-4458-a76a-b4aaf6e4cb5e" = true
+88523f65-21ba-4458-a76a-b4aaf6e4cb5e = false
 
 # can find the largest product of 2
-"f1376b48-1157-419d-92c2-1d7e36a70b8a" = true
+f1376b48-1157-419d-92c2-1d7e36a70b8a = false
 
 # can find the largest product of 3 with numbers in order
-"46356a67-7e02-489e-8fea-321c2fa7b4a4" = true
+46356a67-7e02-489e-8fea-321c2fa7b4a4 = false
 
 # can find the largest product of 3
-"a2dcb54b-2b8f-4993-92dd-5ce56dece64a" = true
+a2dcb54b-2b8f-4993-92dd-5ce56dece64a = false
 
 # can find the largest product of 5 with numbers in order
-"673210a3-33cd-4708-940b-c482d7a88f9d" = true
+673210a3-33cd-4708-940b-c482d7a88f9d = false
 
 # can get the largest product of a big number
-"02acd5a6-3bbf-46df-8282-8b313a80a7c9" = true
+02acd5a6-3bbf-46df-8282-8b313a80a7c9 = false
 
 # reports zero if the only digits are zero
-"76dcc407-21e9-424c-a98e-609f269622b5" = true
+76dcc407-21e9-424c-a98e-609f269622b5 = false
 
 # reports zero if all spans include zero
-"6ef0df9f-52d4-4a5d-b210-f6fae5f20e19" = true
+6ef0df9f-52d4-4a5d-b210-f6fae5f20e19 = false
 
 # rejects span longer than string length
-"5d81aaf7-4f67-4125-bf33-11493cc7eab7" = true
+5d81aaf7-4f67-4125-bf33-11493cc7eab7 = false
 
 # reports 1 for empty string and empty product (0 span)
-"06bc8b90-0c51-4c54-ac22-3ec3893a079e" = true
+06bc8b90-0c51-4c54-ac22-3ec3893a079e = false
 
 # reports 1 for nonempty string and empty product (0 span)
-"3ec0d92e-f2e2-4090-a380-70afee02f4c0" = true
+3ec0d92e-f2e2-4090-a380-70afee02f4c0 = false
 
 # rejects empty string and nonzero span
-"6d96c691-4374-4404-80ee-2ea8f3613dd4" = true
+6d96c691-4374-4404-80ee-2ea8f3613dd4 = false
 
 # rejects invalid character in digits
-"7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74" = true
+7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74 = false
 
 # rejects negative span
-"5fe3c0e5-a945-49f2-b584-f0814b4dd1ef" = true
+5fe3c0e5-a945-49f2-b584-f0814b4dd1ef = false

--- a/exercises/largest-series-product/.meta/tests.toml
+++ b/exercises/largest-series-product/.meta/tests.toml
@@ -1,46 +1,46 @@
 [canonical-tests]
 
 # finds the largest product if span equals length
-7c82f8b7-e347-48ee-8a22-f672323324d4 = false
+"7c82f8b7-e347-48ee-8a22-f672323324d4" = false
 
 # can find the largest product of 2 with numbers in order
-88523f65-21ba-4458-a76a-b4aaf6e4cb5e = false
+"88523f65-21ba-4458-a76a-b4aaf6e4cb5e" = false
 
 # can find the largest product of 2
-f1376b48-1157-419d-92c2-1d7e36a70b8a = false
+"f1376b48-1157-419d-92c2-1d7e36a70b8a" = false
 
 # can find the largest product of 3 with numbers in order
-46356a67-7e02-489e-8fea-321c2fa7b4a4 = false
+"46356a67-7e02-489e-8fea-321c2fa7b4a4" = false
 
 # can find the largest product of 3
-a2dcb54b-2b8f-4993-92dd-5ce56dece64a = false
+"a2dcb54b-2b8f-4993-92dd-5ce56dece64a" = false
 
 # can find the largest product of 5 with numbers in order
-673210a3-33cd-4708-940b-c482d7a88f9d = false
+"673210a3-33cd-4708-940b-c482d7a88f9d" = false
 
 # can get the largest product of a big number
-02acd5a6-3bbf-46df-8282-8b313a80a7c9 = false
+"02acd5a6-3bbf-46df-8282-8b313a80a7c9" = false
 
 # reports zero if the only digits are zero
-76dcc407-21e9-424c-a98e-609f269622b5 = false
+"76dcc407-21e9-424c-a98e-609f269622b5" = false
 
 # reports zero if all spans include zero
-6ef0df9f-52d4-4a5d-b210-f6fae5f20e19 = false
+"6ef0df9f-52d4-4a5d-b210-f6fae5f20e19" = false
 
 # rejects span longer than string length
-5d81aaf7-4f67-4125-bf33-11493cc7eab7 = false
+"5d81aaf7-4f67-4125-bf33-11493cc7eab7" = false
 
 # reports 1 for empty string and empty product (0 span)
-06bc8b90-0c51-4c54-ac22-3ec3893a079e = false
+"06bc8b90-0c51-4c54-ac22-3ec3893a079e" = false
 
 # reports 1 for nonempty string and empty product (0 span)
-3ec0d92e-f2e2-4090-a380-70afee02f4c0 = false
+"3ec0d92e-f2e2-4090-a380-70afee02f4c0" = false
 
 # rejects empty string and nonzero span
-6d96c691-4374-4404-80ee-2ea8f3613dd4 = false
+"6d96c691-4374-4404-80ee-2ea8f3613dd4" = false
 
 # rejects invalid character in digits
-7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74 = false
+"7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74" = false
 
 # rejects negative span
-5fe3c0e5-a945-49f2-b584-f0814b4dd1ef = false
+"5fe3c0e5-a945-49f2-b584-f0814b4dd1ef" = false

--- a/exercises/leap/.meta/tests.toml
+++ b/exercises/leap/.meta/tests.toml
@@ -1,0 +1,28 @@
+[canonical-tests]
+
+# year not divisible by 4 in common year
+"6466b30d-519c-438e-935d-388224ab5223" = true
+
+# year divisible by 2, not divisible by 4 in common year
+"ac227e82-ee82-4a09-9eb6-4f84331ffdb0" = true
+
+# year divisible by 4, not divisible by 100 in leap year
+"4fe9b84c-8e65-489e-970b-856d60b8b78e" = true
+
+# year divisible by 4 and 5 is still a leap year
+"7fc6aed7-e63c-48f5-ae05-5fe182f60a5d" = true
+
+# year divisible by 100, not divisible by 400 in common year
+"78a7848f-9667-4192-ae53-87b30c9a02dd" = true
+
+# year divisible by 100 but not by 3 is still not a leap year
+"9d70f938-537c-40a6-ba19-f50739ce8bac" = true
+
+# year divisible by 400 in leap year
+"42ee56ad-d3e6-48f1-8e3f-c84078d916fc" = true
+
+# year divisible by 400 but not by 125 is still a leap year
+"57902c77-6fe9-40de-8302-587b5c27121e" = true
+
+# year divisible by 200, not divisible by 400 in common year
+"c30331f6-f9f6-4881-ad38-8ca8c12520c1" = true

--- a/exercises/leap/.meta/tests.toml
+++ b/exercises/leap/.meta/tests.toml
@@ -1,28 +1,28 @@
 [canonical-tests]
 
 # year not divisible by 4 in common year
-"6466b30d-519c-438e-935d-388224ab5223" = true
+6466b30d-519c-438e-935d-388224ab5223 = false
 
 # year divisible by 2, not divisible by 4 in common year
-"ac227e82-ee82-4a09-9eb6-4f84331ffdb0" = true
+ac227e82-ee82-4a09-9eb6-4f84331ffdb0 = false
 
 # year divisible by 4, not divisible by 100 in leap year
-"4fe9b84c-8e65-489e-970b-856d60b8b78e" = true
+4fe9b84c-8e65-489e-970b-856d60b8b78e = false
 
 # year divisible by 4 and 5 is still a leap year
-"7fc6aed7-e63c-48f5-ae05-5fe182f60a5d" = true
+7fc6aed7-e63c-48f5-ae05-5fe182f60a5d = false
 
 # year divisible by 100, not divisible by 400 in common year
-"78a7848f-9667-4192-ae53-87b30c9a02dd" = true
+78a7848f-9667-4192-ae53-87b30c9a02dd = false
 
 # year divisible by 100 but not by 3 is still not a leap year
-"9d70f938-537c-40a6-ba19-f50739ce8bac" = true
+9d70f938-537c-40a6-ba19-f50739ce8bac = false
 
 # year divisible by 400 in leap year
-"42ee56ad-d3e6-48f1-8e3f-c84078d916fc" = true
+42ee56ad-d3e6-48f1-8e3f-c84078d916fc = false
 
 # year divisible by 400 but not by 125 is still a leap year
-"57902c77-6fe9-40de-8302-587b5c27121e" = true
+57902c77-6fe9-40de-8302-587b5c27121e = false
 
 # year divisible by 200, not divisible by 400 in common year
-"c30331f6-f9f6-4881-ad38-8ca8c12520c1" = true
+c30331f6-f9f6-4881-ad38-8ca8c12520c1 = false

--- a/exercises/leap/.meta/tests.toml
+++ b/exercises/leap/.meta/tests.toml
@@ -1,28 +1,28 @@
 [canonical-tests]
 
 # year not divisible by 4 in common year
-6466b30d-519c-438e-935d-388224ab5223 = false
+"6466b30d-519c-438e-935d-388224ab5223" = false
 
 # year divisible by 2, not divisible by 4 in common year
-ac227e82-ee82-4a09-9eb6-4f84331ffdb0 = false
+"ac227e82-ee82-4a09-9eb6-4f84331ffdb0" = false
 
 # year divisible by 4, not divisible by 100 in leap year
-4fe9b84c-8e65-489e-970b-856d60b8b78e = false
+"4fe9b84c-8e65-489e-970b-856d60b8b78e" = false
 
 # year divisible by 4 and 5 is still a leap year
-7fc6aed7-e63c-48f5-ae05-5fe182f60a5d = false
+"7fc6aed7-e63c-48f5-ae05-5fe182f60a5d" = false
 
 # year divisible by 100, not divisible by 400 in common year
-78a7848f-9667-4192-ae53-87b30c9a02dd = false
+"78a7848f-9667-4192-ae53-87b30c9a02dd" = false
 
 # year divisible by 100 but not by 3 is still not a leap year
-9d70f938-537c-40a6-ba19-f50739ce8bac = false
+"9d70f938-537c-40a6-ba19-f50739ce8bac" = false
 
 # year divisible by 400 in leap year
-42ee56ad-d3e6-48f1-8e3f-c84078d916fc = false
+"42ee56ad-d3e6-48f1-8e3f-c84078d916fc" = false
 
 # year divisible by 400 but not by 125 is still a leap year
-57902c77-6fe9-40de-8302-587b5c27121e = false
+"57902c77-6fe9-40de-8302-587b5c27121e" = false
 
 # year divisible by 200, not divisible by 400 in common year
-c30331f6-f9f6-4881-ad38-8ca8c12520c1 = false
+"c30331f6-f9f6-4881-ad38-8ca8c12520c1" = false

--- a/exercises/luhn/.meta/tests.toml
+++ b/exercises/luhn/.meta/tests.toml
@@ -1,0 +1,55 @@
+[canonical-tests]
+
+# single digit strings can not be valid
+"792a7082-feb7-48c7-b88b-bbfec160865e" = true
+
+# a single zero is invalid
+"698a7924-64d4-4d89-8daa-32e1aadc271e" = true
+
+# a simple valid SIN that remains valid if reversed
+"73c2f62b-9b10-4c9f-9a04-83cee7367965" = true
+
+# a simple valid SIN that becomes invalid if reversed
+"9369092e-b095-439f-948d-498bd076be11" = true
+
+# a valid Canadian SIN
+"8f9f2350-1faf-4008-ba84-85cbb93ffeca" = true
+
+# invalid Canadian SIN
+"1cdcf269-6560-44fc-91f6-5819a7548737" = true
+
+# invalid credit card
+"656c48c1-34e8-4e60-9a5a-aad8a367810a" = true
+
+# invalid long number with an even remainder
+"20e67fad-2121-43ed-99a8-14b5b856adb9" = true
+
+# valid number with an even number of digits
+"ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa" = true
+
+# valid number with an odd number of spaces
+"ef081c06-a41f-4761-8492-385e13c8202d" = true
+
+# valid strings with a non-digit added at the end become invalid
+"bef66f64-6100-4cbb-8f94-4c9713c5e5b2" = true
+
+# valid strings with punctuation included become invalid
+"2177e225-9ce7-40f6-b55d-fa420e62938e" = true
+
+# valid strings with symbols included become invalid
+"ebf04f27-9698-45e1-9afe-7e0851d0fe8d" = true
+
+# single zero with space is invalid
+"08195c5e-ce7f-422c-a5eb-3e45fece68ba" = true
+
+# more than a single zero is valid
+"12e63a3c-f866-4a79-8c14-b359fc386091" = true
+
+# input digit 9 is correctly converted to output digit 9
+"ab56fa80-5de8-4735-8a4a-14dae588663e" = true
+
+# using ascii value for non-doubled non-digit isn't allowed
+"39a06a5a-5bad-4e0f-b215-b042d46209b1" = true
+
+# using ascii value for doubled non-digit isn't allowed
+"f94cf191-a62f-4868-bc72-7253114aa157" = true

--- a/exercises/luhn/.meta/tests.toml
+++ b/exercises/luhn/.meta/tests.toml
@@ -1,55 +1,55 @@
 [canonical-tests]
 
 # single digit strings can not be valid
-"792a7082-feb7-48c7-b88b-bbfec160865e" = true
+792a7082-feb7-48c7-b88b-bbfec160865e = false
 
 # a single zero is invalid
-"698a7924-64d4-4d89-8daa-32e1aadc271e" = true
+698a7924-64d4-4d89-8daa-32e1aadc271e = false
 
 # a simple valid SIN that remains valid if reversed
-"73c2f62b-9b10-4c9f-9a04-83cee7367965" = true
+73c2f62b-9b10-4c9f-9a04-83cee7367965 = false
 
 # a simple valid SIN that becomes invalid if reversed
-"9369092e-b095-439f-948d-498bd076be11" = true
+9369092e-b095-439f-948d-498bd076be11 = false
 
 # a valid Canadian SIN
-"8f9f2350-1faf-4008-ba84-85cbb93ffeca" = true
+8f9f2350-1faf-4008-ba84-85cbb93ffeca = false
 
 # invalid Canadian SIN
-"1cdcf269-6560-44fc-91f6-5819a7548737" = true
+1cdcf269-6560-44fc-91f6-5819a7548737 = false
 
 # invalid credit card
-"656c48c1-34e8-4e60-9a5a-aad8a367810a" = true
+656c48c1-34e8-4e60-9a5a-aad8a367810a = false
 
 # invalid long number with an even remainder
-"20e67fad-2121-43ed-99a8-14b5b856adb9" = true
+20e67fad-2121-43ed-99a8-14b5b856adb9 = false
 
 # valid number with an even number of digits
-"ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa" = true
+ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa = false
 
 # valid number with an odd number of spaces
-"ef081c06-a41f-4761-8492-385e13c8202d" = true
+ef081c06-a41f-4761-8492-385e13c8202d = false
 
 # valid strings with a non-digit added at the end become invalid
-"bef66f64-6100-4cbb-8f94-4c9713c5e5b2" = true
+bef66f64-6100-4cbb-8f94-4c9713c5e5b2 = false
 
 # valid strings with punctuation included become invalid
-"2177e225-9ce7-40f6-b55d-fa420e62938e" = true
+2177e225-9ce7-40f6-b55d-fa420e62938e = false
 
 # valid strings with symbols included become invalid
-"ebf04f27-9698-45e1-9afe-7e0851d0fe8d" = true
+ebf04f27-9698-45e1-9afe-7e0851d0fe8d = false
 
 # single zero with space is invalid
-"08195c5e-ce7f-422c-a5eb-3e45fece68ba" = true
+08195c5e-ce7f-422c-a5eb-3e45fece68ba = false
 
 # more than a single zero is valid
-"12e63a3c-f866-4a79-8c14-b359fc386091" = true
+12e63a3c-f866-4a79-8c14-b359fc386091 = false
 
 # input digit 9 is correctly converted to output digit 9
-"ab56fa80-5de8-4735-8a4a-14dae588663e" = true
+ab56fa80-5de8-4735-8a4a-14dae588663e = false
 
 # using ascii value for non-doubled non-digit isn't allowed
-"39a06a5a-5bad-4e0f-b215-b042d46209b1" = true
+39a06a5a-5bad-4e0f-b215-b042d46209b1 = false
 
 # using ascii value for doubled non-digit isn't allowed
-"f94cf191-a62f-4868-bc72-7253114aa157" = true
+f94cf191-a62f-4868-bc72-7253114aa157 = false

--- a/exercises/luhn/.meta/tests.toml
+++ b/exercises/luhn/.meta/tests.toml
@@ -1,55 +1,55 @@
 [canonical-tests]
 
 # single digit strings can not be valid
-792a7082-feb7-48c7-b88b-bbfec160865e = false
+"792a7082-feb7-48c7-b88b-bbfec160865e" = false
 
 # a single zero is invalid
-698a7924-64d4-4d89-8daa-32e1aadc271e = false
+"698a7924-64d4-4d89-8daa-32e1aadc271e" = false
 
 # a simple valid SIN that remains valid if reversed
-73c2f62b-9b10-4c9f-9a04-83cee7367965 = false
+"73c2f62b-9b10-4c9f-9a04-83cee7367965" = false
 
 # a simple valid SIN that becomes invalid if reversed
-9369092e-b095-439f-948d-498bd076be11 = false
+"9369092e-b095-439f-948d-498bd076be11" = false
 
 # a valid Canadian SIN
-8f9f2350-1faf-4008-ba84-85cbb93ffeca = false
+"8f9f2350-1faf-4008-ba84-85cbb93ffeca" = false
 
 # invalid Canadian SIN
-1cdcf269-6560-44fc-91f6-5819a7548737 = false
+"1cdcf269-6560-44fc-91f6-5819a7548737" = false
 
 # invalid credit card
-656c48c1-34e8-4e60-9a5a-aad8a367810a = false
+"656c48c1-34e8-4e60-9a5a-aad8a367810a" = false
 
 # invalid long number with an even remainder
-20e67fad-2121-43ed-99a8-14b5b856adb9 = false
+"20e67fad-2121-43ed-99a8-14b5b856adb9" = false
 
 # valid number with an even number of digits
-ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa = false
+"ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa" = false
 
 # valid number with an odd number of spaces
-ef081c06-a41f-4761-8492-385e13c8202d = false
+"ef081c06-a41f-4761-8492-385e13c8202d" = false
 
 # valid strings with a non-digit added at the end become invalid
-bef66f64-6100-4cbb-8f94-4c9713c5e5b2 = false
+"bef66f64-6100-4cbb-8f94-4c9713c5e5b2" = false
 
 # valid strings with punctuation included become invalid
-2177e225-9ce7-40f6-b55d-fa420e62938e = false
+"2177e225-9ce7-40f6-b55d-fa420e62938e" = false
 
 # valid strings with symbols included become invalid
-ebf04f27-9698-45e1-9afe-7e0851d0fe8d = false
+"ebf04f27-9698-45e1-9afe-7e0851d0fe8d" = false
 
 # single zero with space is invalid
-08195c5e-ce7f-422c-a5eb-3e45fece68ba = false
+"08195c5e-ce7f-422c-a5eb-3e45fece68ba" = false
 
 # more than a single zero is valid
-12e63a3c-f866-4a79-8c14-b359fc386091 = false
+"12e63a3c-f866-4a79-8c14-b359fc386091" = false
 
 # input digit 9 is correctly converted to output digit 9
-ab56fa80-5de8-4735-8a4a-14dae588663e = false
+"ab56fa80-5de8-4735-8a4a-14dae588663e" = false
 
 # using ascii value for non-doubled non-digit isn't allowed
-39a06a5a-5bad-4e0f-b215-b042d46209b1 = false
+"39a06a5a-5bad-4e0f-b215-b042d46209b1" = false
 
 # using ascii value for doubled non-digit isn't allowed
-f94cf191-a62f-4868-bc72-7253114aa157 = false
+"f94cf191-a62f-4868-bc72-7253114aa157" = false

--- a/exercises/matching-brackets/.meta/tests.toml
+++ b/exercises/matching-brackets/.meta/tests.toml
@@ -1,0 +1,52 @@
+[canonical-tests]
+
+# paired square brackets
+"81ec11da-38dd-442a-bcf9-3de7754609a5" = true
+
+# empty string
+"287f0167-ac60-4b64-8452-a0aa8f4e5238" = true
+
+# unpaired brackets
+"6c3615a3-df01-4130-a731-8ef5f5d78dac" = true
+
+# wrong ordered brackets
+"9d414171-9b98-4cac-a4e5-941039a97a77" = true
+
+# wrong closing bracket
+"f0f97c94-a149-4736-bc61-f2c5148ffb85" = true
+
+# paired with whitespace
+"754468e0-4696-4582-a30e-534d47d69756" = true
+
+# partially paired brackets
+"ba84f6ee-8164-434a-9c3e-b02c7f8e8545" = true
+
+# simple nested brackets
+"3c86c897-5ff3-4a2b-ad9b-47ac3a30651d" = true
+
+# several paired brackets
+"2d137f2c-a19e-4993-9830-83967a2d4726" = true
+
+# paired and nested brackets
+"2e1f7b56-c137-4c92-9781-958638885a44" = true
+
+# unopened closing brackets
+"84f6233b-e0f7-4077-8966-8085d295c19b" = true
+
+# unpaired and nested brackets
+"9b18c67d-7595-4982-b2c5-4cb949745d49" = true
+
+# paired and wrong nested brackets
+"a0205e34-c2ac-49e6-a88a-899508d7d68e" = true
+
+# paired and incomplete brackets
+"ef47c21b-bcfd-4998-844c-7ad5daad90a8" = true
+
+# too many closing brackets
+"a4675a40-a8be-4fc2-bc47-2a282ce6edbe" = true
+
+# math expression
+"99255f93-261b-4435-a352-02bdecc9bdf2" = true
+
+# complex latex expression
+"8e357d79-f302-469a-8515-2561877256a1" = true

--- a/exercises/matching-brackets/.meta/tests.toml
+++ b/exercises/matching-brackets/.meta/tests.toml
@@ -1,52 +1,52 @@
 [canonical-tests]
 
 # paired square brackets
-81ec11da-38dd-442a-bcf9-3de7754609a5 = true
+"81ec11da-38dd-442a-bcf9-3de7754609a5" = true
 
 # empty string
-287f0167-ac60-4b64-8452-a0aa8f4e5238 = true
+"287f0167-ac60-4b64-8452-a0aa8f4e5238" = true
 
 # unpaired brackets
-6c3615a3-df01-4130-a731-8ef5f5d78dac = true
+"6c3615a3-df01-4130-a731-8ef5f5d78dac" = true
 
 # wrong ordered brackets
-9d414171-9b98-4cac-a4e5-941039a97a77 = true
+"9d414171-9b98-4cac-a4e5-941039a97a77" = true
 
 # wrong closing bracket
-f0f97c94-a149-4736-bc61-f2c5148ffb85 = true
+"f0f97c94-a149-4736-bc61-f2c5148ffb85" = true
 
 # paired with whitespace
-754468e0-4696-4582-a30e-534d47d69756 = true
+"754468e0-4696-4582-a30e-534d47d69756" = true
 
 # partially paired brackets
-ba84f6ee-8164-434a-9c3e-b02c7f8e8545 = true
+"ba84f6ee-8164-434a-9c3e-b02c7f8e8545" = true
 
 # simple nested brackets
-3c86c897-5ff3-4a2b-ad9b-47ac3a30651d = true
+"3c86c897-5ff3-4a2b-ad9b-47ac3a30651d" = true
 
 # several paired brackets
-2d137f2c-a19e-4993-9830-83967a2d4726 = true
+"2d137f2c-a19e-4993-9830-83967a2d4726" = true
 
 # paired and nested brackets
-2e1f7b56-c137-4c92-9781-958638885a44 = true
+"2e1f7b56-c137-4c92-9781-958638885a44" = true
 
 # unopened closing brackets
-84f6233b-e0f7-4077-8966-8085d295c19b = true
+"84f6233b-e0f7-4077-8966-8085d295c19b" = true
 
 # unpaired and nested brackets
-9b18c67d-7595-4982-b2c5-4cb949745d49 = true
+"9b18c67d-7595-4982-b2c5-4cb949745d49" = true
 
 # paired and wrong nested brackets
-a0205e34-c2ac-49e6-a88a-899508d7d68e = true
+"a0205e34-c2ac-49e6-a88a-899508d7d68e" = true
 
 # paired and incomplete brackets
-ef47c21b-bcfd-4998-844c-7ad5daad90a8 = true
+"ef47c21b-bcfd-4998-844c-7ad5daad90a8" = true
 
 # too many closing brackets
-a4675a40-a8be-4fc2-bc47-2a282ce6edbe = true
+"a4675a40-a8be-4fc2-bc47-2a282ce6edbe" = true
 
 # math expression
-99255f93-261b-4435-a352-02bdecc9bdf2 = true
+"99255f93-261b-4435-a352-02bdecc9bdf2" = true
 
 # complex latex expression
-8e357d79-f302-469a-8515-2561877256a1 = true
+"8e357d79-f302-469a-8515-2561877256a1" = true

--- a/exercises/matching-brackets/.meta/tests.toml
+++ b/exercises/matching-brackets/.meta/tests.toml
@@ -1,52 +1,52 @@
 [canonical-tests]
 
 # paired square brackets
-"81ec11da-38dd-442a-bcf9-3de7754609a5" = true
+81ec11da-38dd-442a-bcf9-3de7754609a5 = true
 
 # empty string
-"287f0167-ac60-4b64-8452-a0aa8f4e5238" = true
+287f0167-ac60-4b64-8452-a0aa8f4e5238 = true
 
 # unpaired brackets
-"6c3615a3-df01-4130-a731-8ef5f5d78dac" = true
+6c3615a3-df01-4130-a731-8ef5f5d78dac = true
 
 # wrong ordered brackets
-"9d414171-9b98-4cac-a4e5-941039a97a77" = true
+9d414171-9b98-4cac-a4e5-941039a97a77 = true
 
 # wrong closing bracket
-"f0f97c94-a149-4736-bc61-f2c5148ffb85" = true
+f0f97c94-a149-4736-bc61-f2c5148ffb85 = true
 
 # paired with whitespace
-"754468e0-4696-4582-a30e-534d47d69756" = true
+754468e0-4696-4582-a30e-534d47d69756 = true
 
 # partially paired brackets
-"ba84f6ee-8164-434a-9c3e-b02c7f8e8545" = true
+ba84f6ee-8164-434a-9c3e-b02c7f8e8545 = true
 
 # simple nested brackets
-"3c86c897-5ff3-4a2b-ad9b-47ac3a30651d" = true
+3c86c897-5ff3-4a2b-ad9b-47ac3a30651d = true
 
 # several paired brackets
-"2d137f2c-a19e-4993-9830-83967a2d4726" = true
+2d137f2c-a19e-4993-9830-83967a2d4726 = true
 
 # paired and nested brackets
-"2e1f7b56-c137-4c92-9781-958638885a44" = true
+2e1f7b56-c137-4c92-9781-958638885a44 = true
 
 # unopened closing brackets
-"84f6233b-e0f7-4077-8966-8085d295c19b" = true
+84f6233b-e0f7-4077-8966-8085d295c19b = true
 
 # unpaired and nested brackets
-"9b18c67d-7595-4982-b2c5-4cb949745d49" = true
+9b18c67d-7595-4982-b2c5-4cb949745d49 = true
 
 # paired and wrong nested brackets
-"a0205e34-c2ac-49e6-a88a-899508d7d68e" = true
+a0205e34-c2ac-49e6-a88a-899508d7d68e = true
 
 # paired and incomplete brackets
-"ef47c21b-bcfd-4998-844c-7ad5daad90a8" = true
+ef47c21b-bcfd-4998-844c-7ad5daad90a8 = true
 
 # too many closing brackets
-"a4675a40-a8be-4fc2-bc47-2a282ce6edbe" = true
+a4675a40-a8be-4fc2-bc47-2a282ce6edbe = true
 
 # math expression
-"99255f93-261b-4435-a352-02bdecc9bdf2" = true
+99255f93-261b-4435-a352-02bdecc9bdf2 = true
 
 # complex latex expression
-"8e357d79-f302-469a-8515-2561877256a1" = true
+8e357d79-f302-469a-8515-2561877256a1 = true

--- a/exercises/minesweeper/.meta/tests.toml
+++ b/exercises/minesweeper/.meta/tests.toml
@@ -1,0 +1,37 @@
+[canonical-tests]
+
+# no rows
+"0c5ec4bd-dea7-4138-8651-1203e1cb9f44" = true
+
+# no columns
+"650ac4c0-ad6b-4b41-acde-e4ea5852c3b8" = true
+
+# no mines
+"6fbf8f6d-a03b-42c9-9a58-b489e9235478" = true
+
+# minefield with only mines
+"61aff1c4-fb31-4078-acad-cd5f1e635655" = true
+
+# mine surrounded by spaces
+"84167147-c504-4896-85d7-246b01dea7c5" = true
+
+# space surrounded by mines
+"cb878f35-43e3-4c9d-93d9-139012cccc4a" = true
+
+# horizontal line
+"7037f483-ddb4-4b35-b005-0d0f4ef4606f" = true
+
+# horizontal line, mines at edges
+"e359820f-bb8b-4eda-8762-47b64dba30a6" = true
+
+# vertical line
+"c5198b50-804f-47e9-ae02-c3b42f7ce3ab" = true
+
+# vertical line, mines at edges
+"0c79a64d-703d-4660-9e90-5adfa5408939" = true
+
+# cross
+"4b098563-b7f3-401c-97c6-79dd1b708f34" = true
+
+# large minefield
+"04a260f1-b40a-4e89-839e-8dd8525abe0e" = true

--- a/exercises/minesweeper/.meta/tests.toml
+++ b/exercises/minesweeper/.meta/tests.toml
@@ -1,37 +1,37 @@
 [canonical-tests]
 
 # no rows
-0c5ec4bd-dea7-4138-8651-1203e1cb9f44 = true
+"0c5ec4bd-dea7-4138-8651-1203e1cb9f44" = true
 
 # no columns
-650ac4c0-ad6b-4b41-acde-e4ea5852c3b8 = true
+"650ac4c0-ad6b-4b41-acde-e4ea5852c3b8" = true
 
 # no mines
-6fbf8f6d-a03b-42c9-9a58-b489e9235478 = true
+"6fbf8f6d-a03b-42c9-9a58-b489e9235478" = true
 
 # minefield with only mines
-61aff1c4-fb31-4078-acad-cd5f1e635655 = false
+"61aff1c4-fb31-4078-acad-cd5f1e635655" = false
 
 # mine surrounded by spaces
-84167147-c504-4896-85d7-246b01dea7c5 = true
+"84167147-c504-4896-85d7-246b01dea7c5" = true
 
 # space surrounded by mines
-cb878f35-43e3-4c9d-93d9-139012cccc4a = true
+"cb878f35-43e3-4c9d-93d9-139012cccc4a" = true
 
 # horizontal line
-7037f483-ddb4-4b35-b005-0d0f4ef4606f = true
+"7037f483-ddb4-4b35-b005-0d0f4ef4606f" = true
 
 # horizontal line, mines at edges
-e359820f-bb8b-4eda-8762-47b64dba30a6 = false
+"e359820f-bb8b-4eda-8762-47b64dba30a6" = false
 
 # vertical line
-c5198b50-804f-47e9-ae02-c3b42f7ce3ab = true
+"c5198b50-804f-47e9-ae02-c3b42f7ce3ab" = true
 
 # vertical line, mines at edges
-0c79a64d-703d-4660-9e90-5adfa5408939 = false
+"0c79a64d-703d-4660-9e90-5adfa5408939" = false
 
 # cross
-4b098563-b7f3-401c-97c6-79dd1b708f34 = true
+"4b098563-b7f3-401c-97c6-79dd1b708f34" = true
 
 # large minefield
-04a260f1-b40a-4e89-839e-8dd8525abe0e = false
+"04a260f1-b40a-4e89-839e-8dd8525abe0e" = false

--- a/exercises/minesweeper/.meta/tests.toml
+++ b/exercises/minesweeper/.meta/tests.toml
@@ -22,13 +22,13 @@
 "7037f483-ddb4-4b35-b005-0d0f4ef4606f" = true
 
 # horizontal line, mines at edges
-"e359820f-bb8b-4eda-8762-47b64dba30a6" = false
+"e359820f-bb8b-4eda-8762-47b64dba30a6" = true
 
 # vertical line
 "c5198b50-804f-47e9-ae02-c3b42f7ce3ab" = true
 
 # vertical line, mines at edges
-"0c79a64d-703d-4660-9e90-5adfa5408939" = false
+"0c79a64d-703d-4660-9e90-5adfa5408939" = true
 
 # cross
 "4b098563-b7f3-401c-97c6-79dd1b708f34" = true

--- a/exercises/minesweeper/.meta/tests.toml
+++ b/exercises/minesweeper/.meta/tests.toml
@@ -1,37 +1,37 @@
 [canonical-tests]
 
 # no rows
-"0c5ec4bd-dea7-4138-8651-1203e1cb9f44" = true
+0c5ec4bd-dea7-4138-8651-1203e1cb9f44 = true
 
 # no columns
-"650ac4c0-ad6b-4b41-acde-e4ea5852c3b8" = true
+650ac4c0-ad6b-4b41-acde-e4ea5852c3b8 = true
 
 # no mines
-"6fbf8f6d-a03b-42c9-9a58-b489e9235478" = true
+6fbf8f6d-a03b-42c9-9a58-b489e9235478 = true
 
 # minefield with only mines
-"61aff1c4-fb31-4078-acad-cd5f1e635655" = true
+61aff1c4-fb31-4078-acad-cd5f1e635655 = false
 
 # mine surrounded by spaces
-"84167147-c504-4896-85d7-246b01dea7c5" = true
+84167147-c504-4896-85d7-246b01dea7c5 = true
 
 # space surrounded by mines
-"cb878f35-43e3-4c9d-93d9-139012cccc4a" = true
+cb878f35-43e3-4c9d-93d9-139012cccc4a = true
 
 # horizontal line
-"7037f483-ddb4-4b35-b005-0d0f4ef4606f" = true
+7037f483-ddb4-4b35-b005-0d0f4ef4606f = true
 
 # horizontal line, mines at edges
-"e359820f-bb8b-4eda-8762-47b64dba30a6" = true
+e359820f-bb8b-4eda-8762-47b64dba30a6 = false
 
 # vertical line
-"c5198b50-804f-47e9-ae02-c3b42f7ce3ab" = true
+c5198b50-804f-47e9-ae02-c3b42f7ce3ab = true
 
 # vertical line, mines at edges
-"0c79a64d-703d-4660-9e90-5adfa5408939" = true
+0c79a64d-703d-4660-9e90-5adfa5408939 = false
 
 # cross
-"4b098563-b7f3-401c-97c6-79dd1b708f34" = true
+4b098563-b7f3-401c-97c6-79dd1b708f34 = true
 
 # large minefield
-"04a260f1-b40a-4e89-839e-8dd8525abe0e" = true
+04a260f1-b40a-4e89-839e-8dd8525abe0e = false

--- a/exercises/nth-prime/.meta/tests.toml
+++ b/exercises/nth-prime/.meta/tests.toml
@@ -1,0 +1,16 @@
+[canonical-tests]
+
+# first prime
+"75c65189-8aef-471a-81de-0a90c728160c" = true
+
+# second prime
+"2c38804c-295f-4701-b728-56dea34fd1a0" = true
+
+# sixth prime
+"56692534-781e-4e8c-b1f9-3e82c1640259" = true
+
+# big prime
+"fce1e979-0edb-412d-93aa-2c744e8f50ff" = true
+
+# there is no zeroth prime
+"bd0a9eae-6df7-485b-a144-80e13c7d55b2" = true

--- a/exercises/nth-prime/.meta/tests.toml
+++ b/exercises/nth-prime/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # first prime
-"75c65189-8aef-471a-81de-0a90c728160c" = true
+75c65189-8aef-471a-81de-0a90c728160c = false
 
 # second prime
-"2c38804c-295f-4701-b728-56dea34fd1a0" = true
+2c38804c-295f-4701-b728-56dea34fd1a0 = false
 
 # sixth prime
-"56692534-781e-4e8c-b1f9-3e82c1640259" = true
+56692534-781e-4e8c-b1f9-3e82c1640259 = false
 
 # big prime
-"fce1e979-0edb-412d-93aa-2c744e8f50ff" = true
+fce1e979-0edb-412d-93aa-2c744e8f50ff = false
 
 # there is no zeroth prime
-"bd0a9eae-6df7-485b-a144-80e13c7d55b2" = true
+bd0a9eae-6df7-485b-a144-80e13c7d55b2 = false

--- a/exercises/nth-prime/.meta/tests.toml
+++ b/exercises/nth-prime/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # first prime
-75c65189-8aef-471a-81de-0a90c728160c = false
+"75c65189-8aef-471a-81de-0a90c728160c" = false
 
 # second prime
-2c38804c-295f-4701-b728-56dea34fd1a0 = false
+"2c38804c-295f-4701-b728-56dea34fd1a0" = false
 
 # sixth prime
-56692534-781e-4e8c-b1f9-3e82c1640259 = false
+"56692534-781e-4e8c-b1f9-3e82c1640259" = false
 
 # big prime
-fce1e979-0edb-412d-93aa-2c744e8f50ff = false
+"fce1e979-0edb-412d-93aa-2c744e8f50ff" = false
 
 # there is no zeroth prime
-bd0a9eae-6df7-485b-a144-80e13c7d55b2 = false
+"bd0a9eae-6df7-485b-a144-80e13c7d55b2" = false

--- a/exercises/nucleotide-count/.meta/tests.toml
+++ b/exercises/nucleotide-count/.meta/tests.toml
@@ -1,0 +1,16 @@
+[canonical-tests]
+
+# empty strand
+"3e5c30a8-87e2-4845-a815-a49671ade970" = true
+
+# can count one nucleotide in single-character input
+"a0ea42a6-06d9-4ac6-828c-7ccaccf98fec" = true
+
+# strand with repeated nucleotide
+"eca0d565-ed8c-43e7-9033-6cefbf5115b5" = true
+
+# strand with multiple nucleotides
+"40a45eac-c83f-4740-901a-20b22d15a39f" = true
+
+# strand with invalid nucleotides
+"b4c47851-ee9e-4b0a-be70-a86e343bd851" = true

--- a/exercises/nucleotide-count/.meta/tests.toml
+++ b/exercises/nucleotide-count/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # empty strand
-3e5c30a8-87e2-4845-a815-a49671ade970 = false
+"3e5c30a8-87e2-4845-a815-a49671ade970" = false
 
 # can count one nucleotide in single-character input
-a0ea42a6-06d9-4ac6-828c-7ccaccf98fec = false
+"a0ea42a6-06d9-4ac6-828c-7ccaccf98fec" = false
 
 # strand with repeated nucleotide
-eca0d565-ed8c-43e7-9033-6cefbf5115b5 = false
+"eca0d565-ed8c-43e7-9033-6cefbf5115b5" = false
 
 # strand with multiple nucleotides
-40a45eac-c83f-4740-901a-20b22d15a39f = false
+"40a45eac-c83f-4740-901a-20b22d15a39f" = false
 
 # strand with invalid nucleotides
-b4c47851-ee9e-4b0a-be70-a86e343bd851 = false
+"b4c47851-ee9e-4b0a-be70-a86e343bd851" = false

--- a/exercises/nucleotide-count/.meta/tests.toml
+++ b/exercises/nucleotide-count/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # empty strand
-"3e5c30a8-87e2-4845-a815-a49671ade970" = true
+3e5c30a8-87e2-4845-a815-a49671ade970 = false
 
 # can count one nucleotide in single-character input
-"a0ea42a6-06d9-4ac6-828c-7ccaccf98fec" = true
+a0ea42a6-06d9-4ac6-828c-7ccaccf98fec = false
 
 # strand with repeated nucleotide
-"eca0d565-ed8c-43e7-9033-6cefbf5115b5" = true
+eca0d565-ed8c-43e7-9033-6cefbf5115b5 = false
 
 # strand with multiple nucleotides
-"40a45eac-c83f-4740-901a-20b22d15a39f" = true
+40a45eac-c83f-4740-901a-20b22d15a39f = false
 
 # strand with invalid nucleotides
-"b4c47851-ee9e-4b0a-be70-a86e343bd851" = true
+b4c47851-ee9e-4b0a-be70-a86e343bd851 = false

--- a/exercises/ocr-numbers/.meta/tests.toml
+++ b/exercises/ocr-numbers/.meta/tests.toml
@@ -1,0 +1,52 @@
+[canonical-tests]
+
+# Recognizes 0
+"5ee54e1a-b554-4bf3-a056-9a7976c3f7e8" = true
+
+# Recognizes 1
+"027ada25-17fd-4d78-aee6-35a19623639d" = true
+
+# Unreadable but correctly sized inputs return ?
+"3cce2dbd-01d9-4f94-8fae-419a822e89bb" = true
+
+# Input with a number of lines that is not a multiple of four raises an error
+"cb19b733-4e36-4cf9-a4a1-6e6aac808b9a" = true
+
+# Input with a number of columns that is not a multiple of three raises an error
+"235f7bd1-991b-4587-98d4-84206eec4cc6" = true
+
+# Recognizes 110101100
+"4a841794-73c9-4da9-a779-1f9837faff66" = true
+
+# Garbled numbers in a string are replaced with ?
+"70c338f9-85b1-4296-a3a8-122901cdfde8" = true
+
+# Recognizes 2
+"ea494ff4-3610-44d7-ab7e-72fdef0e0802" = true
+
+# Recognizes 3
+"1acd2c00-412b-4268-93c2-bd7ff8e05a2c" = true
+
+# Recognizes 4
+"eaec6a15-be17-4b6d-b895-596fae5d1329" = true
+
+# Recognizes 5
+"440f397a-f046-4243-a6ca-81ab5406c56e" = true
+
+# Recognizes 6
+"f4c9cf6a-f1e2-4878-bfc3-9b85b657caa0" = true
+
+# Recognizes 7
+"e24ebf80-c611-41bb-a25a-ac2c0f232df5" = true
+
+# Recognizes 8
+"b79cad4f-e264-4818-9d9e-77766792e233" = true
+
+# Recognizes 9
+"5efc9cfc-9227-4688-b77d-845049299e66" = true
+
+# Recognizes string of decimal numbers
+"f60cb04a-42be-494e-a535-3451c8e097a4" = true
+
+# Numbers separated by empty lines are recognized. Lines are joined by commas.
+"b73ecf8b-4423-4b36-860d-3710bdb8a491" = true

--- a/exercises/ocr-numbers/.meta/tests.toml
+++ b/exercises/ocr-numbers/.meta/tests.toml
@@ -1,52 +1,52 @@
 [canonical-tests]
 
 # Recognizes 0
-"5ee54e1a-b554-4bf3-a056-9a7976c3f7e8" = true
+5ee54e1a-b554-4bf3-a056-9a7976c3f7e8 = true
 
 # Recognizes 1
-"027ada25-17fd-4d78-aee6-35a19623639d" = true
+027ada25-17fd-4d78-aee6-35a19623639d = true
 
 # Unreadable but correctly sized inputs return ?
-"3cce2dbd-01d9-4f94-8fae-419a822e89bb" = true
+3cce2dbd-01d9-4f94-8fae-419a822e89bb = false
 
 # Input with a number of lines that is not a multiple of four raises an error
-"cb19b733-4e36-4cf9-a4a1-6e6aac808b9a" = true
+cb19b733-4e36-4cf9-a4a1-6e6aac808b9a = false
 
 # Input with a number of columns that is not a multiple of three raises an error
-"235f7bd1-991b-4587-98d4-84206eec4cc6" = true
+235f7bd1-991b-4587-98d4-84206eec4cc6 = false
 
 # Recognizes 110101100
-"4a841794-73c9-4da9-a779-1f9837faff66" = true
+4a841794-73c9-4da9-a779-1f9837faff66 = true
 
 # Garbled numbers in a string are replaced with ?
-"70c338f9-85b1-4296-a3a8-122901cdfde8" = true
+70c338f9-85b1-4296-a3a8-122901cdfde8 = false
 
 # Recognizes 2
-"ea494ff4-3610-44d7-ab7e-72fdef0e0802" = true
+ea494ff4-3610-44d7-ab7e-72fdef0e0802 = true
 
 # Recognizes 3
-"1acd2c00-412b-4268-93c2-bd7ff8e05a2c" = true
+1acd2c00-412b-4268-93c2-bd7ff8e05a2c = true
 
 # Recognizes 4
-"eaec6a15-be17-4b6d-b895-596fae5d1329" = true
+eaec6a15-be17-4b6d-b895-596fae5d1329 = true
 
 # Recognizes 5
-"440f397a-f046-4243-a6ca-81ab5406c56e" = true
+440f397a-f046-4243-a6ca-81ab5406c56e = true
 
 # Recognizes 6
-"f4c9cf6a-f1e2-4878-bfc3-9b85b657caa0" = true
+f4c9cf6a-f1e2-4878-bfc3-9b85b657caa0 = true
 
 # Recognizes 7
-"e24ebf80-c611-41bb-a25a-ac2c0f232df5" = true
+e24ebf80-c611-41bb-a25a-ac2c0f232df5 = true
 
 # Recognizes 8
-"b79cad4f-e264-4818-9d9e-77766792e233" = true
+b79cad4f-e264-4818-9d9e-77766792e233 = true
 
 # Recognizes 9
-"5efc9cfc-9227-4688-b77d-845049299e66" = true
+5efc9cfc-9227-4688-b77d-845049299e66 = true
 
 # Recognizes string of decimal numbers
-"f60cb04a-42be-494e-a535-3451c8e097a4" = true
+f60cb04a-42be-494e-a535-3451c8e097a4 = true
 
 # Numbers separated by empty lines are recognized. Lines are joined by commas.
-"b73ecf8b-4423-4b36-860d-3710bdb8a491" = true
+b73ecf8b-4423-4b36-860d-3710bdb8a491 = false

--- a/exercises/ocr-numbers/.meta/tests.toml
+++ b/exercises/ocr-numbers/.meta/tests.toml
@@ -1,52 +1,52 @@
 [canonical-tests]
 
 # Recognizes 0
-5ee54e1a-b554-4bf3-a056-9a7976c3f7e8 = true
+"5ee54e1a-b554-4bf3-a056-9a7976c3f7e8" = true
 
 # Recognizes 1
-027ada25-17fd-4d78-aee6-35a19623639d = true
+"027ada25-17fd-4d78-aee6-35a19623639d" = true
 
 # Unreadable but correctly sized inputs return ?
-3cce2dbd-01d9-4f94-8fae-419a822e89bb = false
+"3cce2dbd-01d9-4f94-8fae-419a822e89bb" = false
 
 # Input with a number of lines that is not a multiple of four raises an error
-cb19b733-4e36-4cf9-a4a1-6e6aac808b9a = false
+"cb19b733-4e36-4cf9-a4a1-6e6aac808b9a" = false
 
 # Input with a number of columns that is not a multiple of three raises an error
-235f7bd1-991b-4587-98d4-84206eec4cc6 = false
+"235f7bd1-991b-4587-98d4-84206eec4cc6" = false
 
 # Recognizes 110101100
-4a841794-73c9-4da9-a779-1f9837faff66 = true
+"4a841794-73c9-4da9-a779-1f9837faff66" = true
 
 # Garbled numbers in a string are replaced with ?
-70c338f9-85b1-4296-a3a8-122901cdfde8 = false
+"70c338f9-85b1-4296-a3a8-122901cdfde8" = false
 
 # Recognizes 2
-ea494ff4-3610-44d7-ab7e-72fdef0e0802 = true
+"ea494ff4-3610-44d7-ab7e-72fdef0e0802" = true
 
 # Recognizes 3
-1acd2c00-412b-4268-93c2-bd7ff8e05a2c = true
+"1acd2c00-412b-4268-93c2-bd7ff8e05a2c" = true
 
 # Recognizes 4
-eaec6a15-be17-4b6d-b895-596fae5d1329 = true
+"eaec6a15-be17-4b6d-b895-596fae5d1329" = true
 
 # Recognizes 5
-440f397a-f046-4243-a6ca-81ab5406c56e = true
+"440f397a-f046-4243-a6ca-81ab5406c56e" = true
 
 # Recognizes 6
-f4c9cf6a-f1e2-4878-bfc3-9b85b657caa0 = true
+"f4c9cf6a-f1e2-4878-bfc3-9b85b657caa0" = true
 
 # Recognizes 7
-e24ebf80-c611-41bb-a25a-ac2c0f232df5 = true
+"e24ebf80-c611-41bb-a25a-ac2c0f232df5" = true
 
 # Recognizes 8
-b79cad4f-e264-4818-9d9e-77766792e233 = true
+"b79cad4f-e264-4818-9d9e-77766792e233" = true
 
 # Recognizes 9
-5efc9cfc-9227-4688-b77d-845049299e66 = true
+"5efc9cfc-9227-4688-b77d-845049299e66" = true
 
 # Recognizes string of decimal numbers
-f60cb04a-42be-494e-a535-3451c8e097a4 = true
+"f60cb04a-42be-494e-a535-3451c8e097a4" = true
 
 # Numbers separated by empty lines are recognized. Lines are joined by commas.
-b73ecf8b-4423-4b36-860d-3710bdb8a491 = false
+"b73ecf8b-4423-4b36-860d-3710bdb8a491" = false

--- a/exercises/palindrome-products/.meta/tests.toml
+++ b/exercises/palindrome-products/.meta/tests.toml
@@ -1,0 +1,37 @@
+[canonical-tests]
+
+# finds the smallest palindrome from single digit factors
+"5cff78fe-cf02-459d-85c2-ce584679f887" = true
+
+# finds the largest palindrome from single digit factors
+"0853f82c-5fc4-44ae-be38-fadb2cced92d" = true
+
+# find the smallest palindrome from double digit factors
+"66c3b496-bdec-4103-9129-3fcb5a9063e1" = true
+
+# find the largest palindrome from double digit factors
+"a10682ae-530a-4e56-b89d-69664feafe53" = true
+
+# find smallest palindrome from triple digit factors
+"cecb5a35-46d1-4666-9719-fa2c3af7499d" = true
+
+# find the largest palindrome from triple digit factors
+"edab43e1-c35f-4ea3-8c55-2f31dddd92e5" = true
+
+# find smallest palindrome from four digit factors
+"4f802b5a-9d74-4026-a70f-b53ff9234e4e" = true
+
+# find the largest palindrome from four digit factors
+"787525e0-a5f9-40f3-8cb2-23b52cf5d0be" = true
+
+# empty result for smallest if no palindrome in the range
+"58fb1d63-fddb-4409-ab84-a7a8e58d9ea0" = true
+
+# empty result for largest if no palindrome in the range
+"9de9e9da-f1d9-49a5-8bfc-3d322efbdd02" = true
+
+# error result for smallest if min is more than max
+"12e73aac-d7ee-4877-b8aa-2aa3dcdb9f8a" = true
+
+# error result for largest if min is more than max
+"eeeb5bff-3f47-4b1e-892f-05829277bd74" = true

--- a/exercises/palindrome-products/.meta/tests.toml
+++ b/exercises/palindrome-products/.meta/tests.toml
@@ -1,37 +1,37 @@
 [canonical-tests]
 
 # finds the smallest palindrome from single digit factors
-5cff78fe-cf02-459d-85c2-ce584679f887 = false
+"5cff78fe-cf02-459d-85c2-ce584679f887" = false
 
 # finds the largest palindrome from single digit factors
-0853f82c-5fc4-44ae-be38-fadb2cced92d = false
+"0853f82c-5fc4-44ae-be38-fadb2cced92d" = false
 
 # find the smallest palindrome from double digit factors
-66c3b496-bdec-4103-9129-3fcb5a9063e1 = false
+"66c3b496-bdec-4103-9129-3fcb5a9063e1" = false
 
 # find the largest palindrome from double digit factors
-a10682ae-530a-4e56-b89d-69664feafe53 = false
+"a10682ae-530a-4e56-b89d-69664feafe53" = false
 
 # find smallest palindrome from triple digit factors
-cecb5a35-46d1-4666-9719-fa2c3af7499d = false
+"cecb5a35-46d1-4666-9719-fa2c3af7499d" = false
 
 # find the largest palindrome from triple digit factors
-edab43e1-c35f-4ea3-8c55-2f31dddd92e5 = false
+"edab43e1-c35f-4ea3-8c55-2f31dddd92e5" = false
 
 # find smallest palindrome from four digit factors
-4f802b5a-9d74-4026-a70f-b53ff9234e4e = false
+"4f802b5a-9d74-4026-a70f-b53ff9234e4e" = false
 
 # find the largest palindrome from four digit factors
-787525e0-a5f9-40f3-8cb2-23b52cf5d0be = false
+"787525e0-a5f9-40f3-8cb2-23b52cf5d0be" = false
 
 # empty result for smallest if no palindrome in the range
-58fb1d63-fddb-4409-ab84-a7a8e58d9ea0 = false
+"58fb1d63-fddb-4409-ab84-a7a8e58d9ea0" = false
 
 # empty result for largest if no palindrome in the range
-9de9e9da-f1d9-49a5-8bfc-3d322efbdd02 = false
+"9de9e9da-f1d9-49a5-8bfc-3d322efbdd02" = false
 
 # error result for smallest if min is more than max
-12e73aac-d7ee-4877-b8aa-2aa3dcdb9f8a = false
+"12e73aac-d7ee-4877-b8aa-2aa3dcdb9f8a" = false
 
 # error result for largest if min is more than max
-eeeb5bff-3f47-4b1e-892f-05829277bd74 = false
+"eeeb5bff-3f47-4b1e-892f-05829277bd74" = false

--- a/exercises/palindrome-products/.meta/tests.toml
+++ b/exercises/palindrome-products/.meta/tests.toml
@@ -1,37 +1,37 @@
 [canonical-tests]
 
 # finds the smallest palindrome from single digit factors
-"5cff78fe-cf02-459d-85c2-ce584679f887" = true
+5cff78fe-cf02-459d-85c2-ce584679f887 = false
 
 # finds the largest palindrome from single digit factors
-"0853f82c-5fc4-44ae-be38-fadb2cced92d" = true
+0853f82c-5fc4-44ae-be38-fadb2cced92d = false
 
 # find the smallest palindrome from double digit factors
-"66c3b496-bdec-4103-9129-3fcb5a9063e1" = true
+66c3b496-bdec-4103-9129-3fcb5a9063e1 = false
 
 # find the largest palindrome from double digit factors
-"a10682ae-530a-4e56-b89d-69664feafe53" = true
+a10682ae-530a-4e56-b89d-69664feafe53 = false
 
 # find smallest palindrome from triple digit factors
-"cecb5a35-46d1-4666-9719-fa2c3af7499d" = true
+cecb5a35-46d1-4666-9719-fa2c3af7499d = false
 
 # find the largest palindrome from triple digit factors
-"edab43e1-c35f-4ea3-8c55-2f31dddd92e5" = true
+edab43e1-c35f-4ea3-8c55-2f31dddd92e5 = false
 
 # find smallest palindrome from four digit factors
-"4f802b5a-9d74-4026-a70f-b53ff9234e4e" = true
+4f802b5a-9d74-4026-a70f-b53ff9234e4e = false
 
 # find the largest palindrome from four digit factors
-"787525e0-a5f9-40f3-8cb2-23b52cf5d0be" = true
+787525e0-a5f9-40f3-8cb2-23b52cf5d0be = false
 
 # empty result for smallest if no palindrome in the range
-"58fb1d63-fddb-4409-ab84-a7a8e58d9ea0" = true
+58fb1d63-fddb-4409-ab84-a7a8e58d9ea0 = false
 
 # empty result for largest if no palindrome in the range
-"9de9e9da-f1d9-49a5-8bfc-3d322efbdd02" = true
+9de9e9da-f1d9-49a5-8bfc-3d322efbdd02 = false
 
 # error result for smallest if min is more than max
-"12e73aac-d7ee-4877-b8aa-2aa3dcdb9f8a" = true
+12e73aac-d7ee-4877-b8aa-2aa3dcdb9f8a = false
 
 # error result for largest if min is more than max
-"eeeb5bff-3f47-4b1e-892f-05829277bd74" = true
+eeeb5bff-3f47-4b1e-892f-05829277bd74 = false

--- a/exercises/pangram/.meta/tests.toml
+++ b/exercises/pangram/.meta/tests.toml
@@ -1,0 +1,31 @@
+[canonical-tests]
+
+# empty sentence
+"64f61791-508e-4f5c-83ab-05de042b0149" = true
+
+# perfect lower case
+"74858f80-4a4d-478b-8a5e-c6477e4e4e84" = true
+
+# only lower case
+"61288860-35ca-4abe-ba08-f5df76ecbdcd" = true
+
+# missing the letter 'x'
+"6564267d-8ac5-4d29-baf2-e7d2e304a743" = true
+
+# missing the letter 'h'
+"c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0" = true
+
+# with underscores
+"d835ec38-bc8f-48e4-9e36-eb232427b1df" = true
+
+# with numbers
+"8cc1e080-a178-4494-b4b3-06982c9be2a8" = true
+
+# missing letters replaced by numbers
+"bed96b1c-ff95-45b8-9731-fdbdcb6ede9a" = true
+
+# mixed case and punctuation
+"938bd5d8-ade5-40e2-a2d9-55a338a01030" = true
+
+# case insensitive
+"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = true

--- a/exercises/pangram/.meta/tests.toml
+++ b/exercises/pangram/.meta/tests.toml
@@ -1,31 +1,31 @@
 [canonical-tests]
 
 # empty sentence
-64f61791-508e-4f5c-83ab-05de042b0149 = false
+"64f61791-508e-4f5c-83ab-05de042b0149" = false
 
 # perfect lower case
-74858f80-4a4d-478b-8a5e-c6477e4e4e84 = false
+"74858f80-4a4d-478b-8a5e-c6477e4e4e84" = false
 
 # only lower case
-61288860-35ca-4abe-ba08-f5df76ecbdcd = false
+"61288860-35ca-4abe-ba08-f5df76ecbdcd" = false
 
 # missing the letter 'x'
-6564267d-8ac5-4d29-baf2-e7d2e304a743 = false
+"6564267d-8ac5-4d29-baf2-e7d2e304a743" = false
 
 # missing the letter 'h'
-c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0 = false
+"c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0" = false
 
 # with underscores
-d835ec38-bc8f-48e4-9e36-eb232427b1df = false
+"d835ec38-bc8f-48e4-9e36-eb232427b1df" = false
 
 # with numbers
-8cc1e080-a178-4494-b4b3-06982c9be2a8 = false
+"8cc1e080-a178-4494-b4b3-06982c9be2a8" = false
 
 # missing letters replaced by numbers
-bed96b1c-ff95-45b8-9731-fdbdcb6ede9a = false
+"bed96b1c-ff95-45b8-9731-fdbdcb6ede9a" = false
 
 # mixed case and punctuation
-938bd5d8-ade5-40e2-a2d9-55a338a01030 = false
+"938bd5d8-ade5-40e2-a2d9-55a338a01030" = false
 
 # case insensitive
-2577bf54-83c8-402d-a64b-a2c0f7bb213a = false
+"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = false

--- a/exercises/pangram/.meta/tests.toml
+++ b/exercises/pangram/.meta/tests.toml
@@ -1,31 +1,31 @@
 [canonical-tests]
 
 # empty sentence
-"64f61791-508e-4f5c-83ab-05de042b0149" = true
+64f61791-508e-4f5c-83ab-05de042b0149 = false
 
 # perfect lower case
-"74858f80-4a4d-478b-8a5e-c6477e4e4e84" = true
+74858f80-4a4d-478b-8a5e-c6477e4e4e84 = false
 
 # only lower case
-"61288860-35ca-4abe-ba08-f5df76ecbdcd" = true
+61288860-35ca-4abe-ba08-f5df76ecbdcd = false
 
 # missing the letter 'x'
-"6564267d-8ac5-4d29-baf2-e7d2e304a743" = true
+6564267d-8ac5-4d29-baf2-e7d2e304a743 = false
 
 # missing the letter 'h'
-"c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0" = true
+c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0 = false
 
 # with underscores
-"d835ec38-bc8f-48e4-9e36-eb232427b1df" = true
+d835ec38-bc8f-48e4-9e36-eb232427b1df = false
 
 # with numbers
-"8cc1e080-a178-4494-b4b3-06982c9be2a8" = true
+8cc1e080-a178-4494-b4b3-06982c9be2a8 = false
 
 # missing letters replaced by numbers
-"bed96b1c-ff95-45b8-9731-fdbdcb6ede9a" = true
+bed96b1c-ff95-45b8-9731-fdbdcb6ede9a = false
 
 # mixed case and punctuation
-"938bd5d8-ade5-40e2-a2d9-55a338a01030" = true
+938bd5d8-ade5-40e2-a2d9-55a338a01030 = false
 
 # case insensitive
-"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = true
+2577bf54-83c8-402d-a64b-a2c0f7bb213a = false

--- a/exercises/pascals-triangle/.meta/tests.toml
+++ b/exercises/pascals-triangle/.meta/tests.toml
@@ -1,0 +1,25 @@
+[canonical-tests]
+
+# zero rows
+"9920ce55-9629-46d5-85d6-4201f4a4234d" = true
+
+# single row
+"70d643ce-a46d-4e93-af58-12d88dd01f21" = true
+
+# two rows
+"a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd" = true
+
+# three rows
+"97206a99-79ba-4b04-b1c5-3c0fa1e16925" = true
+
+# four rows
+"565a0431-c797-417c-a2c8-2935e01ce306" = true
+
+# five rows
+"06f9ea50-9f51-4eb2-b9a9-c00975686c27" = true
+
+# six rows
+"c3912965-ddb4-46a9-848e-3363e6b00b13" = true
+
+# ten rows
+"6cb26c66-7b57-4161-962c-81ec8c99f16b" = true

--- a/exercises/pascals-triangle/.meta/tests.toml
+++ b/exercises/pascals-triangle/.meta/tests.toml
@@ -1,25 +1,25 @@
 [canonical-tests]
 
 # zero rows
-"9920ce55-9629-46d5-85d6-4201f4a4234d" = true
+9920ce55-9629-46d5-85d6-4201f4a4234d = false
 
 # single row
-"70d643ce-a46d-4e93-af58-12d88dd01f21" = true
+70d643ce-a46d-4e93-af58-12d88dd01f21 = false
 
 # two rows
-"a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd" = true
+a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd = true
 
 # three rows
-"97206a99-79ba-4b04-b1c5-3c0fa1e16925" = true
+97206a99-79ba-4b04-b1c5-3c0fa1e16925 = true
 
 # four rows
-"565a0431-c797-417c-a2c8-2935e01ce306" = true
+565a0431-c797-417c-a2c8-2935e01ce306 = false
 
 # five rows
-"06f9ea50-9f51-4eb2-b9a9-c00975686c27" = true
+06f9ea50-9f51-4eb2-b9a9-c00975686c27 = true
 
 # six rows
-"c3912965-ddb4-46a9-848e-3363e6b00b13" = true
+c3912965-ddb4-46a9-848e-3363e6b00b13 = true
 
 # ten rows
-"6cb26c66-7b57-4161-962c-81ec8c99f16b" = true
+6cb26c66-7b57-4161-962c-81ec8c99f16b = true

--- a/exercises/pascals-triangle/.meta/tests.toml
+++ b/exercises/pascals-triangle/.meta/tests.toml
@@ -1,25 +1,25 @@
 [canonical-tests]
 
 # zero rows
-9920ce55-9629-46d5-85d6-4201f4a4234d = false
+"9920ce55-9629-46d5-85d6-4201f4a4234d" = false
 
 # single row
-70d643ce-a46d-4e93-af58-12d88dd01f21 = false
+"70d643ce-a46d-4e93-af58-12d88dd01f21" = false
 
 # two rows
-a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd = true
+"a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd" = true
 
 # three rows
-97206a99-79ba-4b04-b1c5-3c0fa1e16925 = true
+"97206a99-79ba-4b04-b1c5-3c0fa1e16925" = true
 
 # four rows
-565a0431-c797-417c-a2c8-2935e01ce306 = false
+"565a0431-c797-417c-a2c8-2935e01ce306" = false
 
 # five rows
-06f9ea50-9f51-4eb2-b9a9-c00975686c27 = true
+"06f9ea50-9f51-4eb2-b9a9-c00975686c27" = true
 
 # six rows
-c3912965-ddb4-46a9-848e-3363e6b00b13 = true
+"c3912965-ddb4-46a9-848e-3363e6b00b13" = true
 
 # ten rows
-6cb26c66-7b57-4161-962c-81ec8c99f16b = true
+"6cb26c66-7b57-4161-962c-81ec8c99f16b" = true

--- a/exercises/perfect-numbers/.meta/tests.toml
+++ b/exercises/perfect-numbers/.meta/tests.toml
@@ -1,0 +1,40 @@
+[canonical-tests]
+
+# Smallest perfect number is classified correctly
+"163e8e86-7bfd-4ee2-bd68-d083dc3381a3" = true
+
+# Medium perfect number is classified correctly
+"169a7854-0431-4ae0-9815-c3b6d967436d" = true
+
+# Large perfect number is classified correctly
+"ee3627c4-7b36-4245-ba7c-8727d585f402" = true
+
+# Smallest abundant number is classified correctly
+"80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e" = true
+
+# Medium abundant number is classified correctly
+"3e300e0d-1a12-4f11-8c48-d1027165ab60" = true
+
+# Large abundant number is classified correctly
+"ec7792e6-8786-449c-b005-ce6dd89a772b" = true
+
+# Smallest prime deficient number is classified correctly
+"e610fdc7-2b6e-43c3-a51c-b70fb37413ba" = true
+
+# Smallest non-prime deficient number is classified correctly
+"0beb7f66-753a-443f-8075-ad7fbd9018f3" = true
+
+# Medium deficient number is classified correctly
+"1c802e45-b4c6-4962-93d7-1cad245821ef" = true
+
+# Large deficient number is classified correctly
+"47dd569f-9e5a-4a11-9a47-a4e91c8c28aa" = true
+
+# Edge case (no factors other than itself) is classified correctly
+"a696dec8-6147-4d68-afad-d38de5476a56" = true
+
+# Zero is rejected (not a natural number)
+"72445cee-660c-4d75-8506-6c40089dc302" = true
+
+# Negative integer is rejected (not a natural number)
+"2d72ce2c-6802-49ac-8ece-c790ba3dae13" = true

--- a/exercises/perfect-numbers/.meta/tests.toml
+++ b/exercises/perfect-numbers/.meta/tests.toml
@@ -1,40 +1,40 @@
 [canonical-tests]
 
 # Smallest perfect number is classified correctly
-163e8e86-7bfd-4ee2-bd68-d083dc3381a3 = false
+"163e8e86-7bfd-4ee2-bd68-d083dc3381a3" = false
 
 # Medium perfect number is classified correctly
-169a7854-0431-4ae0-9815-c3b6d967436d = false
+"169a7854-0431-4ae0-9815-c3b6d967436d" = false
 
 # Large perfect number is classified correctly
-ee3627c4-7b36-4245-ba7c-8727d585f402 = false
+"ee3627c4-7b36-4245-ba7c-8727d585f402" = false
 
 # Smallest abundant number is classified correctly
-80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e = false
+"80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e" = false
 
 # Medium abundant number is classified correctly
-3e300e0d-1a12-4f11-8c48-d1027165ab60 = false
+"3e300e0d-1a12-4f11-8c48-d1027165ab60" = false
 
 # Large abundant number is classified correctly
-ec7792e6-8786-449c-b005-ce6dd89a772b = false
+"ec7792e6-8786-449c-b005-ce6dd89a772b" = false
 
 # Smallest prime deficient number is classified correctly
-e610fdc7-2b6e-43c3-a51c-b70fb37413ba = false
+"e610fdc7-2b6e-43c3-a51c-b70fb37413ba" = false
 
 # Smallest non-prime deficient number is classified correctly
-0beb7f66-753a-443f-8075-ad7fbd9018f3 = false
+"0beb7f66-753a-443f-8075-ad7fbd9018f3" = false
 
 # Medium deficient number is classified correctly
-1c802e45-b4c6-4962-93d7-1cad245821ef = false
+"1c802e45-b4c6-4962-93d7-1cad245821ef" = false
 
 # Large deficient number is classified correctly
-47dd569f-9e5a-4a11-9a47-a4e91c8c28aa = false
+"47dd569f-9e5a-4a11-9a47-a4e91c8c28aa" = false
 
 # Edge case (no factors other than itself) is classified correctly
-a696dec8-6147-4d68-afad-d38de5476a56 = false
+"a696dec8-6147-4d68-afad-d38de5476a56" = false
 
 # Zero is rejected (not a natural number)
-72445cee-660c-4d75-8506-6c40089dc302 = false
+"72445cee-660c-4d75-8506-6c40089dc302" = false
 
 # Negative integer is rejected (not a natural number)
-2d72ce2c-6802-49ac-8ece-c790ba3dae13 = false
+"2d72ce2c-6802-49ac-8ece-c790ba3dae13" = false

--- a/exercises/perfect-numbers/.meta/tests.toml
+++ b/exercises/perfect-numbers/.meta/tests.toml
@@ -1,40 +1,40 @@
 [canonical-tests]
 
 # Smallest perfect number is classified correctly
-"163e8e86-7bfd-4ee2-bd68-d083dc3381a3" = true
+163e8e86-7bfd-4ee2-bd68-d083dc3381a3 = false
 
 # Medium perfect number is classified correctly
-"169a7854-0431-4ae0-9815-c3b6d967436d" = true
+169a7854-0431-4ae0-9815-c3b6d967436d = false
 
 # Large perfect number is classified correctly
-"ee3627c4-7b36-4245-ba7c-8727d585f402" = true
+ee3627c4-7b36-4245-ba7c-8727d585f402 = false
 
 # Smallest abundant number is classified correctly
-"80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e" = true
+80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e = false
 
 # Medium abundant number is classified correctly
-"3e300e0d-1a12-4f11-8c48-d1027165ab60" = true
+3e300e0d-1a12-4f11-8c48-d1027165ab60 = false
 
 # Large abundant number is classified correctly
-"ec7792e6-8786-449c-b005-ce6dd89a772b" = true
+ec7792e6-8786-449c-b005-ce6dd89a772b = false
 
 # Smallest prime deficient number is classified correctly
-"e610fdc7-2b6e-43c3-a51c-b70fb37413ba" = true
+e610fdc7-2b6e-43c3-a51c-b70fb37413ba = false
 
 # Smallest non-prime deficient number is classified correctly
-"0beb7f66-753a-443f-8075-ad7fbd9018f3" = true
+0beb7f66-753a-443f-8075-ad7fbd9018f3 = false
 
 # Medium deficient number is classified correctly
-"1c802e45-b4c6-4962-93d7-1cad245821ef" = true
+1c802e45-b4c6-4962-93d7-1cad245821ef = false
 
 # Large deficient number is classified correctly
-"47dd569f-9e5a-4a11-9a47-a4e91c8c28aa" = true
+47dd569f-9e5a-4a11-9a47-a4e91c8c28aa = false
 
 # Edge case (no factors other than itself) is classified correctly
-"a696dec8-6147-4d68-afad-d38de5476a56" = true
+a696dec8-6147-4d68-afad-d38de5476a56 = false
 
 # Zero is rejected (not a natural number)
-"72445cee-660c-4d75-8506-6c40089dc302" = true
+72445cee-660c-4d75-8506-6c40089dc302 = false
 
 # Negative integer is rejected (not a natural number)
-"2d72ce2c-6802-49ac-8ece-c790ba3dae13" = true
+2d72ce2c-6802-49ac-8ece-c790ba3dae13 = false

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -1,9 +1,9 @@
 # Perfect Numbers
 
 Determine if a number is perfect, abundant, or deficient based on
-Nicomachus' (60 - 120 CE) classification scheme for natural numbers.
+Nicomachus' (60 - 120 CE) classification scheme for positive integers.
 
-The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for natural numbers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
+The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for positive integers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
 
 - **Perfect**: aliquot sum = number
   - 6 is a perfect number because (1 + 2 + 3) = 6

--- a/exercises/phone-number/.meta/tests.toml
+++ b/exercises/phone-number/.meta/tests.toml
@@ -1,0 +1,55 @@
+[canonical-tests]
+
+# cleans the number
+"79666dce-e0f1-46de-95a1-563802913c35" = true
+
+# cleans numbers with dots
+"c360451f-549f-43e4-8aba-fdf6cb0bf83f" = true
+
+# cleans numbers with multiple spaces
+"08f94c34-9a37-46a2-a123-2a8e9727395d" = true
+
+# invalid when 9 digits
+"598d8432-0659-4019-a78b-1c6a73691d21" = true
+
+# invalid when 11 digits does not start with a 1
+"57061c72-07b5-431f-9766-d97da7c4399d" = true
+
+# valid when 11 digits and starting with 1
+"9962cbf3-97bb-4118-ba9b-38ff49c64430" = true
+
+# valid when 11 digits and starting with 1 even with punctuation
+"fa724fbf-054c-4d91-95da-f65ab5b6dbca" = true
+
+# invalid when more than 11 digits
+"c6a5f007-895a-4fc5-90bc-a7e70f9b5cad" = true
+
+# invalid with letters
+"63f38f37-53f6-4a5f-bd86-e9b404f10a60" = true
+
+# invalid with punctuations
+"4bd97d90-52fd-45d3-b0db-06ab95b1244e" = true
+
+# invalid if area code starts with 0
+"d77d07f8-873c-4b17-8978-5f66139bf7d7" = true
+
+# invalid if area code starts with 1
+"c7485cfb-1e7b-4081-8e96-8cdb3b77f15e" = true
+
+# invalid if exchange code starts with 0
+"4d622293-6976-413d-b8bf-dd8a94d4e2ac" = true
+
+# invalid if exchange code starts with 1
+"4cef57b4-7d8e-43aa-8328-1e1b89001262" = true
+
+# invalid if area code starts with 0 on valid 11-digit number
+"9925b09c-1a0d-4960-a197-5d163cbe308c" = true
+
+# invalid if area code starts with 1 on valid 11-digit number
+"3f809d37-40f3-44b5-ad90-535838b1a816" = true
+
+# invalid if exchange code starts with 0 on valid 11-digit number
+"e08e5532-d621-40d4-b0cc-96c159276b65" = true
+
+# invalid if exchange code starts with 1 on valid 11-digit number
+"57b32f3d-696a-455c-8bf1-137b6d171cdf" = true

--- a/exercises/phone-number/.meta/tests.toml
+++ b/exercises/phone-number/.meta/tests.toml
@@ -1,55 +1,55 @@
 [canonical-tests]
 
 # cleans the number
-79666dce-e0f1-46de-95a1-563802913c35 = false
+"79666dce-e0f1-46de-95a1-563802913c35" = false
 
 # cleans numbers with dots
-c360451f-549f-43e4-8aba-fdf6cb0bf83f = false
+"c360451f-549f-43e4-8aba-fdf6cb0bf83f" = false
 
 # cleans numbers with multiple spaces
-08f94c34-9a37-46a2-a123-2a8e9727395d = false
+"08f94c34-9a37-46a2-a123-2a8e9727395d" = false
 
 # invalid when 9 digits
-598d8432-0659-4019-a78b-1c6a73691d21 = false
+"598d8432-0659-4019-a78b-1c6a73691d21" = false
 
 # invalid when 11 digits does not start with a 1
-57061c72-07b5-431f-9766-d97da7c4399d = false
+"57061c72-07b5-431f-9766-d97da7c4399d" = false
 
 # valid when 11 digits and starting with 1
-9962cbf3-97bb-4118-ba9b-38ff49c64430 = false
+"9962cbf3-97bb-4118-ba9b-38ff49c64430" = false
 
 # valid when 11 digits and starting with 1 even with punctuation
-fa724fbf-054c-4d91-95da-f65ab5b6dbca = false
+"fa724fbf-054c-4d91-95da-f65ab5b6dbca" = false
 
 # invalid when more than 11 digits
-c6a5f007-895a-4fc5-90bc-a7e70f9b5cad = false
+"c6a5f007-895a-4fc5-90bc-a7e70f9b5cad" = false
 
 # invalid with letters
-63f38f37-53f6-4a5f-bd86-e9b404f10a60 = false
+"63f38f37-53f6-4a5f-bd86-e9b404f10a60" = false
 
 # invalid with punctuations
-4bd97d90-52fd-45d3-b0db-06ab95b1244e = false
+"4bd97d90-52fd-45d3-b0db-06ab95b1244e" = false
 
 # invalid if area code starts with 0
-d77d07f8-873c-4b17-8978-5f66139bf7d7 = false
+"d77d07f8-873c-4b17-8978-5f66139bf7d7" = false
 
 # invalid if area code starts with 1
-c7485cfb-1e7b-4081-8e96-8cdb3b77f15e = false
+"c7485cfb-1e7b-4081-8e96-8cdb3b77f15e" = false
 
 # invalid if exchange code starts with 0
-4d622293-6976-413d-b8bf-dd8a94d4e2ac = false
+"4d622293-6976-413d-b8bf-dd8a94d4e2ac" = false
 
 # invalid if exchange code starts with 1
-4cef57b4-7d8e-43aa-8328-1e1b89001262 = false
+"4cef57b4-7d8e-43aa-8328-1e1b89001262" = false
 
 # invalid if area code starts with 0 on valid 11-digit number
-9925b09c-1a0d-4960-a197-5d163cbe308c = false
+"9925b09c-1a0d-4960-a197-5d163cbe308c" = false
 
 # invalid if area code starts with 1 on valid 11-digit number
-3f809d37-40f3-44b5-ad90-535838b1a816 = false
+"3f809d37-40f3-44b5-ad90-535838b1a816" = false
 
 # invalid if exchange code starts with 0 on valid 11-digit number
-e08e5532-d621-40d4-b0cc-96c159276b65 = false
+"e08e5532-d621-40d4-b0cc-96c159276b65" = false
 
 # invalid if exchange code starts with 1 on valid 11-digit number
-57b32f3d-696a-455c-8bf1-137b6d171cdf = false
+"57b32f3d-696a-455c-8bf1-137b6d171cdf" = false

--- a/exercises/phone-number/.meta/tests.toml
+++ b/exercises/phone-number/.meta/tests.toml
@@ -1,55 +1,55 @@
 [canonical-tests]
 
 # cleans the number
-"79666dce-e0f1-46de-95a1-563802913c35" = true
+79666dce-e0f1-46de-95a1-563802913c35 = false
 
 # cleans numbers with dots
-"c360451f-549f-43e4-8aba-fdf6cb0bf83f" = true
+c360451f-549f-43e4-8aba-fdf6cb0bf83f = false
 
 # cleans numbers with multiple spaces
-"08f94c34-9a37-46a2-a123-2a8e9727395d" = true
+08f94c34-9a37-46a2-a123-2a8e9727395d = false
 
 # invalid when 9 digits
-"598d8432-0659-4019-a78b-1c6a73691d21" = true
+598d8432-0659-4019-a78b-1c6a73691d21 = false
 
 # invalid when 11 digits does not start with a 1
-"57061c72-07b5-431f-9766-d97da7c4399d" = true
+57061c72-07b5-431f-9766-d97da7c4399d = false
 
 # valid when 11 digits and starting with 1
-"9962cbf3-97bb-4118-ba9b-38ff49c64430" = true
+9962cbf3-97bb-4118-ba9b-38ff49c64430 = false
 
 # valid when 11 digits and starting with 1 even with punctuation
-"fa724fbf-054c-4d91-95da-f65ab5b6dbca" = true
+fa724fbf-054c-4d91-95da-f65ab5b6dbca = false
 
 # invalid when more than 11 digits
-"c6a5f007-895a-4fc5-90bc-a7e70f9b5cad" = true
+c6a5f007-895a-4fc5-90bc-a7e70f9b5cad = false
 
 # invalid with letters
-"63f38f37-53f6-4a5f-bd86-e9b404f10a60" = true
+63f38f37-53f6-4a5f-bd86-e9b404f10a60 = false
 
 # invalid with punctuations
-"4bd97d90-52fd-45d3-b0db-06ab95b1244e" = true
+4bd97d90-52fd-45d3-b0db-06ab95b1244e = false
 
 # invalid if area code starts with 0
-"d77d07f8-873c-4b17-8978-5f66139bf7d7" = true
+d77d07f8-873c-4b17-8978-5f66139bf7d7 = false
 
 # invalid if area code starts with 1
-"c7485cfb-1e7b-4081-8e96-8cdb3b77f15e" = true
+c7485cfb-1e7b-4081-8e96-8cdb3b77f15e = false
 
 # invalid if exchange code starts with 0
-"4d622293-6976-413d-b8bf-dd8a94d4e2ac" = true
+4d622293-6976-413d-b8bf-dd8a94d4e2ac = false
 
 # invalid if exchange code starts with 1
-"4cef57b4-7d8e-43aa-8328-1e1b89001262" = true
+4cef57b4-7d8e-43aa-8328-1e1b89001262 = false
 
 # invalid if area code starts with 0 on valid 11-digit number
-"9925b09c-1a0d-4960-a197-5d163cbe308c" = true
+9925b09c-1a0d-4960-a197-5d163cbe308c = false
 
 # invalid if area code starts with 1 on valid 11-digit number
-"3f809d37-40f3-44b5-ad90-535838b1a816" = true
+3f809d37-40f3-44b5-ad90-535838b1a816 = false
 
 # invalid if exchange code starts with 0 on valid 11-digit number
-"e08e5532-d621-40d4-b0cc-96c159276b65" = true
+e08e5532-d621-40d4-b0cc-96c159276b65 = false
 
 # invalid if exchange code starts with 1 on valid 11-digit number
-"57b32f3d-696a-455c-8bf1-137b6d171cdf" = true
+57b32f3d-696a-455c-8bf1-137b6d171cdf = false

--- a/exercises/pig-latin/.meta/tests.toml
+++ b/exercises/pig-latin/.meta/tests.toml
@@ -1,0 +1,67 @@
+[canonical-tests]
+
+# word beginning with a
+"11567f84-e8c6-4918-aedb-435f0b73db57" = true
+
+# word beginning with e
+"f623f581-bc59-4f45-9032-90c3ca9d2d90" = true
+
+# word beginning with i
+"7dcb08b3-23a6-4e8a-b9aa-d4e859450d58" = true
+
+# word beginning with o
+"0e5c3bff-266d-41c8-909f-364e4d16e09c" = true
+
+# word beginning with u
+"614ba363-ca3c-4e96-ab09-c7320799723c" = true
+
+# word beginning with a vowel and followed by a qu
+"bf2538c6-69eb-4fa7-a494-5a3fec911326" = true
+
+# word beginning with p
+"e5be8a01-2d8a-45eb-abb4-3fcc9582a303" = true
+
+# word beginning with k
+"d36d1e13-a7ed-464d-a282-8820cb2261ce" = true
+
+# word beginning with x
+"d838b56f-0a89-4c90-b326-f16ff4e1dddc" = true
+
+# word beginning with q without a following u
+"bce94a7a-a94e-4e2b-80f4-b2bb02e40f71" = true
+
+# word beginning with ch
+"c01e049a-e3e2-451c-bf8e-e2abb7e438b8" = true
+
+# word beginning with qu
+"9ba1669e-c43f-4b93-837a-cfc731fd1425" = true
+
+# word beginning with qu and a preceding consonant
+"92e82277-d5e4-43d7-8dd3-3a3b316c41f7" = true
+
+# word beginning with th
+"79ae4248-3499-4d5b-af46-5cb05fa073ac" = true
+
+# word beginning with thr
+"e0b3ae65-f508-4de3-8999-19c2f8e243e1" = true
+
+# word beginning with sch
+"20bc19f9-5a35-4341-9d69-1627d6ee6b43" = true
+
+# word beginning with yt
+"54b796cb-613d-4509-8c82-8fbf8fc0af9e" = true
+
+# word beginning with xr
+"8c37c5e1-872e-4630-ba6e-d20a959b67f6" = true
+
+# y is treated like a consonant at the beginning of a word
+"a4a36d33-96f3-422c-a233-d4021460ff00" = true
+
+# y is treated like a vowel at the end of a consonant cluster
+"adc90017-1a12-4100-b595-e346105042c7" = true
+
+# y as second letter in two letter word
+"29b4ca3d-efe5-4a95-9a54-8467f2e5e59a" = true
+
+# a whole phrase
+"44616581-5ce3-4a81-82d0-40c7ab13d2cf" = true

--- a/exercises/pig-latin/.meta/tests.toml
+++ b/exercises/pig-latin/.meta/tests.toml
@@ -1,67 +1,67 @@
 [canonical-tests]
 
 # word beginning with a
-"11567f84-e8c6-4918-aedb-435f0b73db57" = true
+11567f84-e8c6-4918-aedb-435f0b73db57 = false
 
 # word beginning with e
-"f623f581-bc59-4f45-9032-90c3ca9d2d90" = true
+f623f581-bc59-4f45-9032-90c3ca9d2d90 = false
 
 # word beginning with i
-"7dcb08b3-23a6-4e8a-b9aa-d4e859450d58" = true
+7dcb08b3-23a6-4e8a-b9aa-d4e859450d58 = false
 
 # word beginning with o
-"0e5c3bff-266d-41c8-909f-364e4d16e09c" = true
+0e5c3bff-266d-41c8-909f-364e4d16e09c = false
 
 # word beginning with u
-"614ba363-ca3c-4e96-ab09-c7320799723c" = true
+614ba363-ca3c-4e96-ab09-c7320799723c = false
 
 # word beginning with a vowel and followed by a qu
-"bf2538c6-69eb-4fa7-a494-5a3fec911326" = true
+bf2538c6-69eb-4fa7-a494-5a3fec911326 = false
 
 # word beginning with p
-"e5be8a01-2d8a-45eb-abb4-3fcc9582a303" = true
+e5be8a01-2d8a-45eb-abb4-3fcc9582a303 = false
 
 # word beginning with k
-"d36d1e13-a7ed-464d-a282-8820cb2261ce" = true
+d36d1e13-a7ed-464d-a282-8820cb2261ce = false
 
 # word beginning with x
-"d838b56f-0a89-4c90-b326-f16ff4e1dddc" = true
+d838b56f-0a89-4c90-b326-f16ff4e1dddc = false
 
 # word beginning with q without a following u
-"bce94a7a-a94e-4e2b-80f4-b2bb02e40f71" = true
+bce94a7a-a94e-4e2b-80f4-b2bb02e40f71 = false
 
 # word beginning with ch
-"c01e049a-e3e2-451c-bf8e-e2abb7e438b8" = true
+c01e049a-e3e2-451c-bf8e-e2abb7e438b8 = false
 
 # word beginning with qu
-"9ba1669e-c43f-4b93-837a-cfc731fd1425" = true
+9ba1669e-c43f-4b93-837a-cfc731fd1425 = false
 
 # word beginning with qu and a preceding consonant
-"92e82277-d5e4-43d7-8dd3-3a3b316c41f7" = true
+92e82277-d5e4-43d7-8dd3-3a3b316c41f7 = false
 
 # word beginning with th
-"79ae4248-3499-4d5b-af46-5cb05fa073ac" = true
+79ae4248-3499-4d5b-af46-5cb05fa073ac = false
 
 # word beginning with thr
-"e0b3ae65-f508-4de3-8999-19c2f8e243e1" = true
+e0b3ae65-f508-4de3-8999-19c2f8e243e1 = false
 
 # word beginning with sch
-"20bc19f9-5a35-4341-9d69-1627d6ee6b43" = true
+20bc19f9-5a35-4341-9d69-1627d6ee6b43 = false
 
 # word beginning with yt
-"54b796cb-613d-4509-8c82-8fbf8fc0af9e" = true
+54b796cb-613d-4509-8c82-8fbf8fc0af9e = false
 
 # word beginning with xr
-"8c37c5e1-872e-4630-ba6e-d20a959b67f6" = true
+8c37c5e1-872e-4630-ba6e-d20a959b67f6 = false
 
 # y is treated like a consonant at the beginning of a word
-"a4a36d33-96f3-422c-a233-d4021460ff00" = true
+a4a36d33-96f3-422c-a233-d4021460ff00 = false
 
 # y is treated like a vowel at the end of a consonant cluster
-"adc90017-1a12-4100-b595-e346105042c7" = true
+adc90017-1a12-4100-b595-e346105042c7 = false
 
 # y as second letter in two letter word
-"29b4ca3d-efe5-4a95-9a54-8467f2e5e59a" = true
+29b4ca3d-efe5-4a95-9a54-8467f2e5e59a = false
 
 # a whole phrase
-"44616581-5ce3-4a81-82d0-40c7ab13d2cf" = true
+44616581-5ce3-4a81-82d0-40c7ab13d2cf = false

--- a/exercises/pig-latin/.meta/tests.toml
+++ b/exercises/pig-latin/.meta/tests.toml
@@ -1,67 +1,67 @@
 [canonical-tests]
 
 # word beginning with a
-11567f84-e8c6-4918-aedb-435f0b73db57 = false
+"11567f84-e8c6-4918-aedb-435f0b73db57" = false
 
 # word beginning with e
-f623f581-bc59-4f45-9032-90c3ca9d2d90 = false
+"f623f581-bc59-4f45-9032-90c3ca9d2d90" = false
 
 # word beginning with i
-7dcb08b3-23a6-4e8a-b9aa-d4e859450d58 = false
+"7dcb08b3-23a6-4e8a-b9aa-d4e859450d58" = false
 
 # word beginning with o
-0e5c3bff-266d-41c8-909f-364e4d16e09c = false
+"0e5c3bff-266d-41c8-909f-364e4d16e09c" = false
 
 # word beginning with u
-614ba363-ca3c-4e96-ab09-c7320799723c = false
+"614ba363-ca3c-4e96-ab09-c7320799723c" = false
 
 # word beginning with a vowel and followed by a qu
-bf2538c6-69eb-4fa7-a494-5a3fec911326 = false
+"bf2538c6-69eb-4fa7-a494-5a3fec911326" = false
 
 # word beginning with p
-e5be8a01-2d8a-45eb-abb4-3fcc9582a303 = false
+"e5be8a01-2d8a-45eb-abb4-3fcc9582a303" = false
 
 # word beginning with k
-d36d1e13-a7ed-464d-a282-8820cb2261ce = false
+"d36d1e13-a7ed-464d-a282-8820cb2261ce" = false
 
 # word beginning with x
-d838b56f-0a89-4c90-b326-f16ff4e1dddc = false
+"d838b56f-0a89-4c90-b326-f16ff4e1dddc" = false
 
 # word beginning with q without a following u
-bce94a7a-a94e-4e2b-80f4-b2bb02e40f71 = false
+"bce94a7a-a94e-4e2b-80f4-b2bb02e40f71" = false
 
 # word beginning with ch
-c01e049a-e3e2-451c-bf8e-e2abb7e438b8 = false
+"c01e049a-e3e2-451c-bf8e-e2abb7e438b8" = false
 
 # word beginning with qu
-9ba1669e-c43f-4b93-837a-cfc731fd1425 = false
+"9ba1669e-c43f-4b93-837a-cfc731fd1425" = false
 
 # word beginning with qu and a preceding consonant
-92e82277-d5e4-43d7-8dd3-3a3b316c41f7 = false
+"92e82277-d5e4-43d7-8dd3-3a3b316c41f7" = false
 
 # word beginning with th
-79ae4248-3499-4d5b-af46-5cb05fa073ac = false
+"79ae4248-3499-4d5b-af46-5cb05fa073ac" = false
 
 # word beginning with thr
-e0b3ae65-f508-4de3-8999-19c2f8e243e1 = false
+"e0b3ae65-f508-4de3-8999-19c2f8e243e1" = false
 
 # word beginning with sch
-20bc19f9-5a35-4341-9d69-1627d6ee6b43 = false
+"20bc19f9-5a35-4341-9d69-1627d6ee6b43" = false
 
 # word beginning with yt
-54b796cb-613d-4509-8c82-8fbf8fc0af9e = false
+"54b796cb-613d-4509-8c82-8fbf8fc0af9e" = false
 
 # word beginning with xr
-8c37c5e1-872e-4630-ba6e-d20a959b67f6 = false
+"8c37c5e1-872e-4630-ba6e-d20a959b67f6" = false
 
 # y is treated like a consonant at the beginning of a word
-a4a36d33-96f3-422c-a233-d4021460ff00 = false
+"a4a36d33-96f3-422c-a233-d4021460ff00" = false
 
 # y is treated like a vowel at the end of a consonant cluster
-adc90017-1a12-4100-b595-e346105042c7 = false
+"adc90017-1a12-4100-b595-e346105042c7" = false
 
 # y as second letter in two letter word
-29b4ca3d-efe5-4a95-9a54-8467f2e5e59a = false
+"29b4ca3d-efe5-4a95-9a54-8467f2e5e59a" = false
 
 # a whole phrase
-44616581-5ce3-4a81-82d0-40c7ab13d2cf = false
+"44616581-5ce3-4a81-82d0-40c7ab13d2cf" = false

--- a/exercises/poker/.meta/tests.toml
+++ b/exercises/poker/.meta/tests.toml
@@ -1,0 +1,85 @@
+[canonical-tests]
+
+# single hand always wins
+"161f485e-39c2-4012-84cf-bec0c755b66c" = true
+
+# highest card out of all hands wins
+"370ac23a-a00f-48a9-9965-6f3fb595cf45" = true
+
+# a tie has multiple winners
+"d94ad5a7-17df-484b-9932-c64fc26cff52" = true
+
+# multiple hands with the same high cards, tie compares next highest ranked, down to last card
+"61ed83a9-cfaa-40a5-942a-51f52f0a8725" = true
+
+# one pair beats high card
+"f7175a89-34ff-44de-b3d7-f6fd97d1fca4" = true
+
+# highest pair wins
+"e114fd41-a301-4111-a9e7-5a7f72a76561" = true
+
+# two pairs beats one pair
+"935bb4dc-a622-4400-97fa-86e7d06b1f76" = true
+
+# both hands have two pairs, highest ranked pair wins
+"c8aeafe1-6e3d-4711-a6de-5161deca91fd" = true
+
+# both hands have two pairs, with the same highest ranked pair, tie goes to low pair
+"88abe1ba-7ad7-40f3-847e-0a26f8e46a60" = true
+
+# both hands have two identically ranked pairs, tie goes to remaining card (kicker)
+"15a7a315-0577-47a3-9981-d6cf8e6f387b" = true
+
+# three of a kind beats two pair
+"21e9f1e6-2d72-49a1-a930-228e5e0195dc" = true
+
+# both hands have three of a kind, tie goes to highest ranked triplet
+"c2fffd1f-c287-480f-bf2d-9628e63bbcc3" = true
+
+# with multiple decks, two players can have same three of a kind, ties go to highest remaining cards
+"eb856cc2-481c-4b0d-9835-4d75d07a5d9d" = true
+
+# a straight beats three of a kind
+"a858c5d9-2f28-48e7-9980-b7fa04060a60" = true
+
+# aces can end a straight (10 J Q K A)
+"73c9c756-e63e-4b01-a88d-0d4491a7a0e3" = true
+
+# aces can start a straight (A 2 3 4 5)
+"76856b0d-35cd-49ce-a492-fe5db53abc02" = true
+
+# both hands with a straight, tie goes to highest ranked card
+"6980c612-bbff-4914-b17a-b044e4e69ea1" = true
+
+# even though an ace is usually high, a 5-high straight is the lowest-scoring straight
+"5135675c-c2fc-4e21-9ba3-af77a32e9ba4" = true
+
+# flush beats a straight
+"c601b5e6-e1df-4ade-b444-b60ce13b2571" = true
+
+# both hands have a flush, tie goes to high card, down to the last one if necessary
+"4d90261d-251c-49bd-a468-896bf10133de" = true
+
+# full house beats a flush
+"3a19361d-8974-455c-82e5-f7152f5dba7c" = true
+
+# both hands have a full house, tie goes to highest-ranked triplet
+"eb73d0e6-b66c-4f0f-b8ba-bf96bc0a67f0" = true
+
+# with multiple decks, both hands have a full house with the same triplet, tie goes to the pair
+"34b51168-1e43-4c0d-9b32-e356159b4d5d" = true
+
+# four of a kind beats a full house
+"d61e9e99-883b-4f99-b021-18f0ae50c5f4" = true
+
+# both hands have four of a kind, tie goes to high quad
+"2e1c8c63-e0cb-4214-a01b-91954490d2fe" = true
+
+# with multiple decks, both hands with identical four of a kind, tie determined by kicker
+"892ca75d-5474-495d-9f64-a6ce2dcdb7e1" = true
+
+# straight flush beats four of a kind
+"923bd910-dc7b-4f7d-a330-8b42ec10a3ac" = true
+
+# both hands have straight flush, tie goes to highest-ranked card
+"d0927f70-5aec-43db-aed8-1cbd1b6ee9ad" = true

--- a/exercises/poker/.meta/tests.toml
+++ b/exercises/poker/.meta/tests.toml
@@ -1,85 +1,85 @@
 [canonical-tests]
 
 # single hand always wins
-"161f485e-39c2-4012-84cf-bec0c755b66c" = true
+161f485e-39c2-4012-84cf-bec0c755b66c = false
 
 # highest card out of all hands wins
-"370ac23a-a00f-48a9-9965-6f3fb595cf45" = true
+370ac23a-a00f-48a9-9965-6f3fb595cf45 = false
 
 # a tie has multiple winners
-"d94ad5a7-17df-484b-9932-c64fc26cff52" = true
+d94ad5a7-17df-484b-9932-c64fc26cff52 = false
 
 # multiple hands with the same high cards, tie compares next highest ranked, down to last card
-"61ed83a9-cfaa-40a5-942a-51f52f0a8725" = true
+61ed83a9-cfaa-40a5-942a-51f52f0a8725 = false
 
 # one pair beats high card
-"f7175a89-34ff-44de-b3d7-f6fd97d1fca4" = true
+f7175a89-34ff-44de-b3d7-f6fd97d1fca4 = false
 
 # highest pair wins
-"e114fd41-a301-4111-a9e7-5a7f72a76561" = true
+e114fd41-a301-4111-a9e7-5a7f72a76561 = false
 
 # two pairs beats one pair
-"935bb4dc-a622-4400-97fa-86e7d06b1f76" = true
+935bb4dc-a622-4400-97fa-86e7d06b1f76 = false
 
 # both hands have two pairs, highest ranked pair wins
-"c8aeafe1-6e3d-4711-a6de-5161deca91fd" = true
+c8aeafe1-6e3d-4711-a6de-5161deca91fd = false
 
 # both hands have two pairs, with the same highest ranked pair, tie goes to low pair
-"88abe1ba-7ad7-40f3-847e-0a26f8e46a60" = true
+88abe1ba-7ad7-40f3-847e-0a26f8e46a60 = false
 
 # both hands have two identically ranked pairs, tie goes to remaining card (kicker)
-"15a7a315-0577-47a3-9981-d6cf8e6f387b" = true
+15a7a315-0577-47a3-9981-d6cf8e6f387b = false
 
 # three of a kind beats two pair
-"21e9f1e6-2d72-49a1-a930-228e5e0195dc" = true
+21e9f1e6-2d72-49a1-a930-228e5e0195dc = false
 
 # both hands have three of a kind, tie goes to highest ranked triplet
-"c2fffd1f-c287-480f-bf2d-9628e63bbcc3" = true
+c2fffd1f-c287-480f-bf2d-9628e63bbcc3 = false
 
 # with multiple decks, two players can have same three of a kind, ties go to highest remaining cards
-"eb856cc2-481c-4b0d-9835-4d75d07a5d9d" = true
+eb856cc2-481c-4b0d-9835-4d75d07a5d9d = false
 
 # a straight beats three of a kind
-"a858c5d9-2f28-48e7-9980-b7fa04060a60" = true
+a858c5d9-2f28-48e7-9980-b7fa04060a60 = false
 
 # aces can end a straight (10 J Q K A)
-"73c9c756-e63e-4b01-a88d-0d4491a7a0e3" = true
+73c9c756-e63e-4b01-a88d-0d4491a7a0e3 = false
 
 # aces can start a straight (A 2 3 4 5)
-"76856b0d-35cd-49ce-a492-fe5db53abc02" = true
+76856b0d-35cd-49ce-a492-fe5db53abc02 = false
 
 # both hands with a straight, tie goes to highest ranked card
-"6980c612-bbff-4914-b17a-b044e4e69ea1" = true
+6980c612-bbff-4914-b17a-b044e4e69ea1 = false
 
 # even though an ace is usually high, a 5-high straight is the lowest-scoring straight
-"5135675c-c2fc-4e21-9ba3-af77a32e9ba4" = true
+5135675c-c2fc-4e21-9ba3-af77a32e9ba4 = false
 
 # flush beats a straight
-"c601b5e6-e1df-4ade-b444-b60ce13b2571" = true
+c601b5e6-e1df-4ade-b444-b60ce13b2571 = false
 
 # both hands have a flush, tie goes to high card, down to the last one if necessary
-"4d90261d-251c-49bd-a468-896bf10133de" = true
+4d90261d-251c-49bd-a468-896bf10133de = false
 
 # full house beats a flush
-"3a19361d-8974-455c-82e5-f7152f5dba7c" = true
+3a19361d-8974-455c-82e5-f7152f5dba7c = false
 
 # both hands have a full house, tie goes to highest-ranked triplet
-"eb73d0e6-b66c-4f0f-b8ba-bf96bc0a67f0" = true
+eb73d0e6-b66c-4f0f-b8ba-bf96bc0a67f0 = false
 
 # with multiple decks, both hands have a full house with the same triplet, tie goes to the pair
-"34b51168-1e43-4c0d-9b32-e356159b4d5d" = true
+34b51168-1e43-4c0d-9b32-e356159b4d5d = false
 
 # four of a kind beats a full house
-"d61e9e99-883b-4f99-b021-18f0ae50c5f4" = true
+d61e9e99-883b-4f99-b021-18f0ae50c5f4 = false
 
 # both hands have four of a kind, tie goes to high quad
-"2e1c8c63-e0cb-4214-a01b-91954490d2fe" = true
+2e1c8c63-e0cb-4214-a01b-91954490d2fe = false
 
 # with multiple decks, both hands with identical four of a kind, tie determined by kicker
-"892ca75d-5474-495d-9f64-a6ce2dcdb7e1" = true
+892ca75d-5474-495d-9f64-a6ce2dcdb7e1 = false
 
 # straight flush beats four of a kind
-"923bd910-dc7b-4f7d-a330-8b42ec10a3ac" = true
+923bd910-dc7b-4f7d-a330-8b42ec10a3ac = false
 
 # both hands have straight flush, tie goes to highest-ranked card
-"d0927f70-5aec-43db-aed8-1cbd1b6ee9ad" = true
+d0927f70-5aec-43db-aed8-1cbd1b6ee9ad = false

--- a/exercises/poker/.meta/tests.toml
+++ b/exercises/poker/.meta/tests.toml
@@ -1,85 +1,85 @@
 [canonical-tests]
 
 # single hand always wins
-161f485e-39c2-4012-84cf-bec0c755b66c = false
+"161f485e-39c2-4012-84cf-bec0c755b66c" = false
 
 # highest card out of all hands wins
-370ac23a-a00f-48a9-9965-6f3fb595cf45 = false
+"370ac23a-a00f-48a9-9965-6f3fb595cf45" = false
 
 # a tie has multiple winners
-d94ad5a7-17df-484b-9932-c64fc26cff52 = false
+"d94ad5a7-17df-484b-9932-c64fc26cff52" = false
 
 # multiple hands with the same high cards, tie compares next highest ranked, down to last card
-61ed83a9-cfaa-40a5-942a-51f52f0a8725 = false
+"61ed83a9-cfaa-40a5-942a-51f52f0a8725" = false
 
 # one pair beats high card
-f7175a89-34ff-44de-b3d7-f6fd97d1fca4 = false
+"f7175a89-34ff-44de-b3d7-f6fd97d1fca4" = false
 
 # highest pair wins
-e114fd41-a301-4111-a9e7-5a7f72a76561 = false
+"e114fd41-a301-4111-a9e7-5a7f72a76561" = false
 
 # two pairs beats one pair
-935bb4dc-a622-4400-97fa-86e7d06b1f76 = false
+"935bb4dc-a622-4400-97fa-86e7d06b1f76" = false
 
 # both hands have two pairs, highest ranked pair wins
-c8aeafe1-6e3d-4711-a6de-5161deca91fd = false
+"c8aeafe1-6e3d-4711-a6de-5161deca91fd" = false
 
 # both hands have two pairs, with the same highest ranked pair, tie goes to low pair
-88abe1ba-7ad7-40f3-847e-0a26f8e46a60 = false
+"88abe1ba-7ad7-40f3-847e-0a26f8e46a60" = false
 
 # both hands have two identically ranked pairs, tie goes to remaining card (kicker)
-15a7a315-0577-47a3-9981-d6cf8e6f387b = false
+"15a7a315-0577-47a3-9981-d6cf8e6f387b" = false
 
 # three of a kind beats two pair
-21e9f1e6-2d72-49a1-a930-228e5e0195dc = false
+"21e9f1e6-2d72-49a1-a930-228e5e0195dc" = false
 
 # both hands have three of a kind, tie goes to highest ranked triplet
-c2fffd1f-c287-480f-bf2d-9628e63bbcc3 = false
+"c2fffd1f-c287-480f-bf2d-9628e63bbcc3" = false
 
 # with multiple decks, two players can have same three of a kind, ties go to highest remaining cards
-eb856cc2-481c-4b0d-9835-4d75d07a5d9d = false
+"eb856cc2-481c-4b0d-9835-4d75d07a5d9d" = false
 
 # a straight beats three of a kind
-a858c5d9-2f28-48e7-9980-b7fa04060a60 = false
+"a858c5d9-2f28-48e7-9980-b7fa04060a60" = false
 
 # aces can end a straight (10 J Q K A)
-73c9c756-e63e-4b01-a88d-0d4491a7a0e3 = false
+"73c9c756-e63e-4b01-a88d-0d4491a7a0e3" = false
 
 # aces can start a straight (A 2 3 4 5)
-76856b0d-35cd-49ce-a492-fe5db53abc02 = false
+"76856b0d-35cd-49ce-a492-fe5db53abc02" = false
 
 # both hands with a straight, tie goes to highest ranked card
-6980c612-bbff-4914-b17a-b044e4e69ea1 = false
+"6980c612-bbff-4914-b17a-b044e4e69ea1" = false
 
 # even though an ace is usually high, a 5-high straight is the lowest-scoring straight
-5135675c-c2fc-4e21-9ba3-af77a32e9ba4 = false
+"5135675c-c2fc-4e21-9ba3-af77a32e9ba4" = false
 
 # flush beats a straight
-c601b5e6-e1df-4ade-b444-b60ce13b2571 = false
+"c601b5e6-e1df-4ade-b444-b60ce13b2571" = false
 
 # both hands have a flush, tie goes to high card, down to the last one if necessary
-4d90261d-251c-49bd-a468-896bf10133de = false
+"4d90261d-251c-49bd-a468-896bf10133de" = false
 
 # full house beats a flush
-3a19361d-8974-455c-82e5-f7152f5dba7c = false
+"3a19361d-8974-455c-82e5-f7152f5dba7c" = false
 
 # both hands have a full house, tie goes to highest-ranked triplet
-eb73d0e6-b66c-4f0f-b8ba-bf96bc0a67f0 = false
+"eb73d0e6-b66c-4f0f-b8ba-bf96bc0a67f0" = false
 
 # with multiple decks, both hands have a full house with the same triplet, tie goes to the pair
-34b51168-1e43-4c0d-9b32-e356159b4d5d = false
+"34b51168-1e43-4c0d-9b32-e356159b4d5d" = false
 
 # four of a kind beats a full house
-d61e9e99-883b-4f99-b021-18f0ae50c5f4 = false
+"d61e9e99-883b-4f99-b021-18f0ae50c5f4" = false
 
 # both hands have four of a kind, tie goes to high quad
-2e1c8c63-e0cb-4214-a01b-91954490d2fe = false
+"2e1c8c63-e0cb-4214-a01b-91954490d2fe" = false
 
 # with multiple decks, both hands with identical four of a kind, tie determined by kicker
-892ca75d-5474-495d-9f64-a6ce2dcdb7e1 = false
+"892ca75d-5474-495d-9f64-a6ce2dcdb7e1" = false
 
 # straight flush beats four of a kind
-923bd910-dc7b-4f7d-a330-8b42ec10a3ac = false
+"923bd910-dc7b-4f7d-a330-8b42ec10a3ac" = false
 
 # both hands have straight flush, tie goes to highest-ranked card
-d0927f70-5aec-43db-aed8-1cbd1b6ee9ad = false
+"d0927f70-5aec-43db-aed8-1cbd1b6ee9ad" = false

--- a/exercises/prime-factors/.meta/tests.toml
+++ b/exercises/prime-factors/.meta/tests.toml
@@ -1,0 +1,22 @@
+[canonical-tests]
+
+# no factors
+"924fc966-a8f5-4288-82f2-6b9224819ccd" = true
+
+# prime number
+"17e30670-b105-4305-af53-ddde182cb6ad" = true
+
+# square of a prime
+"f59b8350-a180-495a-8fb1-1712fbee1158" = true
+
+# cube of a prime
+"bc8c113f-9580-4516-8669-c5fc29512ceb" = true
+
+# product of primes and non-primes
+"00485cd3-a3fe-4fbe-a64a-a4308fc1f870" = true
+
+# product of primes
+"02251d54-3ca1-4a9b-85e1-b38f4b0ccb91" = true
+
+# factors include a large prime
+"070cf8dc-e202-4285-aa37-8d775c9cd473" = true

--- a/exercises/prime-factors/.meta/tests.toml
+++ b/exercises/prime-factors/.meta/tests.toml
@@ -1,22 +1,22 @@
 [canonical-tests]
 
 # no factors
-924fc966-a8f5-4288-82f2-6b9224819ccd = false
+"924fc966-a8f5-4288-82f2-6b9224819ccd" = false
 
 # prime number
-17e30670-b105-4305-af53-ddde182cb6ad = false
+"17e30670-b105-4305-af53-ddde182cb6ad" = false
 
 # square of a prime
-f59b8350-a180-495a-8fb1-1712fbee1158 = false
+"f59b8350-a180-495a-8fb1-1712fbee1158" = false
 
 # cube of a prime
-bc8c113f-9580-4516-8669-c5fc29512ceb = false
+"bc8c113f-9580-4516-8669-c5fc29512ceb" = false
 
 # product of primes and non-primes
-00485cd3-a3fe-4fbe-a64a-a4308fc1f870 = false
+"00485cd3-a3fe-4fbe-a64a-a4308fc1f870" = false
 
 # product of primes
-02251d54-3ca1-4a9b-85e1-b38f4b0ccb91 = false
+"02251d54-3ca1-4a9b-85e1-b38f4b0ccb91" = false
 
 # factors include a large prime
-070cf8dc-e202-4285-aa37-8d775c9cd473 = false
+"070cf8dc-e202-4285-aa37-8d775c9cd473" = false

--- a/exercises/prime-factors/.meta/tests.toml
+++ b/exercises/prime-factors/.meta/tests.toml
@@ -1,22 +1,22 @@
 [canonical-tests]
 
 # no factors
-"924fc966-a8f5-4288-82f2-6b9224819ccd" = true
+924fc966-a8f5-4288-82f2-6b9224819ccd = false
 
 # prime number
-"17e30670-b105-4305-af53-ddde182cb6ad" = true
+17e30670-b105-4305-af53-ddde182cb6ad = false
 
 # square of a prime
-"f59b8350-a180-495a-8fb1-1712fbee1158" = true
+f59b8350-a180-495a-8fb1-1712fbee1158 = false
 
 # cube of a prime
-"bc8c113f-9580-4516-8669-c5fc29512ceb" = true
+bc8c113f-9580-4516-8669-c5fc29512ceb = false
 
 # product of primes and non-primes
-"00485cd3-a3fe-4fbe-a64a-a4308fc1f870" = true
+00485cd3-a3fe-4fbe-a64a-a4308fc1f870 = false
 
 # product of primes
-"02251d54-3ca1-4a9b-85e1-b38f4b0ccb91" = true
+02251d54-3ca1-4a9b-85e1-b38f4b0ccb91 = false
 
 # factors include a large prime
-"070cf8dc-e202-4285-aa37-8d775c9cd473" = true
+070cf8dc-e202-4285-aa37-8d775c9cd473 = false

--- a/exercises/protein-translation/.meta/tests.toml
+++ b/exercises/protein-translation/.meta/tests.toml
@@ -1,0 +1,70 @@
+[canonical-tests]
+
+# Methionine RNA sequence
+"96d3d44f-34a2-4db4-84cd-fff523e069be" = true
+
+# Phenylalanine RNA sequence 1
+"1b4c56d8-d69f-44eb-be0e-7b17546143d9" = true
+
+# Phenylalanine RNA sequence 2
+"81b53646-bd57-4732-b2cb-6b1880e36d11" = true
+
+# Leucine RNA sequence 1
+"42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4" = true
+
+# Leucine RNA sequence 2
+"ac5edadd-08ed-40a3-b2b9-d82bb50424c4" = true
+
+# Serine RNA sequence 1
+"8bc36e22-f984-44c3-9f6b-ee5d4e73f120" = true
+
+# Serine RNA sequence 2
+"5c3fa5da-4268-44e5-9f4b-f016ccf90131" = true
+
+# Serine RNA sequence 3
+"00579891-b594-42b4-96dc-7ff8bf519606" = true
+
+# Serine RNA sequence 4
+"08c61c3b-fa34-4950-8c4a-133945570ef6" = true
+
+# Tyrosine RNA sequence 1
+"54e1e7d8-63c0-456d-91d2-062c72f8eef5" = true
+
+# Tyrosine RNA sequence 2
+"47bcfba2-9d72-46ad-bbce-22f7666b7eb1" = true
+
+# Cysteine RNA sequence 1
+"3a691829-fe72-43a7-8c8e-1bd083163f72" = true
+
+# Cysteine RNA sequence 2
+"1b6f8a26-ca2f-43b8-8262-3ee446021767" = true
+
+# Tryptophan RNA sequence
+"1e91c1eb-02c0-48a0-9e35-168ad0cb5f39" = true
+
+# STOP codon RNA sequence 1
+"e547af0b-aeab-49c7-9f13-801773a73557" = true
+
+# STOP codon RNA sequence 2
+"67640947-ff02-4f23-a2ef-816f8a2ba72e" = true
+
+# STOP codon RNA sequence 3
+"9c2ad527-ebc9-4ace-808b-2b6447cb54cb" = true
+
+# Translate RNA strand into correct protein list
+"d0f295df-fb70-425c-946c-ec2ec185388e" = true
+
+# Translation stops if STOP codon at beginning of sequence
+"e30e8505-97ec-4e5f-a73e-5726a1faa1f4" = true
+
+# Translation stops if STOP codon at end of two-codon sequence
+"5358a20b-6f4c-4893-bce4-f929001710f3" = true
+
+# Translation stops if STOP codon at end of three-codon sequence
+"ba16703a-1a55-482f-bb07-b21eef5093a3" = true
+
+# Translation stops if STOP codon in middle of three-codon sequence
+"4089bb5a-d5b4-4e71-b79e-b8d1f14a2911" = true
+
+# Translation stops if STOP codon in middle of six-codon sequence
+"2c2a2a60-401f-4a80-b977-e0715b23b93d" = true

--- a/exercises/protein-translation/.meta/tests.toml
+++ b/exercises/protein-translation/.meta/tests.toml
@@ -1,70 +1,70 @@
 [canonical-tests]
 
 # Methionine RNA sequence
-"96d3d44f-34a2-4db4-84cd-fff523e069be" = true
+96d3d44f-34a2-4db4-84cd-fff523e069be = false
 
 # Phenylalanine RNA sequence 1
-"1b4c56d8-d69f-44eb-be0e-7b17546143d9" = true
+1b4c56d8-d69f-44eb-be0e-7b17546143d9 = false
 
 # Phenylalanine RNA sequence 2
-"81b53646-bd57-4732-b2cb-6b1880e36d11" = true
+81b53646-bd57-4732-b2cb-6b1880e36d11 = false
 
 # Leucine RNA sequence 1
-"42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4" = true
+42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4 = false
 
 # Leucine RNA sequence 2
-"ac5edadd-08ed-40a3-b2b9-d82bb50424c4" = true
+ac5edadd-08ed-40a3-b2b9-d82bb50424c4 = false
 
 # Serine RNA sequence 1
-"8bc36e22-f984-44c3-9f6b-ee5d4e73f120" = true
+8bc36e22-f984-44c3-9f6b-ee5d4e73f120 = false
 
 # Serine RNA sequence 2
-"5c3fa5da-4268-44e5-9f4b-f016ccf90131" = true
+5c3fa5da-4268-44e5-9f4b-f016ccf90131 = false
 
 # Serine RNA sequence 3
-"00579891-b594-42b4-96dc-7ff8bf519606" = true
+00579891-b594-42b4-96dc-7ff8bf519606 = false
 
 # Serine RNA sequence 4
-"08c61c3b-fa34-4950-8c4a-133945570ef6" = true
+08c61c3b-fa34-4950-8c4a-133945570ef6 = false
 
 # Tyrosine RNA sequence 1
-"54e1e7d8-63c0-456d-91d2-062c72f8eef5" = true
+54e1e7d8-63c0-456d-91d2-062c72f8eef5 = false
 
 # Tyrosine RNA sequence 2
-"47bcfba2-9d72-46ad-bbce-22f7666b7eb1" = true
+47bcfba2-9d72-46ad-bbce-22f7666b7eb1 = false
 
 # Cysteine RNA sequence 1
-"3a691829-fe72-43a7-8c8e-1bd083163f72" = true
+3a691829-fe72-43a7-8c8e-1bd083163f72 = false
 
 # Cysteine RNA sequence 2
-"1b6f8a26-ca2f-43b8-8262-3ee446021767" = true
+1b6f8a26-ca2f-43b8-8262-3ee446021767 = false
 
 # Tryptophan RNA sequence
-"1e91c1eb-02c0-48a0-9e35-168ad0cb5f39" = true
+1e91c1eb-02c0-48a0-9e35-168ad0cb5f39 = false
 
 # STOP codon RNA sequence 1
-"e547af0b-aeab-49c7-9f13-801773a73557" = true
+e547af0b-aeab-49c7-9f13-801773a73557 = false
 
 # STOP codon RNA sequence 2
-"67640947-ff02-4f23-a2ef-816f8a2ba72e" = true
+67640947-ff02-4f23-a2ef-816f8a2ba72e = false
 
 # STOP codon RNA sequence 3
-"9c2ad527-ebc9-4ace-808b-2b6447cb54cb" = true
+9c2ad527-ebc9-4ace-808b-2b6447cb54cb = false
 
 # Translate RNA strand into correct protein list
-"d0f295df-fb70-425c-946c-ec2ec185388e" = true
+d0f295df-fb70-425c-946c-ec2ec185388e = false
 
 # Translation stops if STOP codon at beginning of sequence
-"e30e8505-97ec-4e5f-a73e-5726a1faa1f4" = true
+e30e8505-97ec-4e5f-a73e-5726a1faa1f4 = false
 
 # Translation stops if STOP codon at end of two-codon sequence
-"5358a20b-6f4c-4893-bce4-f929001710f3" = true
+5358a20b-6f4c-4893-bce4-f929001710f3 = false
 
 # Translation stops if STOP codon at end of three-codon sequence
-"ba16703a-1a55-482f-bb07-b21eef5093a3" = true
+ba16703a-1a55-482f-bb07-b21eef5093a3 = false
 
 # Translation stops if STOP codon in middle of three-codon sequence
-"4089bb5a-d5b4-4e71-b79e-b8d1f14a2911" = true
+4089bb5a-d5b4-4e71-b79e-b8d1f14a2911 = false
 
 # Translation stops if STOP codon in middle of six-codon sequence
-"2c2a2a60-401f-4a80-b977-e0715b23b93d" = true
+2c2a2a60-401f-4a80-b977-e0715b23b93d = false

--- a/exercises/protein-translation/.meta/tests.toml
+++ b/exercises/protein-translation/.meta/tests.toml
@@ -1,70 +1,70 @@
 [canonical-tests]
 
 # Methionine RNA sequence
-96d3d44f-34a2-4db4-84cd-fff523e069be = false
+"96d3d44f-34a2-4db4-84cd-fff523e069be" = false
 
 # Phenylalanine RNA sequence 1
-1b4c56d8-d69f-44eb-be0e-7b17546143d9 = false
+"1b4c56d8-d69f-44eb-be0e-7b17546143d9" = false
 
 # Phenylalanine RNA sequence 2
-81b53646-bd57-4732-b2cb-6b1880e36d11 = false
+"81b53646-bd57-4732-b2cb-6b1880e36d11" = false
 
 # Leucine RNA sequence 1
-42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4 = false
+"42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4" = false
 
 # Leucine RNA sequence 2
-ac5edadd-08ed-40a3-b2b9-d82bb50424c4 = false
+"ac5edadd-08ed-40a3-b2b9-d82bb50424c4" = false
 
 # Serine RNA sequence 1
-8bc36e22-f984-44c3-9f6b-ee5d4e73f120 = false
+"8bc36e22-f984-44c3-9f6b-ee5d4e73f120" = false
 
 # Serine RNA sequence 2
-5c3fa5da-4268-44e5-9f4b-f016ccf90131 = false
+"5c3fa5da-4268-44e5-9f4b-f016ccf90131" = false
 
 # Serine RNA sequence 3
-00579891-b594-42b4-96dc-7ff8bf519606 = false
+"00579891-b594-42b4-96dc-7ff8bf519606" = false
 
 # Serine RNA sequence 4
-08c61c3b-fa34-4950-8c4a-133945570ef6 = false
+"08c61c3b-fa34-4950-8c4a-133945570ef6" = false
 
 # Tyrosine RNA sequence 1
-54e1e7d8-63c0-456d-91d2-062c72f8eef5 = false
+"54e1e7d8-63c0-456d-91d2-062c72f8eef5" = false
 
 # Tyrosine RNA sequence 2
-47bcfba2-9d72-46ad-bbce-22f7666b7eb1 = false
+"47bcfba2-9d72-46ad-bbce-22f7666b7eb1" = false
 
 # Cysteine RNA sequence 1
-3a691829-fe72-43a7-8c8e-1bd083163f72 = false
+"3a691829-fe72-43a7-8c8e-1bd083163f72" = false
 
 # Cysteine RNA sequence 2
-1b6f8a26-ca2f-43b8-8262-3ee446021767 = false
+"1b6f8a26-ca2f-43b8-8262-3ee446021767" = false
 
 # Tryptophan RNA sequence
-1e91c1eb-02c0-48a0-9e35-168ad0cb5f39 = false
+"1e91c1eb-02c0-48a0-9e35-168ad0cb5f39" = false
 
 # STOP codon RNA sequence 1
-e547af0b-aeab-49c7-9f13-801773a73557 = false
+"e547af0b-aeab-49c7-9f13-801773a73557" = false
 
 # STOP codon RNA sequence 2
-67640947-ff02-4f23-a2ef-816f8a2ba72e = false
+"67640947-ff02-4f23-a2ef-816f8a2ba72e" = false
 
 # STOP codon RNA sequence 3
-9c2ad527-ebc9-4ace-808b-2b6447cb54cb = false
+"9c2ad527-ebc9-4ace-808b-2b6447cb54cb" = false
 
 # Translate RNA strand into correct protein list
-d0f295df-fb70-425c-946c-ec2ec185388e = false
+"d0f295df-fb70-425c-946c-ec2ec185388e" = false
 
 # Translation stops if STOP codon at beginning of sequence
-e30e8505-97ec-4e5f-a73e-5726a1faa1f4 = false
+"e30e8505-97ec-4e5f-a73e-5726a1faa1f4" = false
 
 # Translation stops if STOP codon at end of two-codon sequence
-5358a20b-6f4c-4893-bce4-f929001710f3 = false
+"5358a20b-6f4c-4893-bce4-f929001710f3" = false
 
 # Translation stops if STOP codon at end of three-codon sequence
-ba16703a-1a55-482f-bb07-b21eef5093a3 = false
+"ba16703a-1a55-482f-bb07-b21eef5093a3" = false
 
 # Translation stops if STOP codon in middle of three-codon sequence
-4089bb5a-d5b4-4e71-b79e-b8d1f14a2911 = false
+"4089bb5a-d5b4-4e71-b79e-b8d1f14a2911" = false
 
 # Translation stops if STOP codon in middle of six-codon sequence
-2c2a2a60-401f-4a80-b977-e0715b23b93d = false
+"2c2a2a60-401f-4a80-b977-e0715b23b93d" = false

--- a/exercises/proverb/.meta/tests.toml
+++ b/exercises/proverb/.meta/tests.toml
@@ -1,0 +1,19 @@
+[canonical-tests]
+
+# zero pieces
+"e974b73e-7851-484f-8d6d-92e07fe742fc" = true
+
+# one piece
+"2fcd5f5e-8b82-4e74-b51d-df28a5e0faa4" = true
+
+# two pieces
+"d9d0a8a1-d933-46e2-aa94-eecf679f4b0e" = true
+
+# three pieces
+"c95ef757-5e94-4f0d-a6cb-d2083f5e5a83" = true
+
+# full proverb
+"433fb91c-35a2-4d41-aeab-4de1e82b2126" = true
+
+# four pieces modernized
+"c1eefa5a-e8d9-41c7-91d4-99fab6d6b9f7" = true

--- a/exercises/proverb/.meta/tests.toml
+++ b/exercises/proverb/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # zero pieces
-"e974b73e-7851-484f-8d6d-92e07fe742fc" = true
+e974b73e-7851-484f-8d6d-92e07fe742fc = false
 
 # one piece
-"2fcd5f5e-8b82-4e74-b51d-df28a5e0faa4" = true
+2fcd5f5e-8b82-4e74-b51d-df28a5e0faa4 = false
 
 # two pieces
-"d9d0a8a1-d933-46e2-aa94-eecf679f4b0e" = true
+d9d0a8a1-d933-46e2-aa94-eecf679f4b0e = false
 
 # three pieces
-"c95ef757-5e94-4f0d-a6cb-d2083f5e5a83" = true
+c95ef757-5e94-4f0d-a6cb-d2083f5e5a83 = false
 
 # full proverb
-"433fb91c-35a2-4d41-aeab-4de1e82b2126" = true
+433fb91c-35a2-4d41-aeab-4de1e82b2126 = false
 
 # four pieces modernized
-"c1eefa5a-e8d9-41c7-91d4-99fab6d6b9f7" = true
+c1eefa5a-e8d9-41c7-91d4-99fab6d6b9f7 = false

--- a/exercises/proverb/.meta/tests.toml
+++ b/exercises/proverb/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # zero pieces
-e974b73e-7851-484f-8d6d-92e07fe742fc = false
+"e974b73e-7851-484f-8d6d-92e07fe742fc" = false
 
 # one piece
-2fcd5f5e-8b82-4e74-b51d-df28a5e0faa4 = false
+"2fcd5f5e-8b82-4e74-b51d-df28a5e0faa4" = false
 
 # two pieces
-d9d0a8a1-d933-46e2-aa94-eecf679f4b0e = false
+"d9d0a8a1-d933-46e2-aa94-eecf679f4b0e" = false
 
 # three pieces
-c95ef757-5e94-4f0d-a6cb-d2083f5e5a83 = false
+"c95ef757-5e94-4f0d-a6cb-d2083f5e5a83" = false
 
 # full proverb
-433fb91c-35a2-4d41-aeab-4de1e82b2126 = false
+"433fb91c-35a2-4d41-aeab-4de1e82b2126" = false
 
 # four pieces modernized
-c1eefa5a-e8d9-41c7-91d4-99fab6d6b9f7 = false
+"c1eefa5a-e8d9-41c7-91d4-99fab6d6b9f7" = false

--- a/exercises/pythagorean-triplet/.meta/tests.toml
+++ b/exercises/pythagorean-triplet/.meta/tests.toml
@@ -1,0 +1,22 @@
+[canonical-tests]
+
+# triplets whose sum is 12
+"a19de65d-35b8-4480-b1af-371d9541e706" = true
+
+# triplets whose sum is 108
+"48b21332-0a3d-43b2-9a52-90b2a6e5c9f5" = true
+
+# triplets whose sum is 1000
+"dffc1266-418e-4daa-81af-54c3e95c3bb5" = true
+
+# no matching triplets for 1001
+"5f86a2d4-6383-4cce-93a5-e4489e79b186" = true
+
+# returns all matching triplets
+"bf17ba80-1596-409a-bb13-343bdb3b2904" = true
+
+# several matching triplets
+"9d8fb5d5-6c6f-42df-9f95-d3165963ac57" = true
+
+# triplets for large number
+"f5be5734-8aa0-4bd1-99a2-02adcc4402b4" = true

--- a/exercises/pythagorean-triplet/.meta/tests.toml
+++ b/exercises/pythagorean-triplet/.meta/tests.toml
@@ -1,22 +1,22 @@
 [canonical-tests]
 
 # triplets whose sum is 12
-"a19de65d-35b8-4480-b1af-371d9541e706" = true
+a19de65d-35b8-4480-b1af-371d9541e706 = false
 
 # triplets whose sum is 108
-"48b21332-0a3d-43b2-9a52-90b2a6e5c9f5" = true
+48b21332-0a3d-43b2-9a52-90b2a6e5c9f5 = false
 
 # triplets whose sum is 1000
-"dffc1266-418e-4daa-81af-54c3e95c3bb5" = true
+dffc1266-418e-4daa-81af-54c3e95c3bb5 = false
 
 # no matching triplets for 1001
-"5f86a2d4-6383-4cce-93a5-e4489e79b186" = true
+5f86a2d4-6383-4cce-93a5-e4489e79b186 = false
 
 # returns all matching triplets
-"bf17ba80-1596-409a-bb13-343bdb3b2904" = true
+bf17ba80-1596-409a-bb13-343bdb3b2904 = false
 
 # several matching triplets
-"9d8fb5d5-6c6f-42df-9f95-d3165963ac57" = true
+9d8fb5d5-6c6f-42df-9f95-d3165963ac57 = false
 
 # triplets for large number
-"f5be5734-8aa0-4bd1-99a2-02adcc4402b4" = true
+f5be5734-8aa0-4bd1-99a2-02adcc4402b4 = false

--- a/exercises/pythagorean-triplet/.meta/tests.toml
+++ b/exercises/pythagorean-triplet/.meta/tests.toml
@@ -1,22 +1,22 @@
 [canonical-tests]
 
 # triplets whose sum is 12
-a19de65d-35b8-4480-b1af-371d9541e706 = false
+"a19de65d-35b8-4480-b1af-371d9541e706" = false
 
 # triplets whose sum is 108
-48b21332-0a3d-43b2-9a52-90b2a6e5c9f5 = false
+"48b21332-0a3d-43b2-9a52-90b2a6e5c9f5" = false
 
 # triplets whose sum is 1000
-dffc1266-418e-4daa-81af-54c3e95c3bb5 = false
+"dffc1266-418e-4daa-81af-54c3e95c3bb5" = false
 
 # no matching triplets for 1001
-5f86a2d4-6383-4cce-93a5-e4489e79b186 = false
+"5f86a2d4-6383-4cce-93a5-e4489e79b186" = false
 
 # returns all matching triplets
-bf17ba80-1596-409a-bb13-343bdb3b2904 = false
+"bf17ba80-1596-409a-bb13-343bdb3b2904" = false
 
 # several matching triplets
-9d8fb5d5-6c6f-42df-9f95-d3165963ac57 = false
+"9d8fb5d5-6c6f-42df-9f95-d3165963ac57" = false
 
 # triplets for large number
-f5be5734-8aa0-4bd1-99a2-02adcc4402b4 = false
+"f5be5734-8aa0-4bd1-99a2-02adcc4402b4" = false

--- a/exercises/queen-attack/.meta/tests.toml
+++ b/exercises/queen-attack/.meta/tests.toml
@@ -1,0 +1,37 @@
+[canonical-tests]
+
+# queen with a valid position
+"3ac4f735-d36c-44c4-a3e2-316f79704203" = true
+
+# queen must have positive row
+"4e812d5d-b974-4e38-9a6b-8e0492bfa7be" = true
+
+# queen must have row on board
+"f07b7536-b66b-4f08-beb9-4d70d891d5c8" = true
+
+# queen must have positive column
+"15a10794-36d9-4907-ae6b-e5a0d4c54ebe" = true
+
+# queen must have column on board
+"6907762d-0e8a-4c38-87fb-12f2f65f0ce4" = true
+
+# can not attack
+"33ae4113-d237-42ee-bac1-e1e699c0c007" = true
+
+# can attack on same row
+"eaa65540-ea7c-4152-8c21-003c7a68c914" = true
+
+# can attack on same column
+"bae6f609-2c0e-4154-af71-af82b7c31cea" = true
+
+# can attack on first diagonal
+"0e1b4139-b90d-4562-bd58-dfa04f1746c7" = true
+
+# can attack on second diagonal
+"ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd" = true
+
+# can attack on third diagonal
+"0a71e605-6e28-4cc2-aa47-d20a2e71037a" = true
+
+# can attack on fourth diagonal
+"0790b588-ae73-4f1f-a968-dd0b34f45f86" = true

--- a/exercises/queen-attack/.meta/tests.toml
+++ b/exercises/queen-attack/.meta/tests.toml
@@ -1,37 +1,37 @@
 [canonical-tests]
 
 # queen with a valid position
-3ac4f735-d36c-44c4-a3e2-316f79704203 = false
+"3ac4f735-d36c-44c4-a3e2-316f79704203" = false
 
 # queen must have positive row
-4e812d5d-b974-4e38-9a6b-8e0492bfa7be = false
+"4e812d5d-b974-4e38-9a6b-8e0492bfa7be" = false
 
 # queen must have row on board
-f07b7536-b66b-4f08-beb9-4d70d891d5c8 = false
+"f07b7536-b66b-4f08-beb9-4d70d891d5c8" = false
 
 # queen must have positive column
-15a10794-36d9-4907-ae6b-e5a0d4c54ebe = false
+"15a10794-36d9-4907-ae6b-e5a0d4c54ebe" = false
 
 # queen must have column on board
-6907762d-0e8a-4c38-87fb-12f2f65f0ce4 = false
+"6907762d-0e8a-4c38-87fb-12f2f65f0ce4" = false
 
 # can not attack
-33ae4113-d237-42ee-bac1-e1e699c0c007 = false
+"33ae4113-d237-42ee-bac1-e1e699c0c007" = false
 
 # can attack on same row
-eaa65540-ea7c-4152-8c21-003c7a68c914 = false
+"eaa65540-ea7c-4152-8c21-003c7a68c914" = false
 
 # can attack on same column
-bae6f609-2c0e-4154-af71-af82b7c31cea = false
+"bae6f609-2c0e-4154-af71-af82b7c31cea" = false
 
 # can attack on first diagonal
-0e1b4139-b90d-4562-bd58-dfa04f1746c7 = false
+"0e1b4139-b90d-4562-bd58-dfa04f1746c7" = false
 
 # can attack on second diagonal
-ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd = false
+"ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd" = false
 
 # can attack on third diagonal
-0a71e605-6e28-4cc2-aa47-d20a2e71037a = false
+"0a71e605-6e28-4cc2-aa47-d20a2e71037a" = false
 
 # can attack on fourth diagonal
-0790b588-ae73-4f1f-a968-dd0b34f45f86 = false
+"0790b588-ae73-4f1f-a968-dd0b34f45f86" = false

--- a/exercises/queen-attack/.meta/tests.toml
+++ b/exercises/queen-attack/.meta/tests.toml
@@ -1,37 +1,37 @@
 [canonical-tests]
 
 # queen with a valid position
-"3ac4f735-d36c-44c4-a3e2-316f79704203" = true
+3ac4f735-d36c-44c4-a3e2-316f79704203 = false
 
 # queen must have positive row
-"4e812d5d-b974-4e38-9a6b-8e0492bfa7be" = true
+4e812d5d-b974-4e38-9a6b-8e0492bfa7be = false
 
 # queen must have row on board
-"f07b7536-b66b-4f08-beb9-4d70d891d5c8" = true
+f07b7536-b66b-4f08-beb9-4d70d891d5c8 = false
 
 # queen must have positive column
-"15a10794-36d9-4907-ae6b-e5a0d4c54ebe" = true
+15a10794-36d9-4907-ae6b-e5a0d4c54ebe = false
 
 # queen must have column on board
-"6907762d-0e8a-4c38-87fb-12f2f65f0ce4" = true
+6907762d-0e8a-4c38-87fb-12f2f65f0ce4 = false
 
 # can not attack
-"33ae4113-d237-42ee-bac1-e1e699c0c007" = true
+33ae4113-d237-42ee-bac1-e1e699c0c007 = false
 
 # can attack on same row
-"eaa65540-ea7c-4152-8c21-003c7a68c914" = true
+eaa65540-ea7c-4152-8c21-003c7a68c914 = false
 
 # can attack on same column
-"bae6f609-2c0e-4154-af71-af82b7c31cea" = true
+bae6f609-2c0e-4154-af71-af82b7c31cea = false
 
 # can attack on first diagonal
-"0e1b4139-b90d-4562-bd58-dfa04f1746c7" = true
+0e1b4139-b90d-4562-bd58-dfa04f1746c7 = false
 
 # can attack on second diagonal
-"ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd" = true
+ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd = false
 
 # can attack on third diagonal
-"0a71e605-6e28-4cc2-aa47-d20a2e71037a" = true
+0a71e605-6e28-4cc2-aa47-d20a2e71037a = false
 
 # can attack on fourth diagonal
-"0790b588-ae73-4f1f-a968-dd0b34f45f86" = true
+0790b588-ae73-4f1f-a968-dd0b34f45f86 = false

--- a/exercises/rail-fence-cipher/.meta/tests.toml
+++ b/exercises/rail-fence-cipher/.meta/tests.toml
@@ -1,0 +1,19 @@
+[canonical-tests]
+
+# encode with two rails
+"46dc5c50-5538-401d-93a5-41102680d068" = true
+
+# encode with three rails
+"25691697-fbd8-4278-8c38-b84068b7bc29" = true
+
+# encode with ending in the middle
+"384f0fea-1442-4f1a-a7c4-5cbc2044002c" = true
+
+# decode with three rails
+"cd525b17-ec34-45ef-8f0e-4f27c24a7127" = true
+
+# decode with five rails
+"dd7b4a98-1a52-4e5c-9499-cbb117833507" = true
+
+# decode with six rails
+"93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3" = true

--- a/exercises/rail-fence-cipher/.meta/tests.toml
+++ b/exercises/rail-fence-cipher/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # encode with two rails
-46dc5c50-5538-401d-93a5-41102680d068 = false
+"46dc5c50-5538-401d-93a5-41102680d068" = false
 
 # encode with three rails
-25691697-fbd8-4278-8c38-b84068b7bc29 = false
+"25691697-fbd8-4278-8c38-b84068b7bc29" = false
 
 # encode with ending in the middle
-384f0fea-1442-4f1a-a7c4-5cbc2044002c = false
+"384f0fea-1442-4f1a-a7c4-5cbc2044002c" = false
 
 # decode with three rails
-cd525b17-ec34-45ef-8f0e-4f27c24a7127 = false
+"cd525b17-ec34-45ef-8f0e-4f27c24a7127" = false
 
 # decode with five rails
-dd7b4a98-1a52-4e5c-9499-cbb117833507 = false
+"dd7b4a98-1a52-4e5c-9499-cbb117833507" = false
 
 # decode with six rails
-93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3 = false
+"93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3" = false

--- a/exercises/rail-fence-cipher/.meta/tests.toml
+++ b/exercises/rail-fence-cipher/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # encode with two rails
-"46dc5c50-5538-401d-93a5-41102680d068" = true
+46dc5c50-5538-401d-93a5-41102680d068 = false
 
 # encode with three rails
-"25691697-fbd8-4278-8c38-b84068b7bc29" = true
+25691697-fbd8-4278-8c38-b84068b7bc29 = false
 
 # encode with ending in the middle
-"384f0fea-1442-4f1a-a7c4-5cbc2044002c" = true
+384f0fea-1442-4f1a-a7c4-5cbc2044002c = false
 
 # decode with three rails
-"cd525b17-ec34-45ef-8f0e-4f27c24a7127" = true
+cd525b17-ec34-45ef-8f0e-4f27c24a7127 = false
 
 # decode with five rails
-"dd7b4a98-1a52-4e5c-9499-cbb117833507" = true
+dd7b4a98-1a52-4e5c-9499-cbb117833507 = false
 
 # decode with six rails
-"93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3" = true
+93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3 = false

--- a/exercises/raindrops/.meta/tests.toml
+++ b/exercises/raindrops/.meta/tests.toml
@@ -1,0 +1,55 @@
+[canonical-tests]
+
+# the sound for 1 is 1
+"1575d549-e502-46d4-a8e1-6b7bec6123d8" = true
+
+# the sound for 3 is Pling
+"1f51a9f9-4895-4539-b182-d7b0a5ab2913" = true
+
+# the sound for 5 is Plang
+"2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = true
+
+# the sound for 7 is Plong
+"d7e60daa-32ef-4c23-b688-2abff46c4806" = true
+
+# the sound for 6 is Pling as it has a factor 3
+"6bb4947b-a724-430c-923f-f0dc3d62e56a" = true
+
+# 2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base
+"ce51e0e8-d9d4-446d-9949-96eac4458c2d" = true
+
+# the sound for 9 is Pling as it has a factor 3
+"0dd66175-e3e2-47fc-8750-d01739856671" = true
+
+# the sound for 10 is Plang as it has a factor 5
+"022c44d3-2182-4471-95d7-c575af225c96" = true
+
+# the sound for 14 is Plong as it has a factor of 7
+"37ab74db-fed3-40ff-b7b9-04acdfea8edf" = true
+
+# the sound for 15 is PlingPlang as it has factors 3 and 5
+"31f92999-6afb-40ee-9aa4-6d15e3334d0f" = true
+
+# the sound for 21 is PlingPlong as it has factors 3 and 7
+"ff9bb95d-6361-4602-be2c-653fe5239b54" = true
+
+# the sound for 25 is Plang as it has a factor 5
+"d2e75317-b72e-40ab-8a64-6734a21dece1" = true
+
+# the sound for 27 is Pling as it has a factor 3
+"a09c4c58-c662-4e32-97fe-f1501ef7125c" = true
+
+# the sound for 35 is PlangPlong as it has factors 5 and 7
+"bdf061de-8564-4899-a843-14b48b722789" = true
+
+# the sound for 49 is Plong as it has a factor 7
+"c4680bee-69ba-439d-99b5-70c5fd1a7a83" = true
+
+# the sound for 52 is 52
+"17f2bc9a-b65a-4d23-8ccd-266e8c271444" = true
+
+# the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7
+"e46677ed-ff1a-419f-a740-5c713d2830e4" = true
+
+# the sound for 3125 is Plang as it has a factor 5
+"13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = true

--- a/exercises/raindrops/.meta/tests.toml
+++ b/exercises/raindrops/.meta/tests.toml
@@ -1,55 +1,55 @@
 [canonical-tests]
 
 # the sound for 1 is 1
-1575d549-e502-46d4-a8e1-6b7bec6123d8 = false
+"1575d549-e502-46d4-a8e1-6b7bec6123d8" = false
 
 # the sound for 3 is Pling
-1f51a9f9-4895-4539-b182-d7b0a5ab2913 = false
+"1f51a9f9-4895-4539-b182-d7b0a5ab2913" = false
 
 # the sound for 5 is Plang
-2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0 = false
+"2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = false
 
 # the sound for 7 is Plong
-d7e60daa-32ef-4c23-b688-2abff46c4806 = false
+"d7e60daa-32ef-4c23-b688-2abff46c4806" = false
 
 # the sound for 6 is Pling as it has a factor 3
-6bb4947b-a724-430c-923f-f0dc3d62e56a = false
+"6bb4947b-a724-430c-923f-f0dc3d62e56a" = false
 
 # 2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base
-ce51e0e8-d9d4-446d-9949-96eac4458c2d = false
+"ce51e0e8-d9d4-446d-9949-96eac4458c2d" = false
 
 # the sound for 9 is Pling as it has a factor 3
-0dd66175-e3e2-47fc-8750-d01739856671 = false
+"0dd66175-e3e2-47fc-8750-d01739856671" = false
 
 # the sound for 10 is Plang as it has a factor 5
-022c44d3-2182-4471-95d7-c575af225c96 = false
+"022c44d3-2182-4471-95d7-c575af225c96" = false
 
 # the sound for 14 is Plong as it has a factor of 7
-37ab74db-fed3-40ff-b7b9-04acdfea8edf = false
+"37ab74db-fed3-40ff-b7b9-04acdfea8edf" = false
 
 # the sound for 15 is PlingPlang as it has factors 3 and 5
-31f92999-6afb-40ee-9aa4-6d15e3334d0f = false
+"31f92999-6afb-40ee-9aa4-6d15e3334d0f" = false
 
 # the sound for 21 is PlingPlong as it has factors 3 and 7
-ff9bb95d-6361-4602-be2c-653fe5239b54 = false
+"ff9bb95d-6361-4602-be2c-653fe5239b54" = false
 
 # the sound for 25 is Plang as it has a factor 5
-d2e75317-b72e-40ab-8a64-6734a21dece1 = false
+"d2e75317-b72e-40ab-8a64-6734a21dece1" = false
 
 # the sound for 27 is Pling as it has a factor 3
-a09c4c58-c662-4e32-97fe-f1501ef7125c = false
+"a09c4c58-c662-4e32-97fe-f1501ef7125c" = false
 
 # the sound for 35 is PlangPlong as it has factors 5 and 7
-bdf061de-8564-4899-a843-14b48b722789 = false
+"bdf061de-8564-4899-a843-14b48b722789" = false
 
 # the sound for 49 is Plong as it has a factor 7
-c4680bee-69ba-439d-99b5-70c5fd1a7a83 = false
+"c4680bee-69ba-439d-99b5-70c5fd1a7a83" = false
 
 # the sound for 52 is 52
-17f2bc9a-b65a-4d23-8ccd-266e8c271444 = false
+"17f2bc9a-b65a-4d23-8ccd-266e8c271444" = false
 
 # the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7
-e46677ed-ff1a-419f-a740-5c713d2830e4 = false
+"e46677ed-ff1a-419f-a740-5c713d2830e4" = false
 
 # the sound for 3125 is Plang as it has a factor 5
-13c6837a-0fcd-4b86-a0eb-20572f7deb0b = false
+"13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = false

--- a/exercises/raindrops/.meta/tests.toml
+++ b/exercises/raindrops/.meta/tests.toml
@@ -1,55 +1,55 @@
 [canonical-tests]
 
 # the sound for 1 is 1
-"1575d549-e502-46d4-a8e1-6b7bec6123d8" = true
+1575d549-e502-46d4-a8e1-6b7bec6123d8 = false
 
 # the sound for 3 is Pling
-"1f51a9f9-4895-4539-b182-d7b0a5ab2913" = true
+1f51a9f9-4895-4539-b182-d7b0a5ab2913 = false
 
 # the sound for 5 is Plang
-"2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = true
+2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0 = false
 
 # the sound for 7 is Plong
-"d7e60daa-32ef-4c23-b688-2abff46c4806" = true
+d7e60daa-32ef-4c23-b688-2abff46c4806 = false
 
 # the sound for 6 is Pling as it has a factor 3
-"6bb4947b-a724-430c-923f-f0dc3d62e56a" = true
+6bb4947b-a724-430c-923f-f0dc3d62e56a = false
 
 # 2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base
-"ce51e0e8-d9d4-446d-9949-96eac4458c2d" = true
+ce51e0e8-d9d4-446d-9949-96eac4458c2d = false
 
 # the sound for 9 is Pling as it has a factor 3
-"0dd66175-e3e2-47fc-8750-d01739856671" = true
+0dd66175-e3e2-47fc-8750-d01739856671 = false
 
 # the sound for 10 is Plang as it has a factor 5
-"022c44d3-2182-4471-95d7-c575af225c96" = true
+022c44d3-2182-4471-95d7-c575af225c96 = false
 
 # the sound for 14 is Plong as it has a factor of 7
-"37ab74db-fed3-40ff-b7b9-04acdfea8edf" = true
+37ab74db-fed3-40ff-b7b9-04acdfea8edf = false
 
 # the sound for 15 is PlingPlang as it has factors 3 and 5
-"31f92999-6afb-40ee-9aa4-6d15e3334d0f" = true
+31f92999-6afb-40ee-9aa4-6d15e3334d0f = false
 
 # the sound for 21 is PlingPlong as it has factors 3 and 7
-"ff9bb95d-6361-4602-be2c-653fe5239b54" = true
+ff9bb95d-6361-4602-be2c-653fe5239b54 = false
 
 # the sound for 25 is Plang as it has a factor 5
-"d2e75317-b72e-40ab-8a64-6734a21dece1" = true
+d2e75317-b72e-40ab-8a64-6734a21dece1 = false
 
 # the sound for 27 is Pling as it has a factor 3
-"a09c4c58-c662-4e32-97fe-f1501ef7125c" = true
+a09c4c58-c662-4e32-97fe-f1501ef7125c = false
 
 # the sound for 35 is PlangPlong as it has factors 5 and 7
-"bdf061de-8564-4899-a843-14b48b722789" = true
+bdf061de-8564-4899-a843-14b48b722789 = false
 
 # the sound for 49 is Plong as it has a factor 7
-"c4680bee-69ba-439d-99b5-70c5fd1a7a83" = true
+c4680bee-69ba-439d-99b5-70c5fd1a7a83 = false
 
 # the sound for 52 is 52
-"17f2bc9a-b65a-4d23-8ccd-266e8c271444" = true
+17f2bc9a-b65a-4d23-8ccd-266e8c271444 = false
 
 # the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7
-"e46677ed-ff1a-419f-a740-5c713d2830e4" = true
+e46677ed-ff1a-419f-a740-5c713d2830e4 = false
 
 # the sound for 3125 is Plang as it has a factor 5
-"13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = true
+13c6837a-0fcd-4b86-a0eb-20572f7deb0b = false

--- a/exercises/react/.meta/tests.toml
+++ b/exercises/react/.meta/tests.toml
@@ -1,0 +1,43 @@
+[canonical-tests]
+
+# input cells have a value
+"c51ee736-d001-4f30-88d1-0c8e8b43cd07" = true
+
+# an input cell's value can be set
+"dedf0fe0-da0c-4d5d-a582-ffaf5f4d0851" = true
+
+# compute cells calculate initial value
+"5854b975-f545-4f93-8968-cc324cde746e" = true
+
+# compute cells take inputs in the right order
+"25795a3d-b86c-4e91-abe7-1c340e71560c" = true
+
+# compute cells update value when dependencies are changed
+"c62689bf-7be5-41bb-b9f8-65178ef3e8ba" = true
+
+# compute cells can depend on other compute cells
+"5ff36b09-0a88-48d4-b7f8-69dcf3feea40" = true
+
+# compute cells fire callbacks
+"abe33eaf-68ad-42a5-b728-05519ca88d2d" = true
+
+# callback cells only fire on change
+"9e5cb3a4-78e5-4290-80f8-a78612c52db2" = true
+
+# callbacks do not report already reported values
+"ada17cb6-7332-448a-b934-e3d7495c13d3" = true
+
+# callbacks can fire from multiple cells
+"ac271900-ea5c-461c-9add-eeebcb8c03e5" = true
+
+# callbacks can be added and removed
+"95a82dcc-8280-4de3-a4cd-4f19a84e3d6f" = true
+
+# removing a callback multiple times doesn't interfere with other callbacks
+"f2a7b445-f783-4e0e-8393-469ab4915f2a" = true
+
+# callbacks should only be called once even if multiple dependencies change
+"daf6feca-09e0-4ce5-801d-770ddfe1c268" = true
+
+# callbacks should not be called if dependencies change but output value doesn't change
+"9a5b159f-b7aa-4729-807e-f1c38a46d377" = true

--- a/exercises/react/.meta/tests.toml
+++ b/exercises/react/.meta/tests.toml
@@ -1,43 +1,43 @@
 [canonical-tests]
 
 # input cells have a value
-"c51ee736-d001-4f30-88d1-0c8e8b43cd07" = true
+c51ee736-d001-4f30-88d1-0c8e8b43cd07 = true
 
 # an input cell's value can be set
-"dedf0fe0-da0c-4d5d-a582-ffaf5f4d0851" = true
+dedf0fe0-da0c-4d5d-a582-ffaf5f4d0851 = false
 
 # compute cells calculate initial value
-"5854b975-f545-4f93-8968-cc324cde746e" = true
+5854b975-f545-4f93-8968-cc324cde746e = true
 
 # compute cells take inputs in the right order
-"25795a3d-b86c-4e91-abe7-1c340e71560c" = true
+25795a3d-b86c-4e91-abe7-1c340e71560c = true
 
 # compute cells update value when dependencies are changed
-"c62689bf-7be5-41bb-b9f8-65178ef3e8ba" = true
+c62689bf-7be5-41bb-b9f8-65178ef3e8ba = true
 
 # compute cells can depend on other compute cells
-"5ff36b09-0a88-48d4-b7f8-69dcf3feea40" = true
+5ff36b09-0a88-48d4-b7f8-69dcf3feea40 = true
 
 # compute cells fire callbacks
-"abe33eaf-68ad-42a5-b728-05519ca88d2d" = true
+abe33eaf-68ad-42a5-b728-05519ca88d2d = true
 
 # callback cells only fire on change
-"9e5cb3a4-78e5-4290-80f8-a78612c52db2" = true
+9e5cb3a4-78e5-4290-80f8-a78612c52db2 = false
 
 # callbacks do not report already reported values
-"ada17cb6-7332-448a-b934-e3d7495c13d3" = true
+ada17cb6-7332-448a-b934-e3d7495c13d3 = false
 
 # callbacks can fire from multiple cells
-"ac271900-ea5c-461c-9add-eeebcb8c03e5" = true
+ac271900-ea5c-461c-9add-eeebcb8c03e5 = false
 
 # callbacks can be added and removed
-"95a82dcc-8280-4de3-a4cd-4f19a84e3d6f" = true
+95a82dcc-8280-4de3-a4cd-4f19a84e3d6f = true
 
 # removing a callback multiple times doesn't interfere with other callbacks
-"f2a7b445-f783-4e0e-8393-469ab4915f2a" = true
+f2a7b445-f783-4e0e-8393-469ab4915f2a = false
 
 # callbacks should only be called once even if multiple dependencies change
-"daf6feca-09e0-4ce5-801d-770ddfe1c268" = true
+daf6feca-09e0-4ce5-801d-770ddfe1c268 = true
 
 # callbacks should not be called if dependencies change but output value doesn't change
-"9a5b159f-b7aa-4729-807e-f1c38a46d377" = true
+9a5b159f-b7aa-4729-807e-f1c38a46d377 = false

--- a/exercises/react/.meta/tests.toml
+++ b/exercises/react/.meta/tests.toml
@@ -4,7 +4,7 @@
 "c51ee736-d001-4f30-88d1-0c8e8b43cd07" = true
 
 # an input cell's value can be set
-"dedf0fe0-da0c-4d5d-a582-ffaf5f4d0851" = false
+"dedf0fe0-da0c-4d5d-a582-ffaf5f4d0851" = true
 
 # compute cells calculate initial value
 "5854b975-f545-4f93-8968-cc324cde746e" = true
@@ -34,10 +34,10 @@
 "95a82dcc-8280-4de3-a4cd-4f19a84e3d6f" = true
 
 # removing a callback multiple times doesn't interfere with other callbacks
-"f2a7b445-f783-4e0e-8393-469ab4915f2a" = false
+"f2a7b445-f783-4e0e-8393-469ab4915f2a" = true
 
 # callbacks should only be called once even if multiple dependencies change
 "daf6feca-09e0-4ce5-801d-770ddfe1c268" = true
 
 # callbacks should not be called if dependencies change but output value doesn't change
-"9a5b159f-b7aa-4729-807e-f1c38a46d377" = false
+"9a5b159f-b7aa-4729-807e-f1c38a46d377" = true

--- a/exercises/react/.meta/tests.toml
+++ b/exercises/react/.meta/tests.toml
@@ -1,43 +1,43 @@
 [canonical-tests]
 
 # input cells have a value
-c51ee736-d001-4f30-88d1-0c8e8b43cd07 = true
+"c51ee736-d001-4f30-88d1-0c8e8b43cd07" = true
 
 # an input cell's value can be set
-dedf0fe0-da0c-4d5d-a582-ffaf5f4d0851 = false
+"dedf0fe0-da0c-4d5d-a582-ffaf5f4d0851" = false
 
 # compute cells calculate initial value
-5854b975-f545-4f93-8968-cc324cde746e = true
+"5854b975-f545-4f93-8968-cc324cde746e" = true
 
 # compute cells take inputs in the right order
-25795a3d-b86c-4e91-abe7-1c340e71560c = true
+"25795a3d-b86c-4e91-abe7-1c340e71560c" = true
 
 # compute cells update value when dependencies are changed
-c62689bf-7be5-41bb-b9f8-65178ef3e8ba = true
+"c62689bf-7be5-41bb-b9f8-65178ef3e8ba" = true
 
 # compute cells can depend on other compute cells
-5ff36b09-0a88-48d4-b7f8-69dcf3feea40 = true
+"5ff36b09-0a88-48d4-b7f8-69dcf3feea40" = true
 
 # compute cells fire callbacks
-abe33eaf-68ad-42a5-b728-05519ca88d2d = true
+"abe33eaf-68ad-42a5-b728-05519ca88d2d" = true
 
 # callback cells only fire on change
-9e5cb3a4-78e5-4290-80f8-a78612c52db2 = false
+"9e5cb3a4-78e5-4290-80f8-a78612c52db2" = false
 
 # callbacks do not report already reported values
-ada17cb6-7332-448a-b934-e3d7495c13d3 = false
+"ada17cb6-7332-448a-b934-e3d7495c13d3" = false
 
 # callbacks can fire from multiple cells
-ac271900-ea5c-461c-9add-eeebcb8c03e5 = false
+"ac271900-ea5c-461c-9add-eeebcb8c03e5" = false
 
 # callbacks can be added and removed
-95a82dcc-8280-4de3-a4cd-4f19a84e3d6f = true
+"95a82dcc-8280-4de3-a4cd-4f19a84e3d6f" = true
 
 # removing a callback multiple times doesn't interfere with other callbacks
-f2a7b445-f783-4e0e-8393-469ab4915f2a = false
+"f2a7b445-f783-4e0e-8393-469ab4915f2a" = false
 
 # callbacks should only be called once even if multiple dependencies change
-daf6feca-09e0-4ce5-801d-770ddfe1c268 = true
+"daf6feca-09e0-4ce5-801d-770ddfe1c268" = true
 
 # callbacks should not be called if dependencies change but output value doesn't change
-9a5b159f-b7aa-4729-807e-f1c38a46d377 = false
+"9a5b159f-b7aa-4729-807e-f1c38a46d377" = false

--- a/exercises/rectangles/.meta/tests.toml
+++ b/exercises/rectangles/.meta/tests.toml
@@ -1,0 +1,40 @@
+[canonical-tests]
+
+# no rows
+"485b7bab-4150-40aa-a8db-73013427d08c" = true
+
+# no columns
+"076929ed-27e8-45dc-b14b-08279944dc49" = true
+
+# no rectangles
+"0a8abbd1-a0a4-4180-aa4e-65c1b1a073fa" = true
+
+# one rectangle
+"a4ba42e9-4e7f-4973-b7c7-4ce0760ac6cd" = true
+
+# two rectangles without shared parts
+"ced06550-83da-4d23-98b7-d24152e0db93" = true
+
+# five rectangles with shared parts
+"5942d69a-a07c-41c8-8b93-2d13877c706a" = true
+
+# rectangle of height 1 is counted
+"82d70be4-ab37-4bf2-a433-e33778d3bbf1" = true
+
+# rectangle of width 1 is counted
+"57f1bc0e-2782-401e-ab12-7c01d8bfc2e0" = true
+
+# 1x1 square is counted
+"ef0bb65c-bd80-4561-9535-efc4067054f9" = true
+
+# only complete rectangles are counted
+"e1e1d444-e926-4d30-9bf3-7d8ec9a9e330" = true
+
+# rectangles can be of different sizes
+"ca021a84-1281-4a56-9b9b-af14113933a4" = true
+
+# corner is required for a rectangle to be complete
+"51f689a7-ef3f-41ae-aa2f-5ea09ad897ff" = true
+
+# large input with many rectangles
+"d78fe379-8c1b-4d3c-bdf7-29bfb6f6dc66" = true

--- a/exercises/rectangles/.meta/tests.toml
+++ b/exercises/rectangles/.meta/tests.toml
@@ -1,40 +1,40 @@
 [canonical-tests]
 
 # no rows
-"485b7bab-4150-40aa-a8db-73013427d08c" = true
+485b7bab-4150-40aa-a8db-73013427d08c = false
 
 # no columns
-"076929ed-27e8-45dc-b14b-08279944dc49" = true
+076929ed-27e8-45dc-b14b-08279944dc49 = false
 
 # no rectangles
-"0a8abbd1-a0a4-4180-aa4e-65c1b1a073fa" = true
+0a8abbd1-a0a4-4180-aa4e-65c1b1a073fa = false
 
 # one rectangle
-"a4ba42e9-4e7f-4973-b7c7-4ce0760ac6cd" = true
+a4ba42e9-4e7f-4973-b7c7-4ce0760ac6cd = false
 
 # two rectangles without shared parts
-"ced06550-83da-4d23-98b7-d24152e0db93" = true
+ced06550-83da-4d23-98b7-d24152e0db93 = false
 
 # five rectangles with shared parts
-"5942d69a-a07c-41c8-8b93-2d13877c706a" = true
+5942d69a-a07c-41c8-8b93-2d13877c706a = false
 
 # rectangle of height 1 is counted
-"82d70be4-ab37-4bf2-a433-e33778d3bbf1" = true
+82d70be4-ab37-4bf2-a433-e33778d3bbf1 = false
 
 # rectangle of width 1 is counted
-"57f1bc0e-2782-401e-ab12-7c01d8bfc2e0" = true
+57f1bc0e-2782-401e-ab12-7c01d8bfc2e0 = false
 
 # 1x1 square is counted
-"ef0bb65c-bd80-4561-9535-efc4067054f9" = true
+ef0bb65c-bd80-4561-9535-efc4067054f9 = false
 
 # only complete rectangles are counted
-"e1e1d444-e926-4d30-9bf3-7d8ec9a9e330" = true
+e1e1d444-e926-4d30-9bf3-7d8ec9a9e330 = false
 
 # rectangles can be of different sizes
-"ca021a84-1281-4a56-9b9b-af14113933a4" = true
+ca021a84-1281-4a56-9b9b-af14113933a4 = false
 
 # corner is required for a rectangle to be complete
-"51f689a7-ef3f-41ae-aa2f-5ea09ad897ff" = true
+51f689a7-ef3f-41ae-aa2f-5ea09ad897ff = false
 
 # large input with many rectangles
-"d78fe379-8c1b-4d3c-bdf7-29bfb6f6dc66" = true
+d78fe379-8c1b-4d3c-bdf7-29bfb6f6dc66 = false

--- a/exercises/rectangles/.meta/tests.toml
+++ b/exercises/rectangles/.meta/tests.toml
@@ -1,40 +1,40 @@
 [canonical-tests]
 
 # no rows
-485b7bab-4150-40aa-a8db-73013427d08c = false
+"485b7bab-4150-40aa-a8db-73013427d08c" = false
 
 # no columns
-076929ed-27e8-45dc-b14b-08279944dc49 = false
+"076929ed-27e8-45dc-b14b-08279944dc49" = false
 
 # no rectangles
-0a8abbd1-a0a4-4180-aa4e-65c1b1a073fa = false
+"0a8abbd1-a0a4-4180-aa4e-65c1b1a073fa" = false
 
 # one rectangle
-a4ba42e9-4e7f-4973-b7c7-4ce0760ac6cd = false
+"a4ba42e9-4e7f-4973-b7c7-4ce0760ac6cd" = false
 
 # two rectangles without shared parts
-ced06550-83da-4d23-98b7-d24152e0db93 = false
+"ced06550-83da-4d23-98b7-d24152e0db93" = false
 
 # five rectangles with shared parts
-5942d69a-a07c-41c8-8b93-2d13877c706a = false
+"5942d69a-a07c-41c8-8b93-2d13877c706a" = false
 
 # rectangle of height 1 is counted
-82d70be4-ab37-4bf2-a433-e33778d3bbf1 = false
+"82d70be4-ab37-4bf2-a433-e33778d3bbf1" = false
 
 # rectangle of width 1 is counted
-57f1bc0e-2782-401e-ab12-7c01d8bfc2e0 = false
+"57f1bc0e-2782-401e-ab12-7c01d8bfc2e0" = false
 
 # 1x1 square is counted
-ef0bb65c-bd80-4561-9535-efc4067054f9 = false
+"ef0bb65c-bd80-4561-9535-efc4067054f9" = false
 
 # only complete rectangles are counted
-e1e1d444-e926-4d30-9bf3-7d8ec9a9e330 = false
+"e1e1d444-e926-4d30-9bf3-7d8ec9a9e330" = false
 
 # rectangles can be of different sizes
-ca021a84-1281-4a56-9b9b-af14113933a4 = false
+"ca021a84-1281-4a56-9b9b-af14113933a4" = false
 
 # corner is required for a rectangle to be complete
-51f689a7-ef3f-41ae-aa2f-5ea09ad897ff = false
+"51f689a7-ef3f-41ae-aa2f-5ea09ad897ff" = false
 
 # large input with many rectangles
-d78fe379-8c1b-4d3c-bdf7-29bfb6f6dc66 = false
+"d78fe379-8c1b-4d3c-bdf7-29bfb6f6dc66" = false

--- a/exercises/reverse-string/.meta/tests.toml
+++ b/exercises/reverse-string/.meta/tests.toml
@@ -1,0 +1,19 @@
+[canonical-tests]
+
+# an empty string
+"c3b7d806-dced-49ee-8543-933fd1719b1c" = true
+
+# a word
+"01ebf55b-bebb-414e-9dec-06f7bb0bee3c" = true
+
+# a capitalized word
+"0f7c07e4-efd1-4aaa-a07a-90b49ce0b746" = true
+
+# a sentence with punctuation
+"71854b9c-f200-4469-9f5c-1e8e5eff5614" = true
+
+# a palindrome
+"1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c" = true
+
+# an even-sized word
+"b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c" = true

--- a/exercises/reverse-string/.meta/tests.toml
+++ b/exercises/reverse-string/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # an empty string
-c3b7d806-dced-49ee-8543-933fd1719b1c = false
+"c3b7d806-dced-49ee-8543-933fd1719b1c" = false
 
 # a word
-01ebf55b-bebb-414e-9dec-06f7bb0bee3c = false
+"01ebf55b-bebb-414e-9dec-06f7bb0bee3c" = false
 
 # a capitalized word
-0f7c07e4-efd1-4aaa-a07a-90b49ce0b746 = false
+"0f7c07e4-efd1-4aaa-a07a-90b49ce0b746" = false
 
 # a sentence with punctuation
-71854b9c-f200-4469-9f5c-1e8e5eff5614 = false
+"71854b9c-f200-4469-9f5c-1e8e5eff5614" = false
 
 # a palindrome
-1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c = false
+"1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c" = false
 
 # an even-sized word
-b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c = false
+"b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c" = false

--- a/exercises/reverse-string/.meta/tests.toml
+++ b/exercises/reverse-string/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # an empty string
-"c3b7d806-dced-49ee-8543-933fd1719b1c" = true
+c3b7d806-dced-49ee-8543-933fd1719b1c = false
 
 # a word
-"01ebf55b-bebb-414e-9dec-06f7bb0bee3c" = true
+01ebf55b-bebb-414e-9dec-06f7bb0bee3c = false
 
 # a capitalized word
-"0f7c07e4-efd1-4aaa-a07a-90b49ce0b746" = true
+0f7c07e4-efd1-4aaa-a07a-90b49ce0b746 = false
 
 # a sentence with punctuation
-"71854b9c-f200-4469-9f5c-1e8e5eff5614" = true
+71854b9c-f200-4469-9f5c-1e8e5eff5614 = false
 
 # a palindrome
-"1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c" = true
+1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c = false
 
 # an even-sized word
-"b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c" = true
+b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c = false

--- a/exercises/rna-transcription/.meta/tests.toml
+++ b/exercises/rna-transcription/.meta/tests.toml
@@ -1,0 +1,19 @@
+[canonical-tests]
+
+# Empty RNA sequence
+"b4631f82-c98c-4a2f-90b3-c5c2b6c6f661" = true
+
+# RNA complement of cytosine is guanine
+"a9558a3c-318c-4240-9256-5d5ed47005a6" = true
+
+# RNA complement of guanine is cytosine
+"6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7" = true
+
+# RNA complement of thymine is adenine
+"870bd3ec-8487-471d-8d9a-a25046488d3e" = true
+
+# RNA complement of adenine is uracil
+"aade8964-02e1-4073-872f-42d3ffd74c5f" = true
+
+# RNA complement
+"79ed2757-f018-4f47-a1d7-34a559392dbf" = true

--- a/exercises/rna-transcription/.meta/tests.toml
+++ b/exercises/rna-transcription/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # Empty RNA sequence
-b4631f82-c98c-4a2f-90b3-c5c2b6c6f661 = false
+"b4631f82-c98c-4a2f-90b3-c5c2b6c6f661" = false
 
 # RNA complement of cytosine is guanine
-a9558a3c-318c-4240-9256-5d5ed47005a6 = false
+"a9558a3c-318c-4240-9256-5d5ed47005a6" = false
 
 # RNA complement of guanine is cytosine
-6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7 = false
+"6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7" = false
 
 # RNA complement of thymine is adenine
-870bd3ec-8487-471d-8d9a-a25046488d3e = false
+"870bd3ec-8487-471d-8d9a-a25046488d3e" = false
 
 # RNA complement of adenine is uracil
-aade8964-02e1-4073-872f-42d3ffd74c5f = false
+"aade8964-02e1-4073-872f-42d3ffd74c5f" = false
 
 # RNA complement
-79ed2757-f018-4f47-a1d7-34a559392dbf = false
+"79ed2757-f018-4f47-a1d7-34a559392dbf" = false

--- a/exercises/rna-transcription/.meta/tests.toml
+++ b/exercises/rna-transcription/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # Empty RNA sequence
-"b4631f82-c98c-4a2f-90b3-c5c2b6c6f661" = true
+b4631f82-c98c-4a2f-90b3-c5c2b6c6f661 = false
 
 # RNA complement of cytosine is guanine
-"a9558a3c-318c-4240-9256-5d5ed47005a6" = true
+a9558a3c-318c-4240-9256-5d5ed47005a6 = false
 
 # RNA complement of guanine is cytosine
-"6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7" = true
+6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7 = false
 
 # RNA complement of thymine is adenine
-"870bd3ec-8487-471d-8d9a-a25046488d3e" = true
+870bd3ec-8487-471d-8d9a-a25046488d3e = false
 
 # RNA complement of adenine is uracil
-"aade8964-02e1-4073-872f-42d3ffd74c5f" = true
+aade8964-02e1-4073-872f-42d3ffd74c5f = false
 
 # RNA complement
-"79ed2757-f018-4f47-a1d7-34a559392dbf" = true
+79ed2757-f018-4f47-a1d7-34a559392dbf = false

--- a/exercises/robot-simulator/.meta/tests.toml
+++ b/exercises/robot-simulator/.meta/tests.toml
@@ -1,0 +1,55 @@
+[canonical-tests]
+
+# at origin facing north
+"c557c16d-26c1-4e06-827c-f6602cd0785c" = true
+
+# at negative position facing south
+"bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d" = true
+
+# changes north to east
+"8cbd0086-6392-4680-b9b9-73cf491e67e5" = true
+
+# changes east to south
+"8abc87fc-eab2-4276-93b7-9c009e866ba1" = true
+
+# changes south to west
+"3cfe1b85-bbf2-4bae-b54d-d73e7e93617a" = true
+
+# changes west to north
+"5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716" = true
+
+# changes north to west
+"fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63" = true
+
+# changes west to south
+"da33d734-831f-445c-9907-d66d7d2a92e2" = true
+
+# changes south to east
+"bd1ca4b9-4548-45f4-b32e-900fc7c19389" = true
+
+# changes east to north
+"2de27b67-a25c-4b59-9883-bc03b1b55bba" = true
+
+# facing north increments Y
+"f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8" = true
+
+# facing south decrements Y
+"2786cf80-5bbf-44b0-9503-a89a9c5789da" = true
+
+# facing east increments X
+"84bf3c8c-241f-434d-883d-69817dbd6a48" = true
+
+# facing west decrements X
+"bb69c4a7-3bbf-4f64-b415-666fa72d7b04" = true
+
+# moving east and north from README
+"e34ac672-4ed4-4be3-a0b8-d9af259cbaa1" = true
+
+# moving west and north
+"f30e4955-4b47-4aa3-8b39-ae98cfbd515b" = true
+
+# moving west and south
+"3e466bf6-20ab-4d79-8b51-264165182fca" = true
+
+# moving east and north
+"41f0bb96-c617-4e6b-acff-a4b279d44514" = true

--- a/exercises/robot-simulator/.meta/tests.toml
+++ b/exercises/robot-simulator/.meta/tests.toml
@@ -1,55 +1,55 @@
 [canonical-tests]
 
 # at origin facing north
-c557c16d-26c1-4e06-827c-f6602cd0785c = false
+"c557c16d-26c1-4e06-827c-f6602cd0785c" = false
 
 # at negative position facing south
-bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d = false
+"bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d" = false
 
 # changes north to east
-8cbd0086-6392-4680-b9b9-73cf491e67e5 = false
+"8cbd0086-6392-4680-b9b9-73cf491e67e5" = false
 
 # changes east to south
-8abc87fc-eab2-4276-93b7-9c009e866ba1 = false
+"8abc87fc-eab2-4276-93b7-9c009e866ba1" = false
 
 # changes south to west
-3cfe1b85-bbf2-4bae-b54d-d73e7e93617a = false
+"3cfe1b85-bbf2-4bae-b54d-d73e7e93617a" = false
 
 # changes west to north
-5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716 = false
+"5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716" = false
 
 # changes north to west
-fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63 = false
+"fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63" = false
 
 # changes west to south
-da33d734-831f-445c-9907-d66d7d2a92e2 = false
+"da33d734-831f-445c-9907-d66d7d2a92e2" = false
 
 # changes south to east
-bd1ca4b9-4548-45f4-b32e-900fc7c19389 = false
+"bd1ca4b9-4548-45f4-b32e-900fc7c19389" = false
 
 # changes east to north
-2de27b67-a25c-4b59-9883-bc03b1b55bba = false
+"2de27b67-a25c-4b59-9883-bc03b1b55bba" = false
 
 # facing north increments Y
-f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8 = false
+"f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8" = false
 
 # facing south decrements Y
-2786cf80-5bbf-44b0-9503-a89a9c5789da = false
+"2786cf80-5bbf-44b0-9503-a89a9c5789da" = false
 
 # facing east increments X
-84bf3c8c-241f-434d-883d-69817dbd6a48 = false
+"84bf3c8c-241f-434d-883d-69817dbd6a48" = false
 
 # facing west decrements X
-bb69c4a7-3bbf-4f64-b415-666fa72d7b04 = false
+"bb69c4a7-3bbf-4f64-b415-666fa72d7b04" = false
 
 # moving east and north from README
-e34ac672-4ed4-4be3-a0b8-d9af259cbaa1 = false
+"e34ac672-4ed4-4be3-a0b8-d9af259cbaa1" = false
 
 # moving west and north
-f30e4955-4b47-4aa3-8b39-ae98cfbd515b = false
+"f30e4955-4b47-4aa3-8b39-ae98cfbd515b" = false
 
 # moving west and south
-3e466bf6-20ab-4d79-8b51-264165182fca = false
+"3e466bf6-20ab-4d79-8b51-264165182fca" = false
 
 # moving east and north
-41f0bb96-c617-4e6b-acff-a4b279d44514 = false
+"41f0bb96-c617-4e6b-acff-a4b279d44514" = false

--- a/exercises/robot-simulator/.meta/tests.toml
+++ b/exercises/robot-simulator/.meta/tests.toml
@@ -1,55 +1,55 @@
 [canonical-tests]
 
 # at origin facing north
-"c557c16d-26c1-4e06-827c-f6602cd0785c" = true
+c557c16d-26c1-4e06-827c-f6602cd0785c = false
 
 # at negative position facing south
-"bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d" = true
+bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d = false
 
 # changes north to east
-"8cbd0086-6392-4680-b9b9-73cf491e67e5" = true
+8cbd0086-6392-4680-b9b9-73cf491e67e5 = false
 
 # changes east to south
-"8abc87fc-eab2-4276-93b7-9c009e866ba1" = true
+8abc87fc-eab2-4276-93b7-9c009e866ba1 = false
 
 # changes south to west
-"3cfe1b85-bbf2-4bae-b54d-d73e7e93617a" = true
+3cfe1b85-bbf2-4bae-b54d-d73e7e93617a = false
 
 # changes west to north
-"5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716" = true
+5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716 = false
 
 # changes north to west
-"fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63" = true
+fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63 = false
 
 # changes west to south
-"da33d734-831f-445c-9907-d66d7d2a92e2" = true
+da33d734-831f-445c-9907-d66d7d2a92e2 = false
 
 # changes south to east
-"bd1ca4b9-4548-45f4-b32e-900fc7c19389" = true
+bd1ca4b9-4548-45f4-b32e-900fc7c19389 = false
 
 # changes east to north
-"2de27b67-a25c-4b59-9883-bc03b1b55bba" = true
+2de27b67-a25c-4b59-9883-bc03b1b55bba = false
 
 # facing north increments Y
-"f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8" = true
+f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8 = false
 
 # facing south decrements Y
-"2786cf80-5bbf-44b0-9503-a89a9c5789da" = true
+2786cf80-5bbf-44b0-9503-a89a9c5789da = false
 
 # facing east increments X
-"84bf3c8c-241f-434d-883d-69817dbd6a48" = true
+84bf3c8c-241f-434d-883d-69817dbd6a48 = false
 
 # facing west decrements X
-"bb69c4a7-3bbf-4f64-b415-666fa72d7b04" = true
+bb69c4a7-3bbf-4f64-b415-666fa72d7b04 = false
 
 # moving east and north from README
-"e34ac672-4ed4-4be3-a0b8-d9af259cbaa1" = true
+e34ac672-4ed4-4be3-a0b8-d9af259cbaa1 = false
 
 # moving west and north
-"f30e4955-4b47-4aa3-8b39-ae98cfbd515b" = true
+f30e4955-4b47-4aa3-8b39-ae98cfbd515b = false
 
 # moving west and south
-"3e466bf6-20ab-4d79-8b51-264165182fca" = true
+3e466bf6-20ab-4d79-8b51-264165182fca = false
 
 # moving east and north
-"41f0bb96-c617-4e6b-acff-a4b279d44514" = true
+41f0bb96-c617-4e6b-acff-a4b279d44514 = false

--- a/exercises/roman-numerals/.meta/tests.toml
+++ b/exercises/roman-numerals/.meta/tests.toml
@@ -1,0 +1,58 @@
+[canonical-tests]
+
+# 1 is a single I
+"19828a3a-fbf7-4661-8ddd-cbaeee0e2178" = true
+
+# 2 is two I's
+"f088f064-2d35-4476-9a41-f576da3f7b03" = true
+
+# 3 is three I's
+"b374a79c-3bea-43e6-8db8-1286f79c7106" = true
+
+# 4, being 5 - 1, is IV
+"05a0a1d4-a140-4db1-82e8-fcc21fdb49bb" = true
+
+# 5 is a single V
+"57c0f9ad-5024-46ab-975d-de18c430b290" = true
+
+# 6, being 5 + 1, is VI
+"20a2b47f-e57f-4797-a541-0b3825d7f249" = true
+
+# 9, being 10 - 1, is IX
+"ff3fb08c-4917-4aab-9f4e-d663491d083d" = true
+
+# 20 is two X's
+"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = true
+
+# 48 is not 50 - 2 but rather 40 + 8
+"a1f812ef-84da-4e02-b4f0-89c907d0962c" = true
+
+# 49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1
+"607ead62-23d6-4c11-a396-ef821e2e5f75" = true
+
+# 50 is a single L
+"d5b283d4-455d-4e68-aacf-add6c4b51915" = true
+
+# 90, being 100 - 10, is XC
+"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = true
+
+# 100 is a single C
+"30494be1-9afb-4f84-9d71-db9df18b55e3" = true
+
+# 60, being 50 + 10, is LX
+"267f0207-3c55-459a-b81d-67cec7a46ed9" = true
+
+# 400, being 500 - 100, is CD
+"cdb06885-4485-4d71-8bfb-c9d0f496b404" = true
+
+# 500 is a single D
+"6b71841d-13b2-46b4-ba97-dec28133ea80" = true
+
+# 900, being 1000 - 100, is CM
+"432de891-7fd6-4748-a7f6-156082eeca2f" = true
+
+# 1000 is a single M
+"e6de6d24-f668-41c0-88d7-889c0254d173" = true
+
+# 3000 is three M's
+"bb550038-d4eb-4be2-a9ce-f21961ac3bc6" = true

--- a/exercises/roman-numerals/.meta/tests.toml
+++ b/exercises/roman-numerals/.meta/tests.toml
@@ -1,58 +1,58 @@
 [canonical-tests]
 
 # 1 is a single I
-"19828a3a-fbf7-4661-8ddd-cbaeee0e2178" = true
+19828a3a-fbf7-4661-8ddd-cbaeee0e2178 = false
 
 # 2 is two I's
-"f088f064-2d35-4476-9a41-f576da3f7b03" = true
+f088f064-2d35-4476-9a41-f576da3f7b03 = false
 
 # 3 is three I's
-"b374a79c-3bea-43e6-8db8-1286f79c7106" = true
+b374a79c-3bea-43e6-8db8-1286f79c7106 = false
 
 # 4, being 5 - 1, is IV
-"05a0a1d4-a140-4db1-82e8-fcc21fdb49bb" = true
+05a0a1d4-a140-4db1-82e8-fcc21fdb49bb = false
 
 # 5 is a single V
-"57c0f9ad-5024-46ab-975d-de18c430b290" = true
+57c0f9ad-5024-46ab-975d-de18c430b290 = false
 
 # 6, being 5 + 1, is VI
-"20a2b47f-e57f-4797-a541-0b3825d7f249" = true
+20a2b47f-e57f-4797-a541-0b3825d7f249 = false
 
 # 9, being 10 - 1, is IX
-"ff3fb08c-4917-4aab-9f4e-d663491d083d" = true
+ff3fb08c-4917-4aab-9f4e-d663491d083d = false
 
 # 20 is two X's
-"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = true
+2bda64ca-7d28-4c56-b08d-16ce65716cf6 = false
 
 # 48 is not 50 - 2 but rather 40 + 8
-"a1f812ef-84da-4e02-b4f0-89c907d0962c" = true
+a1f812ef-84da-4e02-b4f0-89c907d0962c = false
 
 # 49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1
-"607ead62-23d6-4c11-a396-ef821e2e5f75" = true
+607ead62-23d6-4c11-a396-ef821e2e5f75 = false
 
 # 50 is a single L
-"d5b283d4-455d-4e68-aacf-add6c4b51915" = true
+d5b283d4-455d-4e68-aacf-add6c4b51915 = false
 
 # 90, being 100 - 10, is XC
-"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = true
+46b46e5b-24da-4180-bfe2-2ef30b39d0d0 = false
 
 # 100 is a single C
-"30494be1-9afb-4f84-9d71-db9df18b55e3" = true
+30494be1-9afb-4f84-9d71-db9df18b55e3 = false
 
 # 60, being 50 + 10, is LX
-"267f0207-3c55-459a-b81d-67cec7a46ed9" = true
+267f0207-3c55-459a-b81d-67cec7a46ed9 = false
 
 # 400, being 500 - 100, is CD
-"cdb06885-4485-4d71-8bfb-c9d0f496b404" = true
+cdb06885-4485-4d71-8bfb-c9d0f496b404 = false
 
 # 500 is a single D
-"6b71841d-13b2-46b4-ba97-dec28133ea80" = true
+6b71841d-13b2-46b4-ba97-dec28133ea80 = false
 
 # 900, being 1000 - 100, is CM
-"432de891-7fd6-4748-a7f6-156082eeca2f" = true
+432de891-7fd6-4748-a7f6-156082eeca2f = false
 
 # 1000 is a single M
-"e6de6d24-f668-41c0-88d7-889c0254d173" = true
+e6de6d24-f668-41c0-88d7-889c0254d173 = false
 
 # 3000 is three M's
-"bb550038-d4eb-4be2-a9ce-f21961ac3bc6" = true
+bb550038-d4eb-4be2-a9ce-f21961ac3bc6 = false

--- a/exercises/roman-numerals/.meta/tests.toml
+++ b/exercises/roman-numerals/.meta/tests.toml
@@ -1,58 +1,58 @@
 [canonical-tests]
 
 # 1 is a single I
-19828a3a-fbf7-4661-8ddd-cbaeee0e2178 = false
+"19828a3a-fbf7-4661-8ddd-cbaeee0e2178" = false
 
 # 2 is two I's
-f088f064-2d35-4476-9a41-f576da3f7b03 = false
+"f088f064-2d35-4476-9a41-f576da3f7b03" = false
 
 # 3 is three I's
-b374a79c-3bea-43e6-8db8-1286f79c7106 = false
+"b374a79c-3bea-43e6-8db8-1286f79c7106" = false
 
 # 4, being 5 - 1, is IV
-05a0a1d4-a140-4db1-82e8-fcc21fdb49bb = false
+"05a0a1d4-a140-4db1-82e8-fcc21fdb49bb" = false
 
 # 5 is a single V
-57c0f9ad-5024-46ab-975d-de18c430b290 = false
+"57c0f9ad-5024-46ab-975d-de18c430b290" = false
 
 # 6, being 5 + 1, is VI
-20a2b47f-e57f-4797-a541-0b3825d7f249 = false
+"20a2b47f-e57f-4797-a541-0b3825d7f249" = false
 
 # 9, being 10 - 1, is IX
-ff3fb08c-4917-4aab-9f4e-d663491d083d = false
+"ff3fb08c-4917-4aab-9f4e-d663491d083d" = false
 
 # 20 is two X's
-2bda64ca-7d28-4c56-b08d-16ce65716cf6 = false
+"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = false
 
 # 48 is not 50 - 2 but rather 40 + 8
-a1f812ef-84da-4e02-b4f0-89c907d0962c = false
+"a1f812ef-84da-4e02-b4f0-89c907d0962c" = false
 
 # 49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1
-607ead62-23d6-4c11-a396-ef821e2e5f75 = false
+"607ead62-23d6-4c11-a396-ef821e2e5f75" = false
 
 # 50 is a single L
-d5b283d4-455d-4e68-aacf-add6c4b51915 = false
+"d5b283d4-455d-4e68-aacf-add6c4b51915" = false
 
 # 90, being 100 - 10, is XC
-46b46e5b-24da-4180-bfe2-2ef30b39d0d0 = false
+"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = false
 
 # 100 is a single C
-30494be1-9afb-4f84-9d71-db9df18b55e3 = false
+"30494be1-9afb-4f84-9d71-db9df18b55e3" = false
 
 # 60, being 50 + 10, is LX
-267f0207-3c55-459a-b81d-67cec7a46ed9 = false
+"267f0207-3c55-459a-b81d-67cec7a46ed9" = false
 
 # 400, being 500 - 100, is CD
-cdb06885-4485-4d71-8bfb-c9d0f496b404 = false
+"cdb06885-4485-4d71-8bfb-c9d0f496b404" = false
 
 # 500 is a single D
-6b71841d-13b2-46b4-ba97-dec28133ea80 = false
+"6b71841d-13b2-46b4-ba97-dec28133ea80" = false
 
 # 900, being 1000 - 100, is CM
-432de891-7fd6-4748-a7f6-156082eeca2f = false
+"432de891-7fd6-4748-a7f6-156082eeca2f" = false
 
 # 1000 is a single M
-e6de6d24-f668-41c0-88d7-889c0254d173 = false
+"e6de6d24-f668-41c0-88d7-889c0254d173" = false
 
 # 3000 is three M's
-bb550038-d4eb-4be2-a9ce-f21961ac3bc6 = false
+"bb550038-d4eb-4be2-a9ce-f21961ac3bc6" = false

--- a/exercises/rotational-cipher/.meta/tests.toml
+++ b/exercises/rotational-cipher/.meta/tests.toml
@@ -1,0 +1,31 @@
+[canonical-tests]
+
+# rotate a by 0, same output as input
+"74e58a38-e484-43f1-9466-877a7515e10f" = true
+
+# rotate a by 1
+"7ee352c6-e6b0-4930-b903-d09943ecb8f5" = true
+
+# rotate a by 26, same output as input
+"edf0a733-4231-4594-a5ee-46a4009ad764" = true
+
+# rotate m by 13
+"e3e82cb9-2a5b-403f-9931-e43213879300" = true
+
+# rotate n by 13 with wrap around alphabet
+"19f9eb78-e2ad-4da4-8fe3-9291d47c1709" = true
+
+# rotate capital letters
+"a116aef4-225b-4da9-884f-e8023ca6408a" = true
+
+# rotate spaces
+"71b541bb-819c-4dc6-a9c3-132ef9bb737b" = true
+
+# rotate numbers
+"ef32601d-e9ef-4b29-b2b5-8971392282e6" = true
+
+# rotate punctuation
+"32dd74f6-db2b-41a6-b02c-82eb4f93e549" = true
+
+# rotate all letters
+"9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9" = true

--- a/exercises/rotational-cipher/.meta/tests.toml
+++ b/exercises/rotational-cipher/.meta/tests.toml
@@ -1,31 +1,31 @@
 [canonical-tests]
 
 # rotate a by 0, same output as input
-74e58a38-e484-43f1-9466-877a7515e10f = false
+"74e58a38-e484-43f1-9466-877a7515e10f" = false
 
 # rotate a by 1
-7ee352c6-e6b0-4930-b903-d09943ecb8f5 = false
+"7ee352c6-e6b0-4930-b903-d09943ecb8f5" = false
 
 # rotate a by 26, same output as input
-edf0a733-4231-4594-a5ee-46a4009ad764 = false
+"edf0a733-4231-4594-a5ee-46a4009ad764" = false
 
 # rotate m by 13
-e3e82cb9-2a5b-403f-9931-e43213879300 = false
+"e3e82cb9-2a5b-403f-9931-e43213879300" = false
 
 # rotate n by 13 with wrap around alphabet
-19f9eb78-e2ad-4da4-8fe3-9291d47c1709 = false
+"19f9eb78-e2ad-4da4-8fe3-9291d47c1709" = false
 
 # rotate capital letters
-a116aef4-225b-4da9-884f-e8023ca6408a = false
+"a116aef4-225b-4da9-884f-e8023ca6408a" = false
 
 # rotate spaces
-71b541bb-819c-4dc6-a9c3-132ef9bb737b = true
+"71b541bb-819c-4dc6-a9c3-132ef9bb737b" = true
 
 # rotate numbers
-ef32601d-e9ef-4b29-b2b5-8971392282e6 = true
+"ef32601d-e9ef-4b29-b2b5-8971392282e6" = true
 
 # rotate punctuation
-32dd74f6-db2b-41a6-b02c-82eb4f93e549 = true
+"32dd74f6-db2b-41a6-b02c-82eb4f93e549" = true
 
 # rotate all letters
-9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9 = false
+"9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9" = false

--- a/exercises/rotational-cipher/.meta/tests.toml
+++ b/exercises/rotational-cipher/.meta/tests.toml
@@ -1,31 +1,31 @@
 [canonical-tests]
 
 # rotate a by 0, same output as input
-"74e58a38-e484-43f1-9466-877a7515e10f" = true
+74e58a38-e484-43f1-9466-877a7515e10f = false
 
 # rotate a by 1
-"7ee352c6-e6b0-4930-b903-d09943ecb8f5" = true
+7ee352c6-e6b0-4930-b903-d09943ecb8f5 = false
 
 # rotate a by 26, same output as input
-"edf0a733-4231-4594-a5ee-46a4009ad764" = true
+edf0a733-4231-4594-a5ee-46a4009ad764 = false
 
 # rotate m by 13
-"e3e82cb9-2a5b-403f-9931-e43213879300" = true
+e3e82cb9-2a5b-403f-9931-e43213879300 = false
 
 # rotate n by 13 with wrap around alphabet
-"19f9eb78-e2ad-4da4-8fe3-9291d47c1709" = true
+19f9eb78-e2ad-4da4-8fe3-9291d47c1709 = false
 
 # rotate capital letters
-"a116aef4-225b-4da9-884f-e8023ca6408a" = true
+a116aef4-225b-4da9-884f-e8023ca6408a = false
 
 # rotate spaces
-"71b541bb-819c-4dc6-a9c3-132ef9bb737b" = true
+71b541bb-819c-4dc6-a9c3-132ef9bb737b = true
 
 # rotate numbers
-"ef32601d-e9ef-4b29-b2b5-8971392282e6" = true
+ef32601d-e9ef-4b29-b2b5-8971392282e6 = true
 
 # rotate punctuation
-"32dd74f6-db2b-41a6-b02c-82eb4f93e549" = true
+32dd74f6-db2b-41a6-b02c-82eb4f93e549 = true
 
 # rotate all letters
-"9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9" = true
+9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9 = false

--- a/exercises/run-length-encoding/.meta/tests.toml
+++ b/exercises/run-length-encoding/.meta/tests.toml
@@ -1,0 +1,40 @@
+[canonical-tests]
+
+# empty string
+"ad53b61b-6ffc-422f-81a6-61f7df92a231" = true
+
+# single characters only are encoded without count
+"52012823-b7e6-4277-893c-5b96d42f82de" = true
+
+# string with no single characters
+"b7868492-7e3a-415f-8da3-d88f51f80409" = true
+
+# single characters mixed with repeated characters
+"859b822b-6e9f-44d6-9c46-6091ee6ae358" = true
+
+# multiple whitespace mixed in string
+"1b34de62-e152-47be-bc88-469746df63b3" = true
+
+# lowercase characters
+"abf176e2-3fbd-40ad-bb2f-2dd6d4df721a" = true
+
+# empty string
+"7ec5c390-f03c-4acf-ac29-5f65861cdeb5" = true
+
+# single characters only
+"ad23f455-1ac2-4b0e-87d0-b85b10696098" = true
+
+# string with no single characters
+"21e37583-5a20-4a0e-826c-3dee2c375f54" = true
+
+# single characters with repeated characters
+"1389ad09-c3a8-4813-9324-99363fba429c" = true
+
+# multiple whitespace mixed in string
+"3f8e3c51-6aca-4670-b86c-a213bf4706b0" = true
+
+# lower case string
+"29f721de-9aad-435f-ba37-7662df4fb551" = true
+
+# encode followed by decode gives original string
+"2a762efd-8695-4e04-b0d6-9736899fbc16" = true

--- a/exercises/run-length-encoding/.meta/tests.toml
+++ b/exercises/run-length-encoding/.meta/tests.toml
@@ -1,40 +1,40 @@
 [canonical-tests]
 
 # empty string
-"ad53b61b-6ffc-422f-81a6-61f7df92a231" = true
+ad53b61b-6ffc-422f-81a6-61f7df92a231 = false
 
 # single characters only are encoded without count
-"52012823-b7e6-4277-893c-5b96d42f82de" = true
+52012823-b7e6-4277-893c-5b96d42f82de = false
 
 # string with no single characters
-"b7868492-7e3a-415f-8da3-d88f51f80409" = true
+b7868492-7e3a-415f-8da3-d88f51f80409 = false
 
 # single characters mixed with repeated characters
-"859b822b-6e9f-44d6-9c46-6091ee6ae358" = true
+859b822b-6e9f-44d6-9c46-6091ee6ae358 = false
 
 # multiple whitespace mixed in string
-"1b34de62-e152-47be-bc88-469746df63b3" = true
+1b34de62-e152-47be-bc88-469746df63b3 = false
 
 # lowercase characters
-"abf176e2-3fbd-40ad-bb2f-2dd6d4df721a" = true
+abf176e2-3fbd-40ad-bb2f-2dd6d4df721a = false
 
 # empty string
-"7ec5c390-f03c-4acf-ac29-5f65861cdeb5" = true
+7ec5c390-f03c-4acf-ac29-5f65861cdeb5 = false
 
 # single characters only
-"ad23f455-1ac2-4b0e-87d0-b85b10696098" = true
+ad23f455-1ac2-4b0e-87d0-b85b10696098 = false
 
 # string with no single characters
-"21e37583-5a20-4a0e-826c-3dee2c375f54" = true
+21e37583-5a20-4a0e-826c-3dee2c375f54 = false
 
 # single characters with repeated characters
-"1389ad09-c3a8-4813-9324-99363fba429c" = true
+1389ad09-c3a8-4813-9324-99363fba429c = false
 
 # multiple whitespace mixed in string
-"3f8e3c51-6aca-4670-b86c-a213bf4706b0" = true
+3f8e3c51-6aca-4670-b86c-a213bf4706b0 = false
 
 # lower case string
-"29f721de-9aad-435f-ba37-7662df4fb551" = true
+29f721de-9aad-435f-ba37-7662df4fb551 = false
 
 # encode followed by decode gives original string
-"2a762efd-8695-4e04-b0d6-9736899fbc16" = true
+2a762efd-8695-4e04-b0d6-9736899fbc16 = false

--- a/exercises/run-length-encoding/.meta/tests.toml
+++ b/exercises/run-length-encoding/.meta/tests.toml
@@ -1,40 +1,40 @@
 [canonical-tests]
 
 # empty string
-ad53b61b-6ffc-422f-81a6-61f7df92a231 = false
+"ad53b61b-6ffc-422f-81a6-61f7df92a231" = false
 
 # single characters only are encoded without count
-52012823-b7e6-4277-893c-5b96d42f82de = false
+"52012823-b7e6-4277-893c-5b96d42f82de" = false
 
 # string with no single characters
-b7868492-7e3a-415f-8da3-d88f51f80409 = false
+"b7868492-7e3a-415f-8da3-d88f51f80409" = false
 
 # single characters mixed with repeated characters
-859b822b-6e9f-44d6-9c46-6091ee6ae358 = false
+"859b822b-6e9f-44d6-9c46-6091ee6ae358" = false
 
 # multiple whitespace mixed in string
-1b34de62-e152-47be-bc88-469746df63b3 = false
+"1b34de62-e152-47be-bc88-469746df63b3" = false
 
 # lowercase characters
-abf176e2-3fbd-40ad-bb2f-2dd6d4df721a = false
+"abf176e2-3fbd-40ad-bb2f-2dd6d4df721a" = false
 
 # empty string
-7ec5c390-f03c-4acf-ac29-5f65861cdeb5 = false
+"7ec5c390-f03c-4acf-ac29-5f65861cdeb5" = false
 
 # single characters only
-ad23f455-1ac2-4b0e-87d0-b85b10696098 = false
+"ad23f455-1ac2-4b0e-87d0-b85b10696098" = false
 
 # string with no single characters
-21e37583-5a20-4a0e-826c-3dee2c375f54 = false
+"21e37583-5a20-4a0e-826c-3dee2c375f54" = false
 
 # single characters with repeated characters
-1389ad09-c3a8-4813-9324-99363fba429c = false
+"1389ad09-c3a8-4813-9324-99363fba429c" = false
 
 # multiple whitespace mixed in string
-3f8e3c51-6aca-4670-b86c-a213bf4706b0 = false
+"3f8e3c51-6aca-4670-b86c-a213bf4706b0" = false
 
 # lower case string
-29f721de-9aad-435f-ba37-7662df4fb551 = false
+"29f721de-9aad-435f-ba37-7662df4fb551" = false
 
 # encode followed by decode gives original string
-2a762efd-8695-4e04-b0d6-9736899fbc16 = false
+"2a762efd-8695-4e04-b0d6-9736899fbc16" = false

--- a/exercises/saddle-points/.meta/tests.toml
+++ b/exercises/saddle-points/.meta/tests.toml
@@ -1,0 +1,28 @@
+[canonical-tests]
+
+# Can identify single saddle point
+"3e374e63-a2e0-4530-a39a-d53c560382bd" = true
+
+# Can identify that empty matrix has no saddle points
+"6b501e2b-6c1f-491f-b1bb-7f278f760534" = true
+
+# Can identify lack of saddle points when there are none
+"8c27cc64-e573-4fcb-a099-f0ae863fb02f" = true
+
+# Can identify multiple saddle points in a column
+"6d1399bd-e105-40fd-a2c9-c6609507d7a3" = true
+
+# Can identify multiple saddle points in a row
+"3e81dce9-53b3-44e6-bf26-e328885fd5d1" = true
+
+# Can identify saddle point in bottom right corner
+"88868621-b6f4-4837-bb8b-3fad8b25d46b" = true
+
+# Can identify saddle points in a non square matrix
+"5b9499ca-fcea-4195-830a-9c4584a0ee79" = true
+
+# Can identify that saddle points in a single column matrix are those with the minimum value
+"ee99ccd2-a1f1-4283-ad39-f8c70f0cf594" = true
+
+# Can identify that saddle points in a single row matrix are those with the maximum value
+"63abf709-a84b-407f-a1b3-456638689713" = true

--- a/exercises/saddle-points/.meta/tests.toml
+++ b/exercises/saddle-points/.meta/tests.toml
@@ -1,28 +1,28 @@
 [canonical-tests]
 
 # Can identify single saddle point
-3e374e63-a2e0-4530-a39a-d53c560382bd = false
+"3e374e63-a2e0-4530-a39a-d53c560382bd" = false
 
 # Can identify that empty matrix has no saddle points
-6b501e2b-6c1f-491f-b1bb-7f278f760534 = false
+"6b501e2b-6c1f-491f-b1bb-7f278f760534" = false
 
 # Can identify lack of saddle points when there are none
-8c27cc64-e573-4fcb-a099-f0ae863fb02f = false
+"8c27cc64-e573-4fcb-a099-f0ae863fb02f" = false
 
 # Can identify multiple saddle points in a column
-6d1399bd-e105-40fd-a2c9-c6609507d7a3 = false
+"6d1399bd-e105-40fd-a2c9-c6609507d7a3" = false
 
 # Can identify multiple saddle points in a row
-3e81dce9-53b3-44e6-bf26-e328885fd5d1 = false
+"3e81dce9-53b3-44e6-bf26-e328885fd5d1" = false
 
 # Can identify saddle point in bottom right corner
-88868621-b6f4-4837-bb8b-3fad8b25d46b = false
+"88868621-b6f4-4837-bb8b-3fad8b25d46b" = false
 
 # Can identify saddle points in a non square matrix
-5b9499ca-fcea-4195-830a-9c4584a0ee79 = false
+"5b9499ca-fcea-4195-830a-9c4584a0ee79" = false
 
 # Can identify that saddle points in a single column matrix are those with the minimum value
-ee99ccd2-a1f1-4283-ad39-f8c70f0cf594 = false
+"ee99ccd2-a1f1-4283-ad39-f8c70f0cf594" = false
 
 # Can identify that saddle points in a single row matrix are those with the maximum value
-63abf709-a84b-407f-a1b3-456638689713 = false
+"63abf709-a84b-407f-a1b3-456638689713" = false

--- a/exercises/saddle-points/.meta/tests.toml
+++ b/exercises/saddle-points/.meta/tests.toml
@@ -1,28 +1,28 @@
 [canonical-tests]
 
 # Can identify single saddle point
-"3e374e63-a2e0-4530-a39a-d53c560382bd" = true
+3e374e63-a2e0-4530-a39a-d53c560382bd = false
 
 # Can identify that empty matrix has no saddle points
-"6b501e2b-6c1f-491f-b1bb-7f278f760534" = true
+6b501e2b-6c1f-491f-b1bb-7f278f760534 = false
 
 # Can identify lack of saddle points when there are none
-"8c27cc64-e573-4fcb-a099-f0ae863fb02f" = true
+8c27cc64-e573-4fcb-a099-f0ae863fb02f = false
 
 # Can identify multiple saddle points in a column
-"6d1399bd-e105-40fd-a2c9-c6609507d7a3" = true
+6d1399bd-e105-40fd-a2c9-c6609507d7a3 = false
 
 # Can identify multiple saddle points in a row
-"3e81dce9-53b3-44e6-bf26-e328885fd5d1" = true
+3e81dce9-53b3-44e6-bf26-e328885fd5d1 = false
 
 # Can identify saddle point in bottom right corner
-"88868621-b6f4-4837-bb8b-3fad8b25d46b" = true
+88868621-b6f4-4837-bb8b-3fad8b25d46b = false
 
 # Can identify saddle points in a non square matrix
-"5b9499ca-fcea-4195-830a-9c4584a0ee79" = true
+5b9499ca-fcea-4195-830a-9c4584a0ee79 = false
 
 # Can identify that saddle points in a single column matrix are those with the minimum value
-"ee99ccd2-a1f1-4283-ad39-f8c70f0cf594" = true
+ee99ccd2-a1f1-4283-ad39-f8c70f0cf594 = false
 
 # Can identify that saddle points in a single row matrix are those with the maximum value
-"63abf709-a84b-407f-a1b3-456638689713" = true
+63abf709-a84b-407f-a1b3-456638689713 = false

--- a/exercises/say/.meta/tests.toml
+++ b/exercises/say/.meta/tests.toml
@@ -1,0 +1,46 @@
+[canonical-tests]
+
+# zero
+"5d22a120-ba0c-428c-bd25-8682235d83e8" = true
+
+# one
+"9b5eed77-dbf6-439d-b920-3f7eb58928f6" = true
+
+# fourteen
+"7c499be1-612e-4096-a5e1-43b2f719406d" = true
+
+# twenty
+"f541dd8e-f070-4329-92b4-b7ce2fcf06b4" = true
+
+# twenty-two
+"d78601eb-4a84-4bfa-bf0e-665aeb8abe94" = true
+
+# one hundred
+"e417d452-129e-4056-bd5b-6eb1df334dce" = true
+
+# one hundred twenty-three
+"d6924f30-80ba-4597-acf6-ea3f16269da8" = true
+
+# one thousand
+"3d83da89-a372-46d3-b10d-de0c792432b3" = true
+
+# one thousand two hundred thirty-four
+"865af898-1d5b-495f-8ff0-2f06d3c73709" = true
+
+# one million
+"b6a3f442-266e-47a3-835d-7f8a35f6cf7f" = true
+
+# one million two thousand three hundred forty-five
+"2cea9303-e77e-4212-b8ff-c39f1978fc70" = true
+
+# one billion
+"3e240eeb-f564-4b80-9421-db123f66a38f" = true
+
+# a big number
+"9a43fed1-c875-4710-8286-5065d73b8a9e" = true
+
+# numbers below zero are out of range
+"49a6a17b-084e-423e-994d-a87c0ecc05ef" = true
+
+# numbers above 999,999,999,999 are out of range
+"4d6492eb-5853-4d16-9d34-b0f61b261fd9" = true

--- a/exercises/say/.meta/tests.toml
+++ b/exercises/say/.meta/tests.toml
@@ -1,46 +1,46 @@
 [canonical-tests]
 
 # zero
-"5d22a120-ba0c-428c-bd25-8682235d83e8" = true
+5d22a120-ba0c-428c-bd25-8682235d83e8 = false
 
 # one
-"9b5eed77-dbf6-439d-b920-3f7eb58928f6" = true
+9b5eed77-dbf6-439d-b920-3f7eb58928f6 = false
 
 # fourteen
-"7c499be1-612e-4096-a5e1-43b2f719406d" = true
+7c499be1-612e-4096-a5e1-43b2f719406d = false
 
 # twenty
-"f541dd8e-f070-4329-92b4-b7ce2fcf06b4" = true
+f541dd8e-f070-4329-92b4-b7ce2fcf06b4 = false
 
 # twenty-two
-"d78601eb-4a84-4bfa-bf0e-665aeb8abe94" = true
+d78601eb-4a84-4bfa-bf0e-665aeb8abe94 = false
 
 # one hundred
-"e417d452-129e-4056-bd5b-6eb1df334dce" = true
+e417d452-129e-4056-bd5b-6eb1df334dce = false
 
 # one hundred twenty-three
-"d6924f30-80ba-4597-acf6-ea3f16269da8" = true
+d6924f30-80ba-4597-acf6-ea3f16269da8 = false
 
 # one thousand
-"3d83da89-a372-46d3-b10d-de0c792432b3" = true
+3d83da89-a372-46d3-b10d-de0c792432b3 = false
 
 # one thousand two hundred thirty-four
-"865af898-1d5b-495f-8ff0-2f06d3c73709" = true
+865af898-1d5b-495f-8ff0-2f06d3c73709 = false
 
 # one million
-"b6a3f442-266e-47a3-835d-7f8a35f6cf7f" = true
+b6a3f442-266e-47a3-835d-7f8a35f6cf7f = false
 
 # one million two thousand three hundred forty-five
-"2cea9303-e77e-4212-b8ff-c39f1978fc70" = true
+2cea9303-e77e-4212-b8ff-c39f1978fc70 = false
 
 # one billion
-"3e240eeb-f564-4b80-9421-db123f66a38f" = true
+3e240eeb-f564-4b80-9421-db123f66a38f = false
 
 # a big number
-"9a43fed1-c875-4710-8286-5065d73b8a9e" = true
+9a43fed1-c875-4710-8286-5065d73b8a9e = false
 
 # numbers below zero are out of range
-"49a6a17b-084e-423e-994d-a87c0ecc05ef" = true
+49a6a17b-084e-423e-994d-a87c0ecc05ef = false
 
 # numbers above 999,999,999,999 are out of range
-"4d6492eb-5853-4d16-9d34-b0f61b261fd9" = true
+4d6492eb-5853-4d16-9d34-b0f61b261fd9 = false

--- a/exercises/say/.meta/tests.toml
+++ b/exercises/say/.meta/tests.toml
@@ -1,46 +1,46 @@
 [canonical-tests]
 
 # zero
-5d22a120-ba0c-428c-bd25-8682235d83e8 = false
+"5d22a120-ba0c-428c-bd25-8682235d83e8" = false
 
 # one
-9b5eed77-dbf6-439d-b920-3f7eb58928f6 = false
+"9b5eed77-dbf6-439d-b920-3f7eb58928f6" = false
 
 # fourteen
-7c499be1-612e-4096-a5e1-43b2f719406d = false
+"7c499be1-612e-4096-a5e1-43b2f719406d" = false
 
 # twenty
-f541dd8e-f070-4329-92b4-b7ce2fcf06b4 = false
+"f541dd8e-f070-4329-92b4-b7ce2fcf06b4" = false
 
 # twenty-two
-d78601eb-4a84-4bfa-bf0e-665aeb8abe94 = false
+"d78601eb-4a84-4bfa-bf0e-665aeb8abe94" = false
 
 # one hundred
-e417d452-129e-4056-bd5b-6eb1df334dce = false
+"e417d452-129e-4056-bd5b-6eb1df334dce" = false
 
 # one hundred twenty-three
-d6924f30-80ba-4597-acf6-ea3f16269da8 = false
+"d6924f30-80ba-4597-acf6-ea3f16269da8" = false
 
 # one thousand
-3d83da89-a372-46d3-b10d-de0c792432b3 = false
+"3d83da89-a372-46d3-b10d-de0c792432b3" = false
 
 # one thousand two hundred thirty-four
-865af898-1d5b-495f-8ff0-2f06d3c73709 = false
+"865af898-1d5b-495f-8ff0-2f06d3c73709" = false
 
 # one million
-b6a3f442-266e-47a3-835d-7f8a35f6cf7f = false
+"b6a3f442-266e-47a3-835d-7f8a35f6cf7f" = false
 
 # one million two thousand three hundred forty-five
-2cea9303-e77e-4212-b8ff-c39f1978fc70 = false
+"2cea9303-e77e-4212-b8ff-c39f1978fc70" = false
 
 # one billion
-3e240eeb-f564-4b80-9421-db123f66a38f = false
+"3e240eeb-f564-4b80-9421-db123f66a38f" = false
 
 # a big number
-9a43fed1-c875-4710-8286-5065d73b8a9e = false
+"9a43fed1-c875-4710-8286-5065d73b8a9e" = false
 
 # numbers below zero are out of range
-49a6a17b-084e-423e-994d-a87c0ecc05ef = false
+"49a6a17b-084e-423e-994d-a87c0ecc05ef" = false
 
 # numbers above 999,999,999,999 are out of range
-4d6492eb-5853-4d16-9d34-b0f61b261fd9 = false
+"4d6492eb-5853-4d16-9d34-b0f61b261fd9" = false

--- a/exercises/say/.meta/tests.toml
+++ b/exercises/say/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # zero
-"5d22a120-ba0c-428c-bd25-8682235d83e8" = false
+"5d22a120-ba0c-428c-bd25-8682235d83e8" = true
 
 # one
-"9b5eed77-dbf6-439d-b920-3f7eb58928f6" = false
+"9b5eed77-dbf6-439d-b920-3f7eb58928f6" = true
 
 # fourteen
-"7c499be1-612e-4096-a5e1-43b2f719406d" = false
+"7c499be1-612e-4096-a5e1-43b2f719406d" = true
 
 # twenty
-"f541dd8e-f070-4329-92b4-b7ce2fcf06b4" = false
+"f541dd8e-f070-4329-92b4-b7ce2fcf06b4" = true
 
 # twenty-two
 "d78601eb-4a84-4bfa-bf0e-665aeb8abe94" = false

--- a/exercises/scale-generator/.meta/tests.toml
+++ b/exercises/scale-generator/.meta/tests.toml
@@ -1,0 +1,52 @@
+[canonical-tests]
+
+# Chromatic scale with sharps
+"10ea7b14-8a49-40be-ac55-7c62b55f9b47" = true
+
+# Chromatic scale with flats
+"af8381de-9a72-4efd-823a-48374dbfe76f" = true
+
+# Simple major scale
+"6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e" = true
+
+# Major scale with sharps
+"13a92f89-a83e-40b5-b9d4-01136931ba02" = true
+
+# Major scale with flats
+"aa3320f6-a761-49a1-bcf6-978e0c81080a" = true
+
+# Minor scale with sharps
+"63daeb2f-c3f9-4c45-92be-5bf97f61ff94" = true
+
+# Minor scale with flats
+"616594d0-9c48-4301-949e-af1d4fad16fd" = true
+
+# Dorian mode
+"390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a" = true
+
+# Mixolydian mode
+"846d0862-0f3e-4f3b-8a2d-9cc74f017848" = true
+
+# Lydian mode
+"7d49a8bb-b5f7-46ad-a207-83bd5032291a" = true
+
+# Phrygian mode
+"a4e4dac5-1891-4160-a19f-bb06d653d4d0" = true
+
+# Locrian mode
+"ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa" = true
+
+# Harmonic minor
+"70517400-12b7-4530-b861-fa940ae69ee8" = true
+
+# Octatonic
+"37114c0b-c54d-45da-9f4b-3848201470b0" = true
+
+# Hexatonic
+"496466e7-aa45-4bbd-a64d-f41030feed9c" = true
+
+# Pentatonic
+"bee5d9ec-e226-47b6-b62b-847a9241f3cc" = true
+
+# Enigmatic
+"dbee06a6-7535-4ab7-98e8-d8a36c8402d1" = true

--- a/exercises/scale-generator/.meta/tests.toml
+++ b/exercises/scale-generator/.meta/tests.toml
@@ -40,13 +40,13 @@
 "70517400-12b7-4530-b861-fa940ae69ee8" = false
 
 # Octatonic
-"37114c0b-c54d-45da-9f4b-3848201470b0" = false
+"37114c0b-c54d-45da-9f4b-3848201470b0" = true
 
 # Hexatonic
-"496466e7-aa45-4bbd-a64d-f41030feed9c" = false
+"496466e7-aa45-4bbd-a64d-f41030feed9c" = true
 
 # Pentatonic
-"bee5d9ec-e226-47b6-b62b-847a9241f3cc" = false
+"bee5d9ec-e226-47b6-b62b-847a9241f3cc" = true
 
 # Enigmatic
-"dbee06a6-7535-4ab7-98e8-d8a36c8402d1" = false
+"dbee06a6-7535-4ab7-98e8-d8a36c8402d1" = true

--- a/exercises/scale-generator/.meta/tests.toml
+++ b/exercises/scale-generator/.meta/tests.toml
@@ -1,52 +1,52 @@
 [canonical-tests]
 
 # Chromatic scale with sharps
-10ea7b14-8a49-40be-ac55-7c62b55f9b47 = false
+"10ea7b14-8a49-40be-ac55-7c62b55f9b47" = false
 
 # Chromatic scale with flats
-af8381de-9a72-4efd-823a-48374dbfe76f = false
+"af8381de-9a72-4efd-823a-48374dbfe76f" = false
 
 # Simple major scale
-6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e = false
+"6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e" = false
 
 # Major scale with sharps
-13a92f89-a83e-40b5-b9d4-01136931ba02 = false
+"13a92f89-a83e-40b5-b9d4-01136931ba02" = false
 
 # Major scale with flats
-aa3320f6-a761-49a1-bcf6-978e0c81080a = false
+"aa3320f6-a761-49a1-bcf6-978e0c81080a" = false
 
 # Minor scale with sharps
-63daeb2f-c3f9-4c45-92be-5bf97f61ff94 = false
+"63daeb2f-c3f9-4c45-92be-5bf97f61ff94" = false
 
 # Minor scale with flats
-616594d0-9c48-4301-949e-af1d4fad16fd = false
+"616594d0-9c48-4301-949e-af1d4fad16fd" = false
 
 # Dorian mode
-390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a = false
+"390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a" = false
 
 # Mixolydian mode
-846d0862-0f3e-4f3b-8a2d-9cc74f017848 = false
+"846d0862-0f3e-4f3b-8a2d-9cc74f017848" = false
 
 # Lydian mode
-7d49a8bb-b5f7-46ad-a207-83bd5032291a = false
+"7d49a8bb-b5f7-46ad-a207-83bd5032291a" = false
 
 # Phrygian mode
-a4e4dac5-1891-4160-a19f-bb06d653d4d0 = false
+"a4e4dac5-1891-4160-a19f-bb06d653d4d0" = false
 
 # Locrian mode
-ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa = false
+"ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa" = false
 
 # Harmonic minor
-70517400-12b7-4530-b861-fa940ae69ee8 = false
+"70517400-12b7-4530-b861-fa940ae69ee8" = false
 
 # Octatonic
-37114c0b-c54d-45da-9f4b-3848201470b0 = false
+"37114c0b-c54d-45da-9f4b-3848201470b0" = false
 
 # Hexatonic
-496466e7-aa45-4bbd-a64d-f41030feed9c = false
+"496466e7-aa45-4bbd-a64d-f41030feed9c" = false
 
 # Pentatonic
-bee5d9ec-e226-47b6-b62b-847a9241f3cc = false
+"bee5d9ec-e226-47b6-b62b-847a9241f3cc" = false
 
 # Enigmatic
-dbee06a6-7535-4ab7-98e8-d8a36c8402d1 = false
+"dbee06a6-7535-4ab7-98e8-d8a36c8402d1" = false

--- a/exercises/scale-generator/.meta/tests.toml
+++ b/exercises/scale-generator/.meta/tests.toml
@@ -1,52 +1,52 @@
 [canonical-tests]
 
 # Chromatic scale with sharps
-"10ea7b14-8a49-40be-ac55-7c62b55f9b47" = true
+10ea7b14-8a49-40be-ac55-7c62b55f9b47 = false
 
 # Chromatic scale with flats
-"af8381de-9a72-4efd-823a-48374dbfe76f" = true
+af8381de-9a72-4efd-823a-48374dbfe76f = false
 
 # Simple major scale
-"6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e" = true
+6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e = false
 
 # Major scale with sharps
-"13a92f89-a83e-40b5-b9d4-01136931ba02" = true
+13a92f89-a83e-40b5-b9d4-01136931ba02 = false
 
 # Major scale with flats
-"aa3320f6-a761-49a1-bcf6-978e0c81080a" = true
+aa3320f6-a761-49a1-bcf6-978e0c81080a = false
 
 # Minor scale with sharps
-"63daeb2f-c3f9-4c45-92be-5bf97f61ff94" = true
+63daeb2f-c3f9-4c45-92be-5bf97f61ff94 = false
 
 # Minor scale with flats
-"616594d0-9c48-4301-949e-af1d4fad16fd" = true
+616594d0-9c48-4301-949e-af1d4fad16fd = false
 
 # Dorian mode
-"390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a" = true
+390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a = false
 
 # Mixolydian mode
-"846d0862-0f3e-4f3b-8a2d-9cc74f017848" = true
+846d0862-0f3e-4f3b-8a2d-9cc74f017848 = false
 
 # Lydian mode
-"7d49a8bb-b5f7-46ad-a207-83bd5032291a" = true
+7d49a8bb-b5f7-46ad-a207-83bd5032291a = false
 
 # Phrygian mode
-"a4e4dac5-1891-4160-a19f-bb06d653d4d0" = true
+a4e4dac5-1891-4160-a19f-bb06d653d4d0 = false
 
 # Locrian mode
-"ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa" = true
+ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa = false
 
 # Harmonic minor
-"70517400-12b7-4530-b861-fa940ae69ee8" = true
+70517400-12b7-4530-b861-fa940ae69ee8 = false
 
 # Octatonic
-"37114c0b-c54d-45da-9f4b-3848201470b0" = true
+37114c0b-c54d-45da-9f4b-3848201470b0 = false
 
 # Hexatonic
-"496466e7-aa45-4bbd-a64d-f41030feed9c" = true
+496466e7-aa45-4bbd-a64d-f41030feed9c = false
 
 # Pentatonic
-"bee5d9ec-e226-47b6-b62b-847a9241f3cc" = true
+bee5d9ec-e226-47b6-b62b-847a9241f3cc = false
 
 # Enigmatic
-"dbee06a6-7535-4ab7-98e8-d8a36c8402d1" = true
+dbee06a6-7535-4ab7-98e8-d8a36c8402d1 = false

--- a/exercises/scrabble-score/.meta/tests.toml
+++ b/exercises/scrabble-score/.meta/tests.toml
@@ -1,0 +1,34 @@
+[canonical-tests]
+
+# lowercase letter
+"f46cda29-1ca5-4ef2-bd45-388a767e3db2" = true
+
+# uppercase letter
+"f7794b49-f13e-45d1-a933-4e48459b2201" = true
+
+# valuable letter
+"eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa" = true
+
+# short word
+"f3c8c94e-bb48-4da2-b09f-e832e103151e" = true
+
+# short, valuable word
+"71e3d8fa-900d-4548-930e-68e7067c4615" = true
+
+# medium word
+"d3088ad9-570c-4b51-8764-c75d5a430e99" = true
+
+# medium, valuable word
+"fa20c572-ad86-400a-8511-64512daac352" = true
+
+# long, mixed-case word
+"9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967" = true
+
+# english-like word
+"1e34e2c3-e444-4ea7-b598-3c2b46fd2c10" = true
+
+# empty input
+"4efe3169-b3b6-4334-8bae-ff4ef24a7e4f" = true
+
+# entire alphabet available
+"3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7" = true

--- a/exercises/scrabble-score/.meta/tests.toml
+++ b/exercises/scrabble-score/.meta/tests.toml
@@ -1,34 +1,34 @@
 [canonical-tests]
 
 # lowercase letter
-"f46cda29-1ca5-4ef2-bd45-388a767e3db2" = true
+f46cda29-1ca5-4ef2-bd45-388a767e3db2 = false
 
 # uppercase letter
-"f7794b49-f13e-45d1-a933-4e48459b2201" = true
+f7794b49-f13e-45d1-a933-4e48459b2201 = false
 
 # valuable letter
-"eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa" = true
+eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa = false
 
 # short word
-"f3c8c94e-bb48-4da2-b09f-e832e103151e" = true
+f3c8c94e-bb48-4da2-b09f-e832e103151e = false
 
 # short, valuable word
-"71e3d8fa-900d-4548-930e-68e7067c4615" = true
+71e3d8fa-900d-4548-930e-68e7067c4615 = false
 
 # medium word
-"d3088ad9-570c-4b51-8764-c75d5a430e99" = true
+d3088ad9-570c-4b51-8764-c75d5a430e99 = true
 
 # medium, valuable word
-"fa20c572-ad86-400a-8511-64512daac352" = true
+fa20c572-ad86-400a-8511-64512daac352 = false
 
 # long, mixed-case word
-"9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967" = true
+9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967 = false
 
 # english-like word
-"1e34e2c3-e444-4ea7-b598-3c2b46fd2c10" = true
+1e34e2c3-e444-4ea7-b598-3c2b46fd2c10 = false
 
 # empty input
-"4efe3169-b3b6-4334-8bae-ff4ef24a7e4f" = true
+4efe3169-b3b6-4334-8bae-ff4ef24a7e4f = false
 
 # entire alphabet available
-"3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7" = true
+3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7 = false

--- a/exercises/scrabble-score/.meta/tests.toml
+++ b/exercises/scrabble-score/.meta/tests.toml
@@ -1,34 +1,34 @@
 [canonical-tests]
 
 # lowercase letter
-f46cda29-1ca5-4ef2-bd45-388a767e3db2 = false
+"f46cda29-1ca5-4ef2-bd45-388a767e3db2" = false
 
 # uppercase letter
-f7794b49-f13e-45d1-a933-4e48459b2201 = false
+"f7794b49-f13e-45d1-a933-4e48459b2201" = false
 
 # valuable letter
-eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa = false
+"eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa" = false
 
 # short word
-f3c8c94e-bb48-4da2-b09f-e832e103151e = false
+"f3c8c94e-bb48-4da2-b09f-e832e103151e" = false
 
 # short, valuable word
-71e3d8fa-900d-4548-930e-68e7067c4615 = false
+"71e3d8fa-900d-4548-930e-68e7067c4615" = false
 
 # medium word
-d3088ad9-570c-4b51-8764-c75d5a430e99 = true
+"d3088ad9-570c-4b51-8764-c75d5a430e99" = true
 
 # medium, valuable word
-fa20c572-ad86-400a-8511-64512daac352 = false
+"fa20c572-ad86-400a-8511-64512daac352" = false
 
 # long, mixed-case word
-9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967 = false
+"9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967" = false
 
 # english-like word
-1e34e2c3-e444-4ea7-b598-3c2b46fd2c10 = false
+"1e34e2c3-e444-4ea7-b598-3c2b46fd2c10" = false
 
 # empty input
-4efe3169-b3b6-4334-8bae-ff4ef24a7e4f = false
+"4efe3169-b3b6-4334-8bae-ff4ef24a7e4f" = false
 
 # entire alphabet available
-3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7 = false
+"3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7" = false

--- a/exercises/series/.meta/tests.toml
+++ b/exercises/series/.meta/tests.toml
@@ -1,0 +1,31 @@
+[canonical-tests]
+
+# slices of one from one
+"7ae7a46a-d992-4c2a-9c15-a112d125ebad" = true
+
+# slices of one from two
+"3143b71d-f6a5-4221-aeae-619f906244d2" = true
+
+# slices of two
+"dbb68ff5-76c5-4ccd-895a-93dbec6d5805" = true
+
+# slices of two overlap
+"19bbea47-c987-4e11-a7d1-e103442adf86" = true
+
+# slices can include duplicates
+"8e17148d-ba0a-4007-a07f-d7f87015d84c" = true
+
+# slices of a long series
+"bd5b085e-f612-4f81-97a8-6314258278b0" = true
+
+# slice length is too large
+"6d235d85-46cf-4fae-9955-14b6efef27cd" = true
+
+# slice length cannot be zero
+"d34004ad-8765-4c09-8ba1-ada8ce776806" = true
+
+# slice length cannot be negative
+"10ab822d-8410-470a-a85d-23fbeb549e54" = true
+
+# empty series is invalid
+"c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2" = true

--- a/exercises/series/.meta/tests.toml
+++ b/exercises/series/.meta/tests.toml
@@ -1,31 +1,31 @@
 [canonical-tests]
 
 # slices of one from one
-7ae7a46a-d992-4c2a-9c15-a112d125ebad = false
+"7ae7a46a-d992-4c2a-9c15-a112d125ebad" = false
 
 # slices of one from two
-3143b71d-f6a5-4221-aeae-619f906244d2 = false
+"3143b71d-f6a5-4221-aeae-619f906244d2" = false
 
 # slices of two
-dbb68ff5-76c5-4ccd-895a-93dbec6d5805 = false
+"dbb68ff5-76c5-4ccd-895a-93dbec6d5805" = false
 
 # slices of two overlap
-19bbea47-c987-4e11-a7d1-e103442adf86 = false
+"19bbea47-c987-4e11-a7d1-e103442adf86" = false
 
 # slices can include duplicates
-8e17148d-ba0a-4007-a07f-d7f87015d84c = false
+"8e17148d-ba0a-4007-a07f-d7f87015d84c" = false
 
 # slices of a long series
-bd5b085e-f612-4f81-97a8-6314258278b0 = false
+"bd5b085e-f612-4f81-97a8-6314258278b0" = false
 
 # slice length is too large
-6d235d85-46cf-4fae-9955-14b6efef27cd = false
+"6d235d85-46cf-4fae-9955-14b6efef27cd" = false
 
 # slice length cannot be zero
-d34004ad-8765-4c09-8ba1-ada8ce776806 = false
+"d34004ad-8765-4c09-8ba1-ada8ce776806" = false
 
 # slice length cannot be negative
-10ab822d-8410-470a-a85d-23fbeb549e54 = false
+"10ab822d-8410-470a-a85d-23fbeb549e54" = false
 
 # empty series is invalid
-c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2 = false
+"c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2" = false

--- a/exercises/series/.meta/tests.toml
+++ b/exercises/series/.meta/tests.toml
@@ -1,31 +1,31 @@
 [canonical-tests]
 
 # slices of one from one
-"7ae7a46a-d992-4c2a-9c15-a112d125ebad" = true
+7ae7a46a-d992-4c2a-9c15-a112d125ebad = false
 
 # slices of one from two
-"3143b71d-f6a5-4221-aeae-619f906244d2" = true
+3143b71d-f6a5-4221-aeae-619f906244d2 = false
 
 # slices of two
-"dbb68ff5-76c5-4ccd-895a-93dbec6d5805" = true
+dbb68ff5-76c5-4ccd-895a-93dbec6d5805 = false
 
 # slices of two overlap
-"19bbea47-c987-4e11-a7d1-e103442adf86" = true
+19bbea47-c987-4e11-a7d1-e103442adf86 = false
 
 # slices can include duplicates
-"8e17148d-ba0a-4007-a07f-d7f87015d84c" = true
+8e17148d-ba0a-4007-a07f-d7f87015d84c = false
 
 # slices of a long series
-"bd5b085e-f612-4f81-97a8-6314258278b0" = true
+bd5b085e-f612-4f81-97a8-6314258278b0 = false
 
 # slice length is too large
-"6d235d85-46cf-4fae-9955-14b6efef27cd" = true
+6d235d85-46cf-4fae-9955-14b6efef27cd = false
 
 # slice length cannot be zero
-"d34004ad-8765-4c09-8ba1-ada8ce776806" = true
+d34004ad-8765-4c09-8ba1-ada8ce776806 = false
 
 # slice length cannot be negative
-"10ab822d-8410-470a-a85d-23fbeb549e54" = true
+10ab822d-8410-470a-a85d-23fbeb549e54 = false
 
 # empty series is invalid
-"c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2" = true
+c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2 = false

--- a/exercises/sieve/.meta/tests.toml
+++ b/exercises/sieve/.meta/tests.toml
@@ -1,0 +1,16 @@
+[canonical-tests]
+
+# no primes under two
+"88529125-c4ce-43cc-bb36-1eb4ddd7b44f" = true
+
+# find first prime
+"4afe9474-c705-4477-9923-840e1024cc2b" = true
+
+# find primes up to 10
+"974945d8-8cd9-4f00-9463-7d813c7f17b7" = true
+
+# limit is prime
+"2e2417b7-3f3a-452a-8594-b9af08af6d82" = true
+
+# find primes up to 1000
+"92102a05-4c7c-47de-9ed0-b7d5fcd00f21" = true

--- a/exercises/sieve/.meta/tests.toml
+++ b/exercises/sieve/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # no primes under two
-88529125-c4ce-43cc-bb36-1eb4ddd7b44f = false
+"88529125-c4ce-43cc-bb36-1eb4ddd7b44f" = false
 
 # find first prime
-4afe9474-c705-4477-9923-840e1024cc2b = false
+"4afe9474-c705-4477-9923-840e1024cc2b" = false
 
 # find primes up to 10
-974945d8-8cd9-4f00-9463-7d813c7f17b7 = false
+"974945d8-8cd9-4f00-9463-7d813c7f17b7" = false
 
 # limit is prime
-2e2417b7-3f3a-452a-8594-b9af08af6d82 = true
+"2e2417b7-3f3a-452a-8594-b9af08af6d82" = true
 
 # find primes up to 1000
-92102a05-4c7c-47de-9ed0-b7d5fcd00f21 = false
+"92102a05-4c7c-47de-9ed0-b7d5fcd00f21" = false

--- a/exercises/sieve/.meta/tests.toml
+++ b/exercises/sieve/.meta/tests.toml
@@ -1,16 +1,16 @@
 [canonical-tests]
 
 # no primes under two
-"88529125-c4ce-43cc-bb36-1eb4ddd7b44f" = true
+88529125-c4ce-43cc-bb36-1eb4ddd7b44f = false
 
 # find first prime
-"4afe9474-c705-4477-9923-840e1024cc2b" = true
+4afe9474-c705-4477-9923-840e1024cc2b = false
 
 # find primes up to 10
-"974945d8-8cd9-4f00-9463-7d813c7f17b7" = true
+974945d8-8cd9-4f00-9463-7d813c7f17b7 = false
 
 # limit is prime
-"2e2417b7-3f3a-452a-8594-b9af08af6d82" = true
+2e2417b7-3f3a-452a-8594-b9af08af6d82 = true
 
 # find primes up to 1000
-"92102a05-4c7c-47de-9ed0-b7d5fcd00f21" = true
+92102a05-4c7c-47de-9ed0-b7d5fcd00f21 = false

--- a/exercises/simple-cipher/.meta/tests.toml
+++ b/exercises/simple-cipher/.meta/tests.toml
@@ -1,0 +1,37 @@
+[canonical-tests]
+
+# Can encode
+"b8bdfbe1-bea3-41bb-a999-b41403f2b15d" = true
+
+# Can decode
+"3dff7f36-75db-46b4-ab70-644b3f38b81c" = true
+
+# Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method
+"8143c684-6df6-46ba-bd1f-dea8fcb5d265" = true
+
+# Key is made only of lowercase letters
+"defc0050-e87d-4840-85e4-51a1ab9dd6aa" = true
+
+# Can encode
+"565e5158-5b3b-41dd-b99d-33b9f413c39f" = true
+
+# Can decode
+"d44e4f6a-b8af-4e90-9d08-fd407e31e67b" = true
+
+# Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method
+"70a16473-7339-43df-902d-93408c69e9d1" = true
+
+# Can double shift encode
+"69a1458b-92a6-433a-a02d-7beac3ea91f9" = true
+
+# Can wrap on encode
+"21d207c1-98de-40aa-994f-86197ae230fb" = true
+
+# Can wrap on decode
+"a3d7a4d7-24a9-4de6-bdc4-a6614ced0cb3" = true
+
+# Can encode messages longer than the key
+"e31c9b8c-8eb6-45c9-a4b5-8344a36b9641" = true
+
+# Can decode messages longer than the key
+"93cfaae0-17da-4627-9a04-d6d1e1be52e3" = true

--- a/exercises/simple-cipher/.meta/tests.toml
+++ b/exercises/simple-cipher/.meta/tests.toml
@@ -1,37 +1,37 @@
 [canonical-tests]
 
 # Can encode
-"b8bdfbe1-bea3-41bb-a999-b41403f2b15d" = true
+b8bdfbe1-bea3-41bb-a999-b41403f2b15d = false
 
 # Can decode
-"3dff7f36-75db-46b4-ab70-644b3f38b81c" = true
+3dff7f36-75db-46b4-ab70-644b3f38b81c = false
 
 # Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method
-"8143c684-6df6-46ba-bd1f-dea8fcb5d265" = true
+8143c684-6df6-46ba-bd1f-dea8fcb5d265 = false
 
 # Key is made only of lowercase letters
-"defc0050-e87d-4840-85e4-51a1ab9dd6aa" = true
+defc0050-e87d-4840-85e4-51a1ab9dd6aa = false
 
 # Can encode
-"565e5158-5b3b-41dd-b99d-33b9f413c39f" = true
+565e5158-5b3b-41dd-b99d-33b9f413c39f = false
 
 # Can decode
-"d44e4f6a-b8af-4e90-9d08-fd407e31e67b" = true
+d44e4f6a-b8af-4e90-9d08-fd407e31e67b = false
 
 # Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method
-"70a16473-7339-43df-902d-93408c69e9d1" = true
+70a16473-7339-43df-902d-93408c69e9d1 = false
 
 # Can double shift encode
-"69a1458b-92a6-433a-a02d-7beac3ea91f9" = true
+69a1458b-92a6-433a-a02d-7beac3ea91f9 = false
 
 # Can wrap on encode
-"21d207c1-98de-40aa-994f-86197ae230fb" = true
+21d207c1-98de-40aa-994f-86197ae230fb = false
 
 # Can wrap on decode
-"a3d7a4d7-24a9-4de6-bdc4-a6614ced0cb3" = true
+a3d7a4d7-24a9-4de6-bdc4-a6614ced0cb3 = false
 
 # Can encode messages longer than the key
-"e31c9b8c-8eb6-45c9-a4b5-8344a36b9641" = true
+e31c9b8c-8eb6-45c9-a4b5-8344a36b9641 = false
 
 # Can decode messages longer than the key
-"93cfaae0-17da-4627-9a04-d6d1e1be52e3" = true
+93cfaae0-17da-4627-9a04-d6d1e1be52e3 = false

--- a/exercises/simple-cipher/.meta/tests.toml
+++ b/exercises/simple-cipher/.meta/tests.toml
@@ -1,37 +1,37 @@
 [canonical-tests]
 
 # Can encode
-b8bdfbe1-bea3-41bb-a999-b41403f2b15d = false
+"b8bdfbe1-bea3-41bb-a999-b41403f2b15d" = false
 
 # Can decode
-3dff7f36-75db-46b4-ab70-644b3f38b81c = false
+"3dff7f36-75db-46b4-ab70-644b3f38b81c" = false
 
 # Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method
-8143c684-6df6-46ba-bd1f-dea8fcb5d265 = false
+"8143c684-6df6-46ba-bd1f-dea8fcb5d265" = false
 
 # Key is made only of lowercase letters
-defc0050-e87d-4840-85e4-51a1ab9dd6aa = false
+"defc0050-e87d-4840-85e4-51a1ab9dd6aa" = false
 
 # Can encode
-565e5158-5b3b-41dd-b99d-33b9f413c39f = false
+"565e5158-5b3b-41dd-b99d-33b9f413c39f" = false
 
 # Can decode
-d44e4f6a-b8af-4e90-9d08-fd407e31e67b = false
+"d44e4f6a-b8af-4e90-9d08-fd407e31e67b" = false
 
 # Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method
-70a16473-7339-43df-902d-93408c69e9d1 = false
+"70a16473-7339-43df-902d-93408c69e9d1" = false
 
 # Can double shift encode
-69a1458b-92a6-433a-a02d-7beac3ea91f9 = false
+"69a1458b-92a6-433a-a02d-7beac3ea91f9" = false
 
 # Can wrap on encode
-21d207c1-98de-40aa-994f-86197ae230fb = false
+"21d207c1-98de-40aa-994f-86197ae230fb" = false
 
 # Can wrap on decode
-a3d7a4d7-24a9-4de6-bdc4-a6614ced0cb3 = false
+"a3d7a4d7-24a9-4de6-bdc4-a6614ced0cb3" = false
 
 # Can encode messages longer than the key
-e31c9b8c-8eb6-45c9-a4b5-8344a36b9641 = false
+"e31c9b8c-8eb6-45c9-a4b5-8344a36b9641" = false
 
 # Can decode messages longer than the key
-93cfaae0-17da-4627-9a04-d6d1e1be52e3 = false
+"93cfaae0-17da-4627-9a04-d6d1e1be52e3" = false

--- a/exercises/space-age/.meta/tests.toml
+++ b/exercises/space-age/.meta/tests.toml
@@ -1,0 +1,25 @@
+[canonical-tests]
+
+# age on Earth
+"84f609af-5a91-4d68-90a3-9e32d8a5cd34" = true
+
+# age on Mercury
+"ca20c4e9-6054-458c-9312-79679ffab40b" = true
+
+# age on Venus
+"502c6529-fd1b-41d3-8fab-65e03082b024" = true
+
+# age on Mars
+"9ceadf5e-a0d5-4388-9d40-2c459227ceb8" = true
+
+# age on Jupiter
+"42927dc3-fe5e-4f76-a5b5-f737fc19bcde" = true
+
+# age on Saturn
+"8469b332-7837-4ada-b27c-00ee043ebcad" = true
+
+# age on Uranus
+"999354c1-76f8-4bb5-a672-f317b6436743" = true
+
+# age on Neptune
+"80096d30-a0d4-4449-903e-a381178355d8" = true

--- a/exercises/space-age/.meta/tests.toml
+++ b/exercises/space-age/.meta/tests.toml
@@ -1,25 +1,25 @@
 [canonical-tests]
 
 # age on Earth
-"84f609af-5a91-4d68-90a3-9e32d8a5cd34" = true
+84f609af-5a91-4d68-90a3-9e32d8a5cd34 = false
 
 # age on Mercury
-"ca20c4e9-6054-458c-9312-79679ffab40b" = true
+ca20c4e9-6054-458c-9312-79679ffab40b = false
 
 # age on Venus
-"502c6529-fd1b-41d3-8fab-65e03082b024" = true
+502c6529-fd1b-41d3-8fab-65e03082b024 = false
 
 # age on Mars
-"9ceadf5e-a0d5-4388-9d40-2c459227ceb8" = true
+9ceadf5e-a0d5-4388-9d40-2c459227ceb8 = false
 
 # age on Jupiter
-"42927dc3-fe5e-4f76-a5b5-f737fc19bcde" = true
+42927dc3-fe5e-4f76-a5b5-f737fc19bcde = false
 
 # age on Saturn
-"8469b332-7837-4ada-b27c-00ee043ebcad" = true
+8469b332-7837-4ada-b27c-00ee043ebcad = false
 
 # age on Uranus
-"999354c1-76f8-4bb5-a672-f317b6436743" = true
+999354c1-76f8-4bb5-a672-f317b6436743 = false
 
 # age on Neptune
-"80096d30-a0d4-4449-903e-a381178355d8" = true
+80096d30-a0d4-4449-903e-a381178355d8 = false

--- a/exercises/space-age/.meta/tests.toml
+++ b/exercises/space-age/.meta/tests.toml
@@ -1,25 +1,25 @@
 [canonical-tests]
 
 # age on Earth
-84f609af-5a91-4d68-90a3-9e32d8a5cd34 = false
+"84f609af-5a91-4d68-90a3-9e32d8a5cd34" = false
 
 # age on Mercury
-ca20c4e9-6054-458c-9312-79679ffab40b = false
+"ca20c4e9-6054-458c-9312-79679ffab40b" = false
 
 # age on Venus
-502c6529-fd1b-41d3-8fab-65e03082b024 = false
+"502c6529-fd1b-41d3-8fab-65e03082b024" = false
 
 # age on Mars
-9ceadf5e-a0d5-4388-9d40-2c459227ceb8 = false
+"9ceadf5e-a0d5-4388-9d40-2c459227ceb8" = false
 
 # age on Jupiter
-42927dc3-fe5e-4f76-a5b5-f737fc19bcde = false
+"42927dc3-fe5e-4f76-a5b5-f737fc19bcde" = false
 
 # age on Saturn
-8469b332-7837-4ada-b27c-00ee043ebcad = false
+"8469b332-7837-4ada-b27c-00ee043ebcad" = false
 
 # age on Uranus
-999354c1-76f8-4bb5-a672-f317b6436743 = false
+"999354c1-76f8-4bb5-a672-f317b6436743" = false
 
 # age on Neptune
-80096d30-a0d4-4449-903e-a381178355d8 = false
+"80096d30-a0d4-4449-903e-a381178355d8" = false

--- a/exercises/spiral-matrix/.meta/tests.toml
+++ b/exercises/spiral-matrix/.meta/tests.toml
@@ -1,0 +1,19 @@
+[canonical-tests]
+
+# empty spiral
+"8f584201-b446-4bc9-b132-811c8edd9040" = true
+
+# trivial spiral
+"e40ae5f3-e2c9-4639-8116-8a119d632ab2" = true
+
+# spiral of size 2
+"cf05e42d-eb78-4098-a36e-cdaf0991bc48" = true
+
+# spiral of size 3
+"1c475667-c896-4c23-82e2-e033929de939" = true
+
+# spiral of size 4
+"05ccbc48-d891-44f5-9137-f4ce462a759d" = true
+
+# spiral of size 5
+"f4d2165b-1738-4e0c-bed0-c459045ae50d" = true

--- a/exercises/spiral-matrix/.meta/tests.toml
+++ b/exercises/spiral-matrix/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # empty spiral
-"8f584201-b446-4bc9-b132-811c8edd9040" = true
+8f584201-b446-4bc9-b132-811c8edd9040 = true
 
 # trivial spiral
-"e40ae5f3-e2c9-4639-8116-8a119d632ab2" = true
+e40ae5f3-e2c9-4639-8116-8a119d632ab2 = false
 
 # spiral of size 2
-"cf05e42d-eb78-4098-a36e-cdaf0991bc48" = true
+cf05e42d-eb78-4098-a36e-cdaf0991bc48 = false
 
 # spiral of size 3
-"1c475667-c896-4c23-82e2-e033929de939" = true
+1c475667-c896-4c23-82e2-e033929de939 = false
 
 # spiral of size 4
-"05ccbc48-d891-44f5-9137-f4ce462a759d" = true
+05ccbc48-d891-44f5-9137-f4ce462a759d = false
 
 # spiral of size 5
-"f4d2165b-1738-4e0c-bed0-c459045ae50d" = true
+f4d2165b-1738-4e0c-bed0-c459045ae50d = false

--- a/exercises/spiral-matrix/.meta/tests.toml
+++ b/exercises/spiral-matrix/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # empty spiral
-8f584201-b446-4bc9-b132-811c8edd9040 = true
+"8f584201-b446-4bc9-b132-811c8edd9040" = true
 
 # trivial spiral
-e40ae5f3-e2c9-4639-8116-8a119d632ab2 = false
+"e40ae5f3-e2c9-4639-8116-8a119d632ab2" = false
 
 # spiral of size 2
-cf05e42d-eb78-4098-a36e-cdaf0991bc48 = false
+"cf05e42d-eb78-4098-a36e-cdaf0991bc48" = false
 
 # spiral of size 3
-1c475667-c896-4c23-82e2-e033929de939 = false
+"1c475667-c896-4c23-82e2-e033929de939" = false
 
 # spiral of size 4
-05ccbc48-d891-44f5-9137-f4ce462a759d = false
+"05ccbc48-d891-44f5-9137-f4ce462a759d" = false
 
 # spiral of size 5
-f4d2165b-1738-4e0c-bed0-c459045ae50d = false
+"f4d2165b-1738-4e0c-bed0-c459045ae50d" = false

--- a/exercises/sublist/.meta/tests.toml
+++ b/exercises/sublist/.meta/tests.toml
@@ -1,0 +1,52 @@
+[canonical-tests]
+
+# empty lists
+"97319c93-ebc5-47ab-a022-02a1980e1d29" = true
+
+# empty list within non empty list
+"de27dbd4-df52-46fe-a336-30be58457382" = true
+
+# non empty list contains empty list
+"5487cfd1-bc7d-429f-ac6f-1177b857d4fb" = true
+
+# list equals itself
+"1f390b47-f6b2-4a93-bc23-858ba5dda9a6" = true
+
+# different lists
+"7ed2bfb2-922b-4363-ae75-f3a05e8274f5" = true
+
+# false start
+"3b8a2568-6144-4f06-b0a1-9d266b365341" = true
+
+# consecutive
+"dc39ed58-6311-4814-be30-05a64bc8d9b1" = true
+
+# sublist at start
+"d1270dab-a1ce-41aa-b29d-b3257241ac26" = true
+
+# sublist in middle
+"81f3d3f7-4f25-4ada-bcdc-897c403de1b6" = true
+
+# sublist at end
+"43bcae1e-a9cf-470e-923e-0946e04d8fdd" = true
+
+# at start of superlist
+"76cf99ed-0ff0-4b00-94af-4dfb43fe5caa" = true
+
+# in middle of superlist
+"b83989ec-8bdf-4655-95aa-9f38f3e357fd" = true
+
+# at end of superlist
+"26f9f7c3-6cf6-4610-984a-662f71f8689b" = true
+
+# first list missing element from second list
+"0a6db763-3588-416a-8f47-76b1cedde31e" = true
+
+# second list missing element from first list
+"83ffe6d8-a445-4a3c-8795-1e51a95e65c3" = true
+
+# order matters to a list
+"0d7ee7c1-0347-45c8-9ef5-b88db152b30b" = true
+
+# same digits but different numbers
+"5f47ce86-944e-40f9-9f31-6368aad70aa6" = true

--- a/exercises/sublist/.meta/tests.toml
+++ b/exercises/sublist/.meta/tests.toml
@@ -1,52 +1,52 @@
 [canonical-tests]
 
 # empty lists
-97319c93-ebc5-47ab-a022-02a1980e1d29 = false
+"97319c93-ebc5-47ab-a022-02a1980e1d29" = false
 
 # empty list within non empty list
-de27dbd4-df52-46fe-a336-30be58457382 = false
+"de27dbd4-df52-46fe-a336-30be58457382" = false
 
 # non empty list contains empty list
-5487cfd1-bc7d-429f-ac6f-1177b857d4fb = false
+"5487cfd1-bc7d-429f-ac6f-1177b857d4fb" = false
 
 # list equals itself
-1f390b47-f6b2-4a93-bc23-858ba5dda9a6 = false
+"1f390b47-f6b2-4a93-bc23-858ba5dda9a6" = false
 
 # different lists
-7ed2bfb2-922b-4363-ae75-f3a05e8274f5 = false
+"7ed2bfb2-922b-4363-ae75-f3a05e8274f5" = false
 
 # false start
-3b8a2568-6144-4f06-b0a1-9d266b365341 = false
+"3b8a2568-6144-4f06-b0a1-9d266b365341" = false
 
 # consecutive
-dc39ed58-6311-4814-be30-05a64bc8d9b1 = false
+"dc39ed58-6311-4814-be30-05a64bc8d9b1" = false
 
 # sublist at start
-d1270dab-a1ce-41aa-b29d-b3257241ac26 = false
+"d1270dab-a1ce-41aa-b29d-b3257241ac26" = false
 
 # sublist in middle
-81f3d3f7-4f25-4ada-bcdc-897c403de1b6 = true
+"81f3d3f7-4f25-4ada-bcdc-897c403de1b6" = true
 
 # sublist at end
-43bcae1e-a9cf-470e-923e-0946e04d8fdd = true
+"43bcae1e-a9cf-470e-923e-0946e04d8fdd" = true
 
 # at start of superlist
-76cf99ed-0ff0-4b00-94af-4dfb43fe5caa = false
+"76cf99ed-0ff0-4b00-94af-4dfb43fe5caa" = false
 
 # in middle of superlist
-b83989ec-8bdf-4655-95aa-9f38f3e357fd = false
+"b83989ec-8bdf-4655-95aa-9f38f3e357fd" = false
 
 # at end of superlist
-26f9f7c3-6cf6-4610-984a-662f71f8689b = false
+"26f9f7c3-6cf6-4610-984a-662f71f8689b" = false
 
 # first list missing element from second list
-0a6db763-3588-416a-8f47-76b1cedde31e = false
+"0a6db763-3588-416a-8f47-76b1cedde31e" = false
 
 # second list missing element from first list
-83ffe6d8-a445-4a3c-8795-1e51a95e65c3 = false
+"83ffe6d8-a445-4a3c-8795-1e51a95e65c3" = false
 
 # order matters to a list
-0d7ee7c1-0347-45c8-9ef5-b88db152b30b = false
+"0d7ee7c1-0347-45c8-9ef5-b88db152b30b" = false
 
 # same digits but different numbers
-5f47ce86-944e-40f9-9f31-6368aad70aa6 = false
+"5f47ce86-944e-40f9-9f31-6368aad70aa6" = false

--- a/exercises/sublist/.meta/tests.toml
+++ b/exercises/sublist/.meta/tests.toml
@@ -1,52 +1,52 @@
 [canonical-tests]
 
 # empty lists
-"97319c93-ebc5-47ab-a022-02a1980e1d29" = true
+97319c93-ebc5-47ab-a022-02a1980e1d29 = false
 
 # empty list within non empty list
-"de27dbd4-df52-46fe-a336-30be58457382" = true
+de27dbd4-df52-46fe-a336-30be58457382 = false
 
 # non empty list contains empty list
-"5487cfd1-bc7d-429f-ac6f-1177b857d4fb" = true
+5487cfd1-bc7d-429f-ac6f-1177b857d4fb = false
 
 # list equals itself
-"1f390b47-f6b2-4a93-bc23-858ba5dda9a6" = true
+1f390b47-f6b2-4a93-bc23-858ba5dda9a6 = false
 
 # different lists
-"7ed2bfb2-922b-4363-ae75-f3a05e8274f5" = true
+7ed2bfb2-922b-4363-ae75-f3a05e8274f5 = false
 
 # false start
-"3b8a2568-6144-4f06-b0a1-9d266b365341" = true
+3b8a2568-6144-4f06-b0a1-9d266b365341 = false
 
 # consecutive
-"dc39ed58-6311-4814-be30-05a64bc8d9b1" = true
+dc39ed58-6311-4814-be30-05a64bc8d9b1 = false
 
 # sublist at start
-"d1270dab-a1ce-41aa-b29d-b3257241ac26" = true
+d1270dab-a1ce-41aa-b29d-b3257241ac26 = false
 
 # sublist in middle
-"81f3d3f7-4f25-4ada-bcdc-897c403de1b6" = true
+81f3d3f7-4f25-4ada-bcdc-897c403de1b6 = true
 
 # sublist at end
-"43bcae1e-a9cf-470e-923e-0946e04d8fdd" = true
+43bcae1e-a9cf-470e-923e-0946e04d8fdd = true
 
 # at start of superlist
-"76cf99ed-0ff0-4b00-94af-4dfb43fe5caa" = true
+76cf99ed-0ff0-4b00-94af-4dfb43fe5caa = false
 
 # in middle of superlist
-"b83989ec-8bdf-4655-95aa-9f38f3e357fd" = true
+b83989ec-8bdf-4655-95aa-9f38f3e357fd = false
 
 # at end of superlist
-"26f9f7c3-6cf6-4610-984a-662f71f8689b" = true
+26f9f7c3-6cf6-4610-984a-662f71f8689b = false
 
 # first list missing element from second list
-"0a6db763-3588-416a-8f47-76b1cedde31e" = true
+0a6db763-3588-416a-8f47-76b1cedde31e = false
 
 # second list missing element from first list
-"83ffe6d8-a445-4a3c-8795-1e51a95e65c3" = true
+83ffe6d8-a445-4a3c-8795-1e51a95e65c3 = false
 
 # order matters to a list
-"0d7ee7c1-0347-45c8-9ef5-b88db152b30b" = true
+0d7ee7c1-0347-45c8-9ef5-b88db152b30b = false
 
 # same digits but different numbers
-"5f47ce86-944e-40f9-9f31-6368aad70aa6" = true
+5f47ce86-944e-40f9-9f31-6368aad70aa6 = false

--- a/exercises/sum-of-multiples/.meta/tests.toml
+++ b/exercises/sum-of-multiples/.meta/tests.toml
@@ -1,0 +1,49 @@
+[canonical-tests]
+
+# no multiples within limit
+"54aaab5a-ce86-4edc-8b40-d3ab2400a279" = true
+
+# one factor has multiples within limit
+"361e4e50-c89b-4f60-95ef-5bc5c595490a" = true
+
+# more than one multiple within limit
+"e644e070-040e-4ae0-9910-93c69fc3f7ce" = true
+
+# more than one factor with multiples within limit
+"607d6eb9-535c-41ce-91b5-3a61da3fa57f" = true
+
+# each multiple is only counted once
+"f47e8209-c0c5-4786-b07b-dc273bf86b9b" = true
+
+# a much larger limit
+"28c4b267-c980-4054-93e9-07723db615ac" = true
+
+# three factors
+"09c4494d-ff2d-4e0f-8421-f5532821ee12" = true
+
+# factors not relatively prime
+"2d0d5faa-f177-4ad6-bde9-ebb865083751" = true
+
+# some pairs of factors relatively prime and some not
+"ece8f2e8-96aa-4166-bbb7-6ce71261e354" = true
+
+# one factor is a multiple of another
+"624fdade-6ffb-400e-8472-456a38c171c0" = true
+
+# much larger factors
+"949ee7eb-db51-479c-b5cb-4a22b40ac057" = true
+
+# all numbers are multiples of 1
+"41093673-acbd-482c-ab80-d00a0cbedecd" = true
+
+# no factors means an empty sum
+"1730453b-baaa-438e-a9c2-d754497b2a76" = true
+
+# the only multiple of 0 is 0
+"214a01e9-f4bf-45bb-80f1-1dce9fbb0310" = true
+
+# the factor 0 does not affect the sum of multiples of other factors
+"c423ae21-a0cb-4ec7-aeb1-32971af5b510" = true
+
+# solutions using include-exclude must extend to cardinality greater than 3
+"17053ba9-112f-4ac0-aadb-0519dd836342" = true

--- a/exercises/sum-of-multiples/.meta/tests.toml
+++ b/exercises/sum-of-multiples/.meta/tests.toml
@@ -1,49 +1,49 @@
 [canonical-tests]
 
 # no multiples within limit
-"54aaab5a-ce86-4edc-8b40-d3ab2400a279" = true
+54aaab5a-ce86-4edc-8b40-d3ab2400a279 = true
 
 # one factor has multiples within limit
-"361e4e50-c89b-4f60-95ef-5bc5c595490a" = true
+361e4e50-c89b-4f60-95ef-5bc5c595490a = true
 
 # more than one multiple within limit
-"e644e070-040e-4ae0-9910-93c69fc3f7ce" = true
+e644e070-040e-4ae0-9910-93c69fc3f7ce = true
 
 # more than one factor with multiples within limit
-"607d6eb9-535c-41ce-91b5-3a61da3fa57f" = true
+607d6eb9-535c-41ce-91b5-3a61da3fa57f = true
 
 # each multiple is only counted once
-"f47e8209-c0c5-4786-b07b-dc273bf86b9b" = true
+f47e8209-c0c5-4786-b07b-dc273bf86b9b = true
 
 # a much larger limit
-"28c4b267-c980-4054-93e9-07723db615ac" = true
+28c4b267-c980-4054-93e9-07723db615ac = true
 
 # three factors
-"09c4494d-ff2d-4e0f-8421-f5532821ee12" = true
+09c4494d-ff2d-4e0f-8421-f5532821ee12 = true
 
 # factors not relatively prime
-"2d0d5faa-f177-4ad6-bde9-ebb865083751" = true
+2d0d5faa-f177-4ad6-bde9-ebb865083751 = true
 
 # some pairs of factors relatively prime and some not
-"ece8f2e8-96aa-4166-bbb7-6ce71261e354" = true
+ece8f2e8-96aa-4166-bbb7-6ce71261e354 = true
 
 # one factor is a multiple of another
-"624fdade-6ffb-400e-8472-456a38c171c0" = true
+624fdade-6ffb-400e-8472-456a38c171c0 = true
 
 # much larger factors
-"949ee7eb-db51-479c-b5cb-4a22b40ac057" = true
+949ee7eb-db51-479c-b5cb-4a22b40ac057 = true
 
 # all numbers are multiples of 1
-"41093673-acbd-482c-ab80-d00a0cbedecd" = true
+41093673-acbd-482c-ab80-d00a0cbedecd = true
 
 # no factors means an empty sum
-"1730453b-baaa-438e-a9c2-d754497b2a76" = true
+1730453b-baaa-438e-a9c2-d754497b2a76 = true
 
 # the only multiple of 0 is 0
-"214a01e9-f4bf-45bb-80f1-1dce9fbb0310" = true
+214a01e9-f4bf-45bb-80f1-1dce9fbb0310 = true
 
 # the factor 0 does not affect the sum of multiples of other factors
-"c423ae21-a0cb-4ec7-aeb1-32971af5b510" = true
+c423ae21-a0cb-4ec7-aeb1-32971af5b510 = true
 
 # solutions using include-exclude must extend to cardinality greater than 3
-"17053ba9-112f-4ac0-aadb-0519dd836342" = true
+17053ba9-112f-4ac0-aadb-0519dd836342 = false

--- a/exercises/sum-of-multiples/.meta/tests.toml
+++ b/exercises/sum-of-multiples/.meta/tests.toml
@@ -1,49 +1,49 @@
 [canonical-tests]
 
 # no multiples within limit
-54aaab5a-ce86-4edc-8b40-d3ab2400a279 = true
+"54aaab5a-ce86-4edc-8b40-d3ab2400a279" = true
 
 # one factor has multiples within limit
-361e4e50-c89b-4f60-95ef-5bc5c595490a = true
+"361e4e50-c89b-4f60-95ef-5bc5c595490a" = true
 
 # more than one multiple within limit
-e644e070-040e-4ae0-9910-93c69fc3f7ce = true
+"e644e070-040e-4ae0-9910-93c69fc3f7ce" = true
 
 # more than one factor with multiples within limit
-607d6eb9-535c-41ce-91b5-3a61da3fa57f = true
+"607d6eb9-535c-41ce-91b5-3a61da3fa57f" = true
 
 # each multiple is only counted once
-f47e8209-c0c5-4786-b07b-dc273bf86b9b = true
+"f47e8209-c0c5-4786-b07b-dc273bf86b9b" = true
 
 # a much larger limit
-28c4b267-c980-4054-93e9-07723db615ac = true
+"28c4b267-c980-4054-93e9-07723db615ac" = true
 
 # three factors
-09c4494d-ff2d-4e0f-8421-f5532821ee12 = true
+"09c4494d-ff2d-4e0f-8421-f5532821ee12" = true
 
 # factors not relatively prime
-2d0d5faa-f177-4ad6-bde9-ebb865083751 = true
+"2d0d5faa-f177-4ad6-bde9-ebb865083751" = true
 
 # some pairs of factors relatively prime and some not
-ece8f2e8-96aa-4166-bbb7-6ce71261e354 = true
+"ece8f2e8-96aa-4166-bbb7-6ce71261e354" = true
 
 # one factor is a multiple of another
-624fdade-6ffb-400e-8472-456a38c171c0 = true
+"624fdade-6ffb-400e-8472-456a38c171c0" = true
 
 # much larger factors
-949ee7eb-db51-479c-b5cb-4a22b40ac057 = true
+"949ee7eb-db51-479c-b5cb-4a22b40ac057" = true
 
 # all numbers are multiples of 1
-41093673-acbd-482c-ab80-d00a0cbedecd = true
+"41093673-acbd-482c-ab80-d00a0cbedecd" = true
 
 # no factors means an empty sum
-1730453b-baaa-438e-a9c2-d754497b2a76 = true
+"1730453b-baaa-438e-a9c2-d754497b2a76" = true
 
 # the only multiple of 0 is 0
-214a01e9-f4bf-45bb-80f1-1dce9fbb0310 = true
+"214a01e9-f4bf-45bb-80f1-1dce9fbb0310" = true
 
 # the factor 0 does not affect the sum of multiples of other factors
-c423ae21-a0cb-4ec7-aeb1-32971af5b510 = true
+"c423ae21-a0cb-4ec7-aeb1-32971af5b510" = true
 
 # solutions using include-exclude must extend to cardinality greater than 3
-17053ba9-112f-4ac0-aadb-0519dd836342 = false
+"17053ba9-112f-4ac0-aadb-0519dd836342" = false

--- a/exercises/tournament/.meta/tests.toml
+++ b/exercises/tournament/.meta/tests.toml
@@ -1,0 +1,34 @@
+[canonical-tests]
+
+# just the header if no input
+"67e9fab1-07c1-49cf-9159-bc8671cc7c9c" = true
+
+# a win is three points, a loss is zero points
+"1b4a8aef-0734-4007-80a2-0626178c88f4" = true
+
+# a win can also be expressed as a loss
+"5f45ac09-4efe-46e7-8ddb-75ad85f86e05" = true
+
+# a different team can win
+"fd297368-efa0-442d-9f37-dd3f9a437239" = true
+
+# a draw is one point each
+"26c016f9-e753-4a93-94e9-842f7b4d70fc" = true
+
+# There can be more than one match
+"731204f6-4f34-4928-97eb-1c307ba83e62" = true
+
+# There can be more than one winner
+"49dc2463-42af-4ea6-95dc-f06cc5776adf" = true
+
+# There can be more than two teams
+"6d930f33-435c-4e6f-9e2d-63fa85ce7dc7" = true
+
+# typical input
+"97022974-0c8a-4a50-8fe7-e36bdd8a5945" = true
+
+# incomplete competition (not all pairs have played)
+"fe562f0d-ac0a-4c62-b9c9-44ee3236392b" = true
+
+# ties broken alphabetically
+"3aa0386f-150b-4f99-90bb-5195e7b7d3b8" = true

--- a/exercises/tournament/.meta/tests.toml
+++ b/exercises/tournament/.meta/tests.toml
@@ -1,34 +1,34 @@
 [canonical-tests]
 
 # just the header if no input
-"67e9fab1-07c1-49cf-9159-bc8671cc7c9c" = true
+67e9fab1-07c1-49cf-9159-bc8671cc7c9c = true
 
 # a win is three points, a loss is zero points
-"1b4a8aef-0734-4007-80a2-0626178c88f4" = true
+1b4a8aef-0734-4007-80a2-0626178c88f4 = false
 
 # a win can also be expressed as a loss
-"5f45ac09-4efe-46e7-8ddb-75ad85f86e05" = true
+5f45ac09-4efe-46e7-8ddb-75ad85f86e05 = true
 
 # a different team can win
-"fd297368-efa0-442d-9f37-dd3f9a437239" = true
+fd297368-efa0-442d-9f37-dd3f9a437239 = true
 
 # a draw is one point each
-"26c016f9-e753-4a93-94e9-842f7b4d70fc" = true
+26c016f9-e753-4a93-94e9-842f7b4d70fc = true
 
 # There can be more than one match
-"731204f6-4f34-4928-97eb-1c307ba83e62" = true
+731204f6-4f34-4928-97eb-1c307ba83e62 = true
 
 # There can be more than one winner
-"49dc2463-42af-4ea6-95dc-f06cc5776adf" = true
+49dc2463-42af-4ea6-95dc-f06cc5776adf = true
 
 # There can be more than two teams
-"6d930f33-435c-4e6f-9e2d-63fa85ce7dc7" = true
+6d930f33-435c-4e6f-9e2d-63fa85ce7dc7 = true
 
 # typical input
-"97022974-0c8a-4a50-8fe7-e36bdd8a5945" = true
+97022974-0c8a-4a50-8fe7-e36bdd8a5945 = true
 
 # incomplete competition (not all pairs have played)
-"fe562f0d-ac0a-4c62-b9c9-44ee3236392b" = true
+fe562f0d-ac0a-4c62-b9c9-44ee3236392b = false
 
 # ties broken alphabetically
-"3aa0386f-150b-4f99-90bb-5195e7b7d3b8" = true
+3aa0386f-150b-4f99-90bb-5195e7b7d3b8 = true

--- a/exercises/tournament/.meta/tests.toml
+++ b/exercises/tournament/.meta/tests.toml
@@ -1,34 +1,34 @@
 [canonical-tests]
 
 # just the header if no input
-67e9fab1-07c1-49cf-9159-bc8671cc7c9c = true
+"67e9fab1-07c1-49cf-9159-bc8671cc7c9c" = true
 
 # a win is three points, a loss is zero points
-1b4a8aef-0734-4007-80a2-0626178c88f4 = false
+"1b4a8aef-0734-4007-80a2-0626178c88f4" = false
 
 # a win can also be expressed as a loss
-5f45ac09-4efe-46e7-8ddb-75ad85f86e05 = true
+"5f45ac09-4efe-46e7-8ddb-75ad85f86e05" = true
 
 # a different team can win
-fd297368-efa0-442d-9f37-dd3f9a437239 = true
+"fd297368-efa0-442d-9f37-dd3f9a437239" = true
 
 # a draw is one point each
-26c016f9-e753-4a93-94e9-842f7b4d70fc = true
+"26c016f9-e753-4a93-94e9-842f7b4d70fc" = true
 
 # There can be more than one match
-731204f6-4f34-4928-97eb-1c307ba83e62 = true
+"731204f6-4f34-4928-97eb-1c307ba83e62" = true
 
 # There can be more than one winner
-49dc2463-42af-4ea6-95dc-f06cc5776adf = true
+"49dc2463-42af-4ea6-95dc-f06cc5776adf" = true
 
 # There can be more than two teams
-6d930f33-435c-4e6f-9e2d-63fa85ce7dc7 = true
+"6d930f33-435c-4e6f-9e2d-63fa85ce7dc7" = true
 
 # typical input
-97022974-0c8a-4a50-8fe7-e36bdd8a5945 = true
+"97022974-0c8a-4a50-8fe7-e36bdd8a5945" = true
 
 # incomplete competition (not all pairs have played)
-fe562f0d-ac0a-4c62-b9c9-44ee3236392b = false
+"fe562f0d-ac0a-4c62-b9c9-44ee3236392b" = false
 
 # ties broken alphabetically
-3aa0386f-150b-4f99-90bb-5195e7b7d3b8 = true
+"3aa0386f-150b-4f99-90bb-5195e7b7d3b8" = true

--- a/exercises/tournament/.meta/tests.toml
+++ b/exercises/tournament/.meta/tests.toml
@@ -4,7 +4,7 @@
 "67e9fab1-07c1-49cf-9159-bc8671cc7c9c" = true
 
 # a win is three points, a loss is zero points
-"1b4a8aef-0734-4007-80a2-0626178c88f4" = false
+"1b4a8aef-0734-4007-80a2-0626178c88f4" = true
 
 # a win can also be expressed as a loss
 "5f45ac09-4efe-46e7-8ddb-75ad85f86e05" = true
@@ -28,7 +28,7 @@
 "97022974-0c8a-4a50-8fe7-e36bdd8a5945" = true
 
 # incomplete competition (not all pairs have played)
-"fe562f0d-ac0a-4c62-b9c9-44ee3236392b" = false
+"fe562f0d-ac0a-4c62-b9c9-44ee3236392b" = true
 
 # ties broken alphabetically
 "3aa0386f-150b-4f99-90bb-5195e7b7d3b8" = true

--- a/exercises/triangle/.meta/tests.toml
+++ b/exercises/triangle/.meta/tests.toml
@@ -1,0 +1,58 @@
+[canonical-tests]
+
+# all sides are equal
+"8b2c43ac-7257-43f9-b552-7631a91988af" = true
+
+# any side is unequal
+"33eb6f87-0498-4ccf-9573-7f8c3ce92b7b" = true
+
+# no sides are equal
+"c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87" = true
+
+# all zero sides is not a triangle
+"16e8ceb0-eadb-46d1-b892-c50327479251" = true
+
+# sides may be floats
+"3022f537-b8e5-4cc1-8f12-fd775827a00c" = true
+
+# last two sides are equal
+"cbc612dc-d75a-4c1c-87fc-e2d5edd70b71" = true
+
+# first two sides are equal
+"e388ce93-f25e-4daf-b977-4b7ede992217" = true
+
+# first and last sides are equal
+"d2080b79-4523-4c3f-9d42-2da6e81ab30f" = true
+
+# equilateral triangles are also isosceles
+"8d71e185-2bd7-4841-b7e1-71689a5491d8" = true
+
+# no sides are equal
+"840ed5f8-366f-43c5-ac69-8f05e6f10bbb" = true
+
+# first triangle inequality violation
+"2eba0cfb-6c65-4c40-8146-30b608905eae" = true
+
+# second triangle inequality violation
+"278469cb-ac6b-41f0-81d4-66d9b828f8ac" = true
+
+# third triangle inequality violation
+"90efb0c7-72bb-4514-b320-3a3892e278ff" = true
+
+# sides may be floats
+"adb4ee20-532f-43dc-8d31-e9271b7ef2bc" = true
+
+# no sides are equal
+"e8b5f09c-ec2e-47c1-abec-f35095733afb" = true
+
+# all sides are equal
+"2510001f-b44d-4d18-9872-2303e7977dc1" = true
+
+# two sides are equal
+"c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e" = true
+
+# may not violate triangle inequality
+"70ad5154-0033-48b7-af2c-b8d739cd9fdc" = true
+
+# sides may be floats
+"26d9d59d-f8f1-40d3-ad58-ae4d54123d7d" = true

--- a/exercises/triangle/.meta/tests.toml
+++ b/exercises/triangle/.meta/tests.toml
@@ -1,58 +1,58 @@
 [canonical-tests]
 
 # all sides are equal
-8b2c43ac-7257-43f9-b552-7631a91988af = false
+"8b2c43ac-7257-43f9-b552-7631a91988af" = false
 
 # any side is unequal
-33eb6f87-0498-4ccf-9573-7f8c3ce92b7b = false
+"33eb6f87-0498-4ccf-9573-7f8c3ce92b7b" = false
 
 # no sides are equal
-c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87 = false
+"c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87" = false
 
 # all zero sides is not a triangle
-16e8ceb0-eadb-46d1-b892-c50327479251 = false
+"16e8ceb0-eadb-46d1-b892-c50327479251" = false
 
 # sides may be floats
-3022f537-b8e5-4cc1-8f12-fd775827a00c = false
+"3022f537-b8e5-4cc1-8f12-fd775827a00c" = false
 
 # last two sides are equal
-cbc612dc-d75a-4c1c-87fc-e2d5edd70b71 = false
+"cbc612dc-d75a-4c1c-87fc-e2d5edd70b71" = false
 
 # first two sides are equal
-e388ce93-f25e-4daf-b977-4b7ede992217 = false
+"e388ce93-f25e-4daf-b977-4b7ede992217" = false
 
 # first and last sides are equal
-d2080b79-4523-4c3f-9d42-2da6e81ab30f = false
+"d2080b79-4523-4c3f-9d42-2da6e81ab30f" = false
 
 # equilateral triangles are also isosceles
-8d71e185-2bd7-4841-b7e1-71689a5491d8 = false
+"8d71e185-2bd7-4841-b7e1-71689a5491d8" = false
 
 # no sides are equal
-840ed5f8-366f-43c5-ac69-8f05e6f10bbb = false
+"840ed5f8-366f-43c5-ac69-8f05e6f10bbb" = false
 
 # first triangle inequality violation
-2eba0cfb-6c65-4c40-8146-30b608905eae = false
+"2eba0cfb-6c65-4c40-8146-30b608905eae" = false
 
 # second triangle inequality violation
-278469cb-ac6b-41f0-81d4-66d9b828f8ac = false
+"278469cb-ac6b-41f0-81d4-66d9b828f8ac" = false
 
 # third triangle inequality violation
-90efb0c7-72bb-4514-b320-3a3892e278ff = false
+"90efb0c7-72bb-4514-b320-3a3892e278ff" = false
 
 # sides may be floats
-adb4ee20-532f-43dc-8d31-e9271b7ef2bc = false
+"adb4ee20-532f-43dc-8d31-e9271b7ef2bc" = false
 
 # no sides are equal
-e8b5f09c-ec2e-47c1-abec-f35095733afb = false
+"e8b5f09c-ec2e-47c1-abec-f35095733afb" = false
 
 # all sides are equal
-2510001f-b44d-4d18-9872-2303e7977dc1 = false
+"2510001f-b44d-4d18-9872-2303e7977dc1" = false
 
 # two sides are equal
-c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e = false
+"c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e" = false
 
 # may not violate triangle inequality
-70ad5154-0033-48b7-af2c-b8d739cd9fdc = false
+"70ad5154-0033-48b7-af2c-b8d739cd9fdc" = false
 
 # sides may be floats
-26d9d59d-f8f1-40d3-ad58-ae4d54123d7d = false
+"26d9d59d-f8f1-40d3-ad58-ae4d54123d7d" = false

--- a/exercises/triangle/.meta/tests.toml
+++ b/exercises/triangle/.meta/tests.toml
@@ -1,58 +1,58 @@
 [canonical-tests]
 
 # all sides are equal
-"8b2c43ac-7257-43f9-b552-7631a91988af" = true
+8b2c43ac-7257-43f9-b552-7631a91988af = false
 
 # any side is unequal
-"33eb6f87-0498-4ccf-9573-7f8c3ce92b7b" = true
+33eb6f87-0498-4ccf-9573-7f8c3ce92b7b = false
 
 # no sides are equal
-"c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87" = true
+c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87 = false
 
 # all zero sides is not a triangle
-"16e8ceb0-eadb-46d1-b892-c50327479251" = true
+16e8ceb0-eadb-46d1-b892-c50327479251 = false
 
 # sides may be floats
-"3022f537-b8e5-4cc1-8f12-fd775827a00c" = true
+3022f537-b8e5-4cc1-8f12-fd775827a00c = false
 
 # last two sides are equal
-"cbc612dc-d75a-4c1c-87fc-e2d5edd70b71" = true
+cbc612dc-d75a-4c1c-87fc-e2d5edd70b71 = false
 
 # first two sides are equal
-"e388ce93-f25e-4daf-b977-4b7ede992217" = true
+e388ce93-f25e-4daf-b977-4b7ede992217 = false
 
 # first and last sides are equal
-"d2080b79-4523-4c3f-9d42-2da6e81ab30f" = true
+d2080b79-4523-4c3f-9d42-2da6e81ab30f = false
 
 # equilateral triangles are also isosceles
-"8d71e185-2bd7-4841-b7e1-71689a5491d8" = true
+8d71e185-2bd7-4841-b7e1-71689a5491d8 = false
 
 # no sides are equal
-"840ed5f8-366f-43c5-ac69-8f05e6f10bbb" = true
+840ed5f8-366f-43c5-ac69-8f05e6f10bbb = false
 
 # first triangle inequality violation
-"2eba0cfb-6c65-4c40-8146-30b608905eae" = true
+2eba0cfb-6c65-4c40-8146-30b608905eae = false
 
 # second triangle inequality violation
-"278469cb-ac6b-41f0-81d4-66d9b828f8ac" = true
+278469cb-ac6b-41f0-81d4-66d9b828f8ac = false
 
 # third triangle inequality violation
-"90efb0c7-72bb-4514-b320-3a3892e278ff" = true
+90efb0c7-72bb-4514-b320-3a3892e278ff = false
 
 # sides may be floats
-"adb4ee20-532f-43dc-8d31-e9271b7ef2bc" = true
+adb4ee20-532f-43dc-8d31-e9271b7ef2bc = false
 
 # no sides are equal
-"e8b5f09c-ec2e-47c1-abec-f35095733afb" = true
+e8b5f09c-ec2e-47c1-abec-f35095733afb = false
 
 # all sides are equal
-"2510001f-b44d-4d18-9872-2303e7977dc1" = true
+2510001f-b44d-4d18-9872-2303e7977dc1 = false
 
 # two sides are equal
-"c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e" = true
+c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e = false
 
 # may not violate triangle inequality
-"70ad5154-0033-48b7-af2c-b8d739cd9fdc" = true
+70ad5154-0033-48b7-af2c-b8d739cd9fdc = false
 
 # sides may be floats
-"26d9d59d-f8f1-40d3-ad58-ae4d54123d7d" = true
+26d9d59d-f8f1-40d3-ad58-ae4d54123d7d = false

--- a/exercises/two-bucket/.meta/tests.toml
+++ b/exercises/two-bucket/.meta/tests.toml
@@ -1,0 +1,19 @@
+[canonical-tests]
+
+# Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one
+"a6f2b4ba-065f-4dca-b6f0-e3eee51cb661" = true
+
+# Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two
+"6c4ea451-9678-4926-b9b3-68364e066d40" = true
+
+# Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one
+"3389f45e-6a56-46d5-9607-75aa930502ff" = true
+
+# Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two
+"fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1" = true
+
+# Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two
+"0ee1f57e-da84-44f7-ac91-38b878691602" = true
+
+# Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two
+"eb329c63-5540-4735-b30b-97f7f4df0f84" = true

--- a/exercises/two-bucket/.meta/tests.toml
+++ b/exercises/two-bucket/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one
-"a6f2b4ba-065f-4dca-b6f0-e3eee51cb661" = true
+a6f2b4ba-065f-4dca-b6f0-e3eee51cb661 = false
 
 # Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two
-"6c4ea451-9678-4926-b9b3-68364e066d40" = true
+6c4ea451-9678-4926-b9b3-68364e066d40 = false
 
 # Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one
-"3389f45e-6a56-46d5-9607-75aa930502ff" = true
+3389f45e-6a56-46d5-9607-75aa930502ff = false
 
 # Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two
-"fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1" = true
+fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1 = false
 
 # Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two
-"0ee1f57e-da84-44f7-ac91-38b878691602" = true
+0ee1f57e-da84-44f7-ac91-38b878691602 = false
 
 # Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two
-"eb329c63-5540-4735-b30b-97f7f4df0f84" = true
+eb329c63-5540-4735-b30b-97f7f4df0f84 = false

--- a/exercises/two-bucket/.meta/tests.toml
+++ b/exercises/two-bucket/.meta/tests.toml
@@ -1,19 +1,19 @@
 [canonical-tests]
 
 # Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one
-a6f2b4ba-065f-4dca-b6f0-e3eee51cb661 = false
+"a6f2b4ba-065f-4dca-b6f0-e3eee51cb661" = false
 
 # Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two
-6c4ea451-9678-4926-b9b3-68364e066d40 = false
+"6c4ea451-9678-4926-b9b3-68364e066d40" = false
 
 # Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one
-3389f45e-6a56-46d5-9607-75aa930502ff = false
+"3389f45e-6a56-46d5-9607-75aa930502ff" = false
 
 # Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two
-fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1 = false
+"fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1" = false
 
 # Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two
-0ee1f57e-da84-44f7-ac91-38b878691602 = false
+"0ee1f57e-da84-44f7-ac91-38b878691602" = false
 
 # Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two
-eb329c63-5540-4735-b30b-97f7f4df0f84 = false
+"eb329c63-5540-4735-b30b-97f7f4df0f84" = false

--- a/exercises/two-fer/.meta/tests.toml
+++ b/exercises/two-fer/.meta/tests.toml
@@ -1,0 +1,10 @@
+[canonical-tests]
+
+# no name given
+"1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce" = true
+
+# a name given
+"b4c6dbb8-b4fb-42c2-bafd-10785abe7709" = true
+
+# another name given
+"3549048d-1a6e-4653-9a79-b0bda163e8d5" = true

--- a/exercises/two-fer/.meta/tests.toml
+++ b/exercises/two-fer/.meta/tests.toml
@@ -1,10 +1,10 @@
 [canonical-tests]
 
 # no name given
-"1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce" = true
+1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce = false
 
 # a name given
-"b4c6dbb8-b4fb-42c2-bafd-10785abe7709" = true
+b4c6dbb8-b4fb-42c2-bafd-10785abe7709 = false
 
 # another name given
-"3549048d-1a6e-4653-9a79-b0bda163e8d5" = true
+3549048d-1a6e-4653-9a79-b0bda163e8d5 = false

--- a/exercises/two-fer/.meta/tests.toml
+++ b/exercises/two-fer/.meta/tests.toml
@@ -1,10 +1,10 @@
 [canonical-tests]
 
 # no name given
-1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce = false
+"1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce" = false
 
 # a name given
-b4c6dbb8-b4fb-42c2-bafd-10785abe7709 = false
+"b4c6dbb8-b4fb-42c2-bafd-10785abe7709" = false
 
 # another name given
-3549048d-1a6e-4653-9a79-b0bda163e8d5 = false
+"3549048d-1a6e-4653-9a79-b0bda163e8d5" = false

--- a/exercises/variable-length-quantity/.meta/tests.toml
+++ b/exercises/variable-length-quantity/.meta/tests.toml
@@ -1,0 +1,79 @@
+[canonical-tests]
+
+# zero
+"35c9db2e-f781-4c52-b73b-8e76427defd0" = true
+
+# arbitrary single byte
+"be44d299-a151-4604-a10e-d4b867f41540" = true
+
+# largest single byte
+"ea399615-d274-4af6-bbef-a1c23c9e1346" = true
+
+# smallest double byte
+"77b07086-bd3f-4882-8476-8dcafee79b1c" = true
+
+# arbitrary double byte
+"63955a49-2690-4e22-a556-0040648d6b2d" = true
+
+# largest double byte
+"29da7031-0067-43d3-83a7-4f14b29ed97a" = true
+
+# smallest triple byte
+"3345d2e3-79a9-4999-869e-d4856e3a8e01" = true
+
+# arbitrary triple byte
+"5df0bc2d-2a57-4300-a653-a75ee4bd0bee" = true
+
+# largest triple byte
+"f51d8539-312d-4db1-945c-250222c6aa22" = true
+
+# smallest quadruple byte
+"da78228b-544f-47b7-8bfe-d16b35bbe570" = true
+
+# arbitrary quadruple byte
+"11ed3469-a933-46f1-996f-2231e05d7bb6" = true
+
+# largest quadruple byte
+"d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c" = true
+
+# smallest quintuple byte
+"91a18b33-24e7-4bfb-bbca-eca78ff4fc47" = true
+
+# arbitrary quintuple byte
+"5f34ff12-2952-4669-95fe-2d11b693d331" = true
+
+# maximum 32-bit integer input
+"7489694b-88c3-4078-9864-6fe802411009" = true
+
+# two single-byte values
+"f9b91821-cada-4a73-9421-3c81d6ff3661" = true
+
+# two multi-byte values
+"68694449-25d2-4974-ba75-fa7bb36db212" = true
+
+# many multi-byte values
+"51a06b5c-de1b-4487-9a50-9db1b8930d85" = true
+
+# one byte
+"baa73993-4514-4915-bac0-f7f585e0e59a" = true
+
+# two bytes
+"72e94369-29f9-46f2-8c95-6c5b7a595aee" = true
+
+# three bytes
+"df5a44c4-56f7-464e-a997-1db5f63ce691" = true
+
+# four bytes
+"1bb58684-f2dc-450a-8406-1f3452aa1947" = true
+
+# maximum 32-bit integer
+"cecd5233-49f1-4dd1-a41a-9840a40f09cd" = true
+
+# incomplete sequence causes error
+"e7d74ba3-8b8e-4bcb-858d-d08302e15695" = true
+
+# incomplete sequence causes error, even if value is zero
+"aa378291-9043-4724-bc53-aca1b4a3fcb6" = true
+
+# multiple values
+"a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee" = true

--- a/exercises/variable-length-quantity/.meta/tests.toml
+++ b/exercises/variable-length-quantity/.meta/tests.toml
@@ -1,79 +1,79 @@
 [canonical-tests]
 
 # zero
-35c9db2e-f781-4c52-b73b-8e76427defd0 = false
+"35c9db2e-f781-4c52-b73b-8e76427defd0" = false
 
 # arbitrary single byte
-be44d299-a151-4604-a10e-d4b867f41540 = false
+"be44d299-a151-4604-a10e-d4b867f41540" = false
 
 # largest single byte
-ea399615-d274-4af6-bbef-a1c23c9e1346 = false
+"ea399615-d274-4af6-bbef-a1c23c9e1346" = false
 
 # smallest double byte
-77b07086-bd3f-4882-8476-8dcafee79b1c = false
+"77b07086-bd3f-4882-8476-8dcafee79b1c" = false
 
 # arbitrary double byte
-63955a49-2690-4e22-a556-0040648d6b2d = false
+"63955a49-2690-4e22-a556-0040648d6b2d" = false
 
 # largest double byte
-29da7031-0067-43d3-83a7-4f14b29ed97a = false
+"29da7031-0067-43d3-83a7-4f14b29ed97a" = false
 
 # smallest triple byte
-3345d2e3-79a9-4999-869e-d4856e3a8e01 = false
+"3345d2e3-79a9-4999-869e-d4856e3a8e01" = false
 
 # arbitrary triple byte
-5df0bc2d-2a57-4300-a653-a75ee4bd0bee = false
+"5df0bc2d-2a57-4300-a653-a75ee4bd0bee" = false
 
 # largest triple byte
-f51d8539-312d-4db1-945c-250222c6aa22 = false
+"f51d8539-312d-4db1-945c-250222c6aa22" = false
 
 # smallest quadruple byte
-da78228b-544f-47b7-8bfe-d16b35bbe570 = false
+"da78228b-544f-47b7-8bfe-d16b35bbe570" = false
 
 # arbitrary quadruple byte
-11ed3469-a933-46f1-996f-2231e05d7bb6 = false
+"11ed3469-a933-46f1-996f-2231e05d7bb6" = false
 
 # largest quadruple byte
-d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c = false
+"d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c" = false
 
 # smallest quintuple byte
-91a18b33-24e7-4bfb-bbca-eca78ff4fc47 = false
+"91a18b33-24e7-4bfb-bbca-eca78ff4fc47" = false
 
 # arbitrary quintuple byte
-5f34ff12-2952-4669-95fe-2d11b693d331 = false
+"5f34ff12-2952-4669-95fe-2d11b693d331" = false
 
 # maximum 32-bit integer input
-7489694b-88c3-4078-9864-6fe802411009 = false
+"7489694b-88c3-4078-9864-6fe802411009" = false
 
 # two single-byte values
-f9b91821-cada-4a73-9421-3c81d6ff3661 = false
+"f9b91821-cada-4a73-9421-3c81d6ff3661" = false
 
 # two multi-byte values
-68694449-25d2-4974-ba75-fa7bb36db212 = false
+"68694449-25d2-4974-ba75-fa7bb36db212" = false
 
 # many multi-byte values
-51a06b5c-de1b-4487-9a50-9db1b8930d85 = false
+"51a06b5c-de1b-4487-9a50-9db1b8930d85" = false
 
 # one byte
-baa73993-4514-4915-bac0-f7f585e0e59a = false
+"baa73993-4514-4915-bac0-f7f585e0e59a" = false
 
 # two bytes
-72e94369-29f9-46f2-8c95-6c5b7a595aee = false
+"72e94369-29f9-46f2-8c95-6c5b7a595aee" = false
 
 # three bytes
-df5a44c4-56f7-464e-a997-1db5f63ce691 = false
+"df5a44c4-56f7-464e-a997-1db5f63ce691" = false
 
 # four bytes
-1bb58684-f2dc-450a-8406-1f3452aa1947 = false
+"1bb58684-f2dc-450a-8406-1f3452aa1947" = false
 
 # maximum 32-bit integer
-cecd5233-49f1-4dd1-a41a-9840a40f09cd = false
+"cecd5233-49f1-4dd1-a41a-9840a40f09cd" = false
 
 # incomplete sequence causes error
-e7d74ba3-8b8e-4bcb-858d-d08302e15695 = false
+"e7d74ba3-8b8e-4bcb-858d-d08302e15695" = false
 
 # incomplete sequence causes error, even if value is zero
-aa378291-9043-4724-bc53-aca1b4a3fcb6 = false
+"aa378291-9043-4724-bc53-aca1b4a3fcb6" = false
 
 # multiple values
-a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee = false
+"a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee" = false

--- a/exercises/variable-length-quantity/.meta/tests.toml
+++ b/exercises/variable-length-quantity/.meta/tests.toml
@@ -1,79 +1,79 @@
 [canonical-tests]
 
 # zero
-"35c9db2e-f781-4c52-b73b-8e76427defd0" = true
+35c9db2e-f781-4c52-b73b-8e76427defd0 = false
 
 # arbitrary single byte
-"be44d299-a151-4604-a10e-d4b867f41540" = true
+be44d299-a151-4604-a10e-d4b867f41540 = false
 
 # largest single byte
-"ea399615-d274-4af6-bbef-a1c23c9e1346" = true
+ea399615-d274-4af6-bbef-a1c23c9e1346 = false
 
 # smallest double byte
-"77b07086-bd3f-4882-8476-8dcafee79b1c" = true
+77b07086-bd3f-4882-8476-8dcafee79b1c = false
 
 # arbitrary double byte
-"63955a49-2690-4e22-a556-0040648d6b2d" = true
+63955a49-2690-4e22-a556-0040648d6b2d = false
 
 # largest double byte
-"29da7031-0067-43d3-83a7-4f14b29ed97a" = true
+29da7031-0067-43d3-83a7-4f14b29ed97a = false
 
 # smallest triple byte
-"3345d2e3-79a9-4999-869e-d4856e3a8e01" = true
+3345d2e3-79a9-4999-869e-d4856e3a8e01 = false
 
 # arbitrary triple byte
-"5df0bc2d-2a57-4300-a653-a75ee4bd0bee" = true
+5df0bc2d-2a57-4300-a653-a75ee4bd0bee = false
 
 # largest triple byte
-"f51d8539-312d-4db1-945c-250222c6aa22" = true
+f51d8539-312d-4db1-945c-250222c6aa22 = false
 
 # smallest quadruple byte
-"da78228b-544f-47b7-8bfe-d16b35bbe570" = true
+da78228b-544f-47b7-8bfe-d16b35bbe570 = false
 
 # arbitrary quadruple byte
-"11ed3469-a933-46f1-996f-2231e05d7bb6" = true
+11ed3469-a933-46f1-996f-2231e05d7bb6 = false
 
 # largest quadruple byte
-"d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c" = true
+d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c = false
 
 # smallest quintuple byte
-"91a18b33-24e7-4bfb-bbca-eca78ff4fc47" = true
+91a18b33-24e7-4bfb-bbca-eca78ff4fc47 = false
 
 # arbitrary quintuple byte
-"5f34ff12-2952-4669-95fe-2d11b693d331" = true
+5f34ff12-2952-4669-95fe-2d11b693d331 = false
 
 # maximum 32-bit integer input
-"7489694b-88c3-4078-9864-6fe802411009" = true
+7489694b-88c3-4078-9864-6fe802411009 = false
 
 # two single-byte values
-"f9b91821-cada-4a73-9421-3c81d6ff3661" = true
+f9b91821-cada-4a73-9421-3c81d6ff3661 = false
 
 # two multi-byte values
-"68694449-25d2-4974-ba75-fa7bb36db212" = true
+68694449-25d2-4974-ba75-fa7bb36db212 = false
 
 # many multi-byte values
-"51a06b5c-de1b-4487-9a50-9db1b8930d85" = true
+51a06b5c-de1b-4487-9a50-9db1b8930d85 = false
 
 # one byte
-"baa73993-4514-4915-bac0-f7f585e0e59a" = true
+baa73993-4514-4915-bac0-f7f585e0e59a = false
 
 # two bytes
-"72e94369-29f9-46f2-8c95-6c5b7a595aee" = true
+72e94369-29f9-46f2-8c95-6c5b7a595aee = false
 
 # three bytes
-"df5a44c4-56f7-464e-a997-1db5f63ce691" = true
+df5a44c4-56f7-464e-a997-1db5f63ce691 = false
 
 # four bytes
-"1bb58684-f2dc-450a-8406-1f3452aa1947" = true
+1bb58684-f2dc-450a-8406-1f3452aa1947 = false
 
 # maximum 32-bit integer
-"cecd5233-49f1-4dd1-a41a-9840a40f09cd" = true
+cecd5233-49f1-4dd1-a41a-9840a40f09cd = false
 
 # incomplete sequence causes error
-"e7d74ba3-8b8e-4bcb-858d-d08302e15695" = true
+e7d74ba3-8b8e-4bcb-858d-d08302e15695 = false
 
 # incomplete sequence causes error, even if value is zero
-"aa378291-9043-4724-bc53-aca1b4a3fcb6" = true
+aa378291-9043-4724-bc53-aca1b4a3fcb6 = false
 
 # multiple values
-"a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee" = true
+a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee = false

--- a/exercises/word-count/.meta/tests.toml
+++ b/exercises/word-count/.meta/tests.toml
@@ -1,0 +1,40 @@
+[canonical-tests]
+
+# count one word
+"61559d5f-2cad-48fb-af53-d3973a9ee9ef" = true
+
+# count one of each word
+"5abd53a3-1aed-43a4-a15a-29f88c09cbbd" = true
+
+# multiple occurrences of a word
+"2a3091e5-952e-4099-9fac-8f85d9655c0e" = true
+
+# handles cramped lists
+"e81877ae-d4da-4af4-931c-d923cd621ca6" = true
+
+# handles expanded lists
+"7349f682-9707-47c0-a9af-be56e1e7ff30" = true
+
+# ignore punctuation
+"a514a0f2-8589-4279-8892-887f76a14c82" = true
+
+# include numbers
+"d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e" = true
+
+# normalize case
+"dac6bc6a-21ae-4954-945d-d7f716392dbf" = true
+
+# with apostrophes
+"4185a902-bdb0-4074-864c-f416e42a0f19" = true
+
+# with quotations
+"be72af2b-8afe-4337-b151-b297202e4a7b" = true
+
+# substrings from the beginning
+"8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6" = true
+
+# multiple spaces not detected as a word
+"c5f4ef26-f3f7-4725-b314-855c04fb4c13" = true
+
+# alternating word separators not detected as a word
+"50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360" = true

--- a/exercises/word-count/.meta/tests.toml
+++ b/exercises/word-count/.meta/tests.toml
@@ -1,40 +1,40 @@
 [canonical-tests]
 
 # count one word
-"61559d5f-2cad-48fb-af53-d3973a9ee9ef" = true
+61559d5f-2cad-48fb-af53-d3973a9ee9ef = false
 
 # count one of each word
-"5abd53a3-1aed-43a4-a15a-29f88c09cbbd" = true
+5abd53a3-1aed-43a4-a15a-29f88c09cbbd = false
 
 # multiple occurrences of a word
-"2a3091e5-952e-4099-9fac-8f85d9655c0e" = true
+2a3091e5-952e-4099-9fac-8f85d9655c0e = false
 
 # handles cramped lists
-"e81877ae-d4da-4af4-931c-d923cd621ca6" = true
+e81877ae-d4da-4af4-931c-d923cd621ca6 = false
 
 # handles expanded lists
-"7349f682-9707-47c0-a9af-be56e1e7ff30" = true
+7349f682-9707-47c0-a9af-be56e1e7ff30 = false
 
 # ignore punctuation
-"a514a0f2-8589-4279-8892-887f76a14c82" = true
+a514a0f2-8589-4279-8892-887f76a14c82 = false
 
 # include numbers
-"d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e" = true
+d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e = false
 
 # normalize case
-"dac6bc6a-21ae-4954-945d-d7f716392dbf" = true
+dac6bc6a-21ae-4954-945d-d7f716392dbf = false
 
 # with apostrophes
-"4185a902-bdb0-4074-864c-f416e42a0f19" = true
+4185a902-bdb0-4074-864c-f416e42a0f19 = true
 
 # with quotations
-"be72af2b-8afe-4337-b151-b297202e4a7b" = true
+be72af2b-8afe-4337-b151-b297202e4a7b = true
 
 # substrings from the beginning
-"8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6" = true
+8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6 = false
 
 # multiple spaces not detected as a word
-"c5f4ef26-f3f7-4725-b314-855c04fb4c13" = true
+c5f4ef26-f3f7-4725-b314-855c04fb4c13 = true
 
 # alternating word separators not detected as a word
-"50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360" = true
+50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360 = false

--- a/exercises/word-count/.meta/tests.toml
+++ b/exercises/word-count/.meta/tests.toml
@@ -1,40 +1,40 @@
 [canonical-tests]
 
 # count one word
-61559d5f-2cad-48fb-af53-d3973a9ee9ef = false
+"61559d5f-2cad-48fb-af53-d3973a9ee9ef" = false
 
 # count one of each word
-5abd53a3-1aed-43a4-a15a-29f88c09cbbd = false
+"5abd53a3-1aed-43a4-a15a-29f88c09cbbd" = false
 
 # multiple occurrences of a word
-2a3091e5-952e-4099-9fac-8f85d9655c0e = false
+"2a3091e5-952e-4099-9fac-8f85d9655c0e" = false
 
 # handles cramped lists
-e81877ae-d4da-4af4-931c-d923cd621ca6 = false
+"e81877ae-d4da-4af4-931c-d923cd621ca6" = false
 
 # handles expanded lists
-7349f682-9707-47c0-a9af-be56e1e7ff30 = false
+"7349f682-9707-47c0-a9af-be56e1e7ff30" = false
 
 # ignore punctuation
-a514a0f2-8589-4279-8892-887f76a14c82 = false
+"a514a0f2-8589-4279-8892-887f76a14c82" = false
 
 # include numbers
-d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e = false
+"d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e" = false
 
 # normalize case
-dac6bc6a-21ae-4954-945d-d7f716392dbf = false
+"dac6bc6a-21ae-4954-945d-d7f716392dbf" = false
 
 # with apostrophes
-4185a902-bdb0-4074-864c-f416e42a0f19 = true
+"4185a902-bdb0-4074-864c-f416e42a0f19" = true
 
 # with quotations
-be72af2b-8afe-4337-b151-b297202e4a7b = true
+"be72af2b-8afe-4337-b151-b297202e4a7b" = true
 
 # substrings from the beginning
-8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6 = false
+"8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6" = false
 
 # multiple spaces not detected as a word
-c5f4ef26-f3f7-4725-b314-855c04fb4c13 = true
+"c5f4ef26-f3f7-4725-b314-855c04fb4c13" = true
 
 # alternating word separators not detected as a word
-50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360 = false
+"50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360" = false

--- a/exercises/wordy/.meta/tests.toml
+++ b/exercises/wordy/.meta/tests.toml
@@ -1,0 +1,70 @@
+[canonical-tests]
+
+# just a number
+"88bf4b28-0de3-4883-93c7-db1b14aa806e" = true
+
+# addition
+"bb8c655c-cf42-4dfc-90e0-152fcfd8d4e0" = true
+
+# more addition
+"79e49e06-c5ae-40aa-a352-7a3a01f70015" = true
+
+# addition with negative numbers
+"b345dbe0-f733-44e1-863c-5ae3568f3803" = true
+
+# large addition
+"cd070f39-c4cc-45c4-97fb-1be5e5846f87" = true
+
+# subtraction
+"0d86474a-cd93-4649-a4fa-f6109a011191" = true
+
+# multiplication
+"30bc8395-5500-4712-a0cf-1d788a529be5" = true
+
+# division
+"34c36b08-8605-4217-bb57-9a01472c427f" = true
+
+# multiple additions
+"da6d2ce4-fb94-4d26-8f5f-b078adad0596" = true
+
+# addition and subtraction
+"7fd74c50-9911-4597-be09-8de7f2fea2bb" = true
+
+# multiple subtraction
+"b120ffd5-bad6-4e22-81c8-5512e8faf905" = true
+
+# subtraction then addition
+"4f4a5749-ef0c-4f60-841f-abcfaf05d2ae" = true
+
+# multiple multiplication
+"312d908c-f68f-42c9-aa75-961623cc033f" = true
+
+# addition and multiplication
+"38e33587-8940-4cc1-bc28-bfd7e3966276" = true
+
+# multiple division
+"3c854f97-9311-46e8-b574-92b60d17d394" = true
+
+# unknown operation
+"3ad3e433-8af7-41ec-aa9b-97b42ab49357" = true
+
+# Non math question
+"8a7e85a8-9e7b-4d46-868f-6d759f4648f8" = true
+
+# reject problem missing an operand
+"42d78b5f-dbd7-4cdb-8b30-00f794bb24cf" = true
+
+# reject problem with no operands or operators
+"c2c3cbfc-1a72-42f2-b597-246e617e66f5" = true
+
+# reject two operations in a row
+"4b3df66d-6ed5-4c95-a0a1-d38891fbdab6" = true
+
+# reject two numbers in a row
+"6abd7a50-75b4-4665-aa33-2030fd08bab1" = true
+
+# reject postfix notation
+"10a56c22-e0aa-405f-b1d2-c642d9c4c9de" = true
+
+# reject prefix notation
+"0035bc63-ac43-4bb5-ad6d-e8651b7d954e" = true

--- a/exercises/wordy/.meta/tests.toml
+++ b/exercises/wordy/.meta/tests.toml
@@ -1,70 +1,70 @@
 [canonical-tests]
 
 # just a number
-88bf4b28-0de3-4883-93c7-db1b14aa806e = true
+"88bf4b28-0de3-4883-93c7-db1b14aa806e" = true
 
 # addition
-bb8c655c-cf42-4dfc-90e0-152fcfd8d4e0 = true
+"bb8c655c-cf42-4dfc-90e0-152fcfd8d4e0" = true
 
 # more addition
-79e49e06-c5ae-40aa-a352-7a3a01f70015 = true
+"79e49e06-c5ae-40aa-a352-7a3a01f70015" = true
 
 # addition with negative numbers
-b345dbe0-f733-44e1-863c-5ae3568f3803 = true
+"b345dbe0-f733-44e1-863c-5ae3568f3803" = true
 
 # large addition
-cd070f39-c4cc-45c4-97fb-1be5e5846f87 = true
+"cd070f39-c4cc-45c4-97fb-1be5e5846f87" = true
 
 # subtraction
-0d86474a-cd93-4649-a4fa-f6109a011191 = true
+"0d86474a-cd93-4649-a4fa-f6109a011191" = true
 
 # multiplication
-30bc8395-5500-4712-a0cf-1d788a529be5 = true
+"30bc8395-5500-4712-a0cf-1d788a529be5" = true
 
 # division
-34c36b08-8605-4217-bb57-9a01472c427f = true
+"34c36b08-8605-4217-bb57-9a01472c427f" = true
 
 # multiple additions
-da6d2ce4-fb94-4d26-8f5f-b078adad0596 = true
+"da6d2ce4-fb94-4d26-8f5f-b078adad0596" = true
 
 # addition and subtraction
-7fd74c50-9911-4597-be09-8de7f2fea2bb = true
+"7fd74c50-9911-4597-be09-8de7f2fea2bb" = true
 
 # multiple subtraction
-b120ffd5-bad6-4e22-81c8-5512e8faf905 = true
+"b120ffd5-bad6-4e22-81c8-5512e8faf905" = true
 
 # subtraction then addition
-4f4a5749-ef0c-4f60-841f-abcfaf05d2ae = true
+"4f4a5749-ef0c-4f60-841f-abcfaf05d2ae" = true
 
 # multiple multiplication
-312d908c-f68f-42c9-aa75-961623cc033f = false
+"312d908c-f68f-42c9-aa75-961623cc033f" = false
 
 # addition and multiplication
-38e33587-8940-4cc1-bc28-bfd7e3966276 = true
+"38e33587-8940-4cc1-bc28-bfd7e3966276" = true
 
 # multiple division
-3c854f97-9311-46e8-b574-92b60d17d394 = false
+"3c854f97-9311-46e8-b574-92b60d17d394" = false
 
 # unknown operation
-3ad3e433-8af7-41ec-aa9b-97b42ab49357 = true
+"3ad3e433-8af7-41ec-aa9b-97b42ab49357" = true
 
 # Non math question
-8a7e85a8-9e7b-4d46-868f-6d759f4648f8 = true
+"8a7e85a8-9e7b-4d46-868f-6d759f4648f8" = true
 
 # reject problem missing an operand
-42d78b5f-dbd7-4cdb-8b30-00f794bb24cf = true
+"42d78b5f-dbd7-4cdb-8b30-00f794bb24cf" = true
 
 # reject problem with no operands or operators
-c2c3cbfc-1a72-42f2-b597-246e617e66f5 = true
+"c2c3cbfc-1a72-42f2-b597-246e617e66f5" = true
 
 # reject two operations in a row
-4b3df66d-6ed5-4c95-a0a1-d38891fbdab6 = true
+"4b3df66d-6ed5-4c95-a0a1-d38891fbdab6" = true
 
 # reject two numbers in a row
-6abd7a50-75b4-4665-aa33-2030fd08bab1 = true
+"6abd7a50-75b4-4665-aa33-2030fd08bab1" = true
 
 # reject postfix notation
-10a56c22-e0aa-405f-b1d2-c642d9c4c9de = true
+"10a56c22-e0aa-405f-b1d2-c642d9c4c9de" = true
 
 # reject prefix notation
-0035bc63-ac43-4bb5-ad6d-e8651b7d954e = true
+"0035bc63-ac43-4bb5-ad6d-e8651b7d954e" = true

--- a/exercises/wordy/.meta/tests.toml
+++ b/exercises/wordy/.meta/tests.toml
@@ -1,70 +1,70 @@
 [canonical-tests]
 
 # just a number
-"88bf4b28-0de3-4883-93c7-db1b14aa806e" = true
+88bf4b28-0de3-4883-93c7-db1b14aa806e = true
 
 # addition
-"bb8c655c-cf42-4dfc-90e0-152fcfd8d4e0" = true
+bb8c655c-cf42-4dfc-90e0-152fcfd8d4e0 = true
 
 # more addition
-"79e49e06-c5ae-40aa-a352-7a3a01f70015" = true
+79e49e06-c5ae-40aa-a352-7a3a01f70015 = true
 
 # addition with negative numbers
-"b345dbe0-f733-44e1-863c-5ae3568f3803" = true
+b345dbe0-f733-44e1-863c-5ae3568f3803 = true
 
 # large addition
-"cd070f39-c4cc-45c4-97fb-1be5e5846f87" = true
+cd070f39-c4cc-45c4-97fb-1be5e5846f87 = true
 
 # subtraction
-"0d86474a-cd93-4649-a4fa-f6109a011191" = true
+0d86474a-cd93-4649-a4fa-f6109a011191 = true
 
 # multiplication
-"30bc8395-5500-4712-a0cf-1d788a529be5" = true
+30bc8395-5500-4712-a0cf-1d788a529be5 = true
 
 # division
-"34c36b08-8605-4217-bb57-9a01472c427f" = true
+34c36b08-8605-4217-bb57-9a01472c427f = true
 
 # multiple additions
-"da6d2ce4-fb94-4d26-8f5f-b078adad0596" = true
+da6d2ce4-fb94-4d26-8f5f-b078adad0596 = true
 
 # addition and subtraction
-"7fd74c50-9911-4597-be09-8de7f2fea2bb" = true
+7fd74c50-9911-4597-be09-8de7f2fea2bb = true
 
 # multiple subtraction
-"b120ffd5-bad6-4e22-81c8-5512e8faf905" = true
+b120ffd5-bad6-4e22-81c8-5512e8faf905 = true
 
 # subtraction then addition
-"4f4a5749-ef0c-4f60-841f-abcfaf05d2ae" = true
+4f4a5749-ef0c-4f60-841f-abcfaf05d2ae = true
 
 # multiple multiplication
-"312d908c-f68f-42c9-aa75-961623cc033f" = true
+312d908c-f68f-42c9-aa75-961623cc033f = false
 
 # addition and multiplication
-"38e33587-8940-4cc1-bc28-bfd7e3966276" = true
+38e33587-8940-4cc1-bc28-bfd7e3966276 = true
 
 # multiple division
-"3c854f97-9311-46e8-b574-92b60d17d394" = true
+3c854f97-9311-46e8-b574-92b60d17d394 = false
 
 # unknown operation
-"3ad3e433-8af7-41ec-aa9b-97b42ab49357" = true
+3ad3e433-8af7-41ec-aa9b-97b42ab49357 = true
 
 # Non math question
-"8a7e85a8-9e7b-4d46-868f-6d759f4648f8" = true
+8a7e85a8-9e7b-4d46-868f-6d759f4648f8 = true
 
 # reject problem missing an operand
-"42d78b5f-dbd7-4cdb-8b30-00f794bb24cf" = true
+42d78b5f-dbd7-4cdb-8b30-00f794bb24cf = true
 
 # reject problem with no operands or operators
-"c2c3cbfc-1a72-42f2-b597-246e617e66f5" = true
+c2c3cbfc-1a72-42f2-b597-246e617e66f5 = true
 
 # reject two operations in a row
-"4b3df66d-6ed5-4c95-a0a1-d38891fbdab6" = true
+4b3df66d-6ed5-4c95-a0a1-d38891fbdab6 = true
 
 # reject two numbers in a row
-"6abd7a50-75b4-4665-aa33-2030fd08bab1" = true
+6abd7a50-75b4-4665-aa33-2030fd08bab1 = true
 
 # reject postfix notation
-"10a56c22-e0aa-405f-b1d2-c642d9c4c9de" = true
+10a56c22-e0aa-405f-b1d2-c642d9c4c9de = true
 
 # reject prefix notation
-"0035bc63-ac43-4bb5-ad6d-e8651b7d954e" = true
+0035bc63-ac43-4bb5-ad6d-e8651b7d954e = true


### PR DESCRIPTION
We're in the process of re-opening the [Problem Specifications repo](https://github.com/exercism/problem-specifications), as discussed in [this issue](https://github.com/exercism/problem-specifications/issues/1674).
This PR adds `.meta/tests.toml` files for all exercises for which canonical data is defined in the Problem Specifications repo.
We'll now discuss _why_ we're making this change.
## Keeping track of implemented tests
While most of the changes to the Problem Specifications repo are specific to that repo, there is one track-specific change:
> If a track implements an exercise for which test data exists, the exercise _must_ contain a `.meta/tests.toml` file.
The goal of the `tests.toml` file is to keep track of which tests are implemented by the exercise.
Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
A `tests.toml` file for a track's `two-fer` exercise looks like this:
```toml
[canonical-tests]
# no name given
"19709124-b82e-4e86-a722-9e5c5ebf3952" = true
# a name given
"3451eebd-123f-4256-b667-7b109affce32" = true
# another name given
"653611c6-be9f-4935-ab42-978e25fe9a10" = false
```
In this case, the track has chosen to implement two of the three available tests.
If a track uses a _test generator_ to generate an exercise's test suite, it _must_ use the contents of the `tests.toml` file to determine which tests to include in the generated test suite.
## Tooling
To make it easy to keep the `tests.toml` up to date, tracks can use the [`canonical_data_syncer` application](https://github.com/exercism/canonical-data-syncer).
This application is a small, standalone binary that will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data.
It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
To use the canonical data syncer tool, tracks should copying the [`fetch-canonical_data_syncer`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer) and/or [`fetch-canonical_data_syncer.ps1`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer.ps1) scripts into their repository.
Then, running either of these scripts will download the latest version of the tool to the track's `bin` directory.
The tool can be run using `./bin/canonical_data_syncer` or `.\bin\canonical_data_syncer.exe`, depending on your operating system.
## Changes
In this PR, we're adding `meta/tests.toml` files for all the exercises for which canonical data is defined.
We've initially marked all tests as _included_, which means that we'll assume that your track has implemented those tests.
If there isn't anything obviously wrong with the PR, I would suggest to merge this PR first, and then later on update the `meta/tests.toml` files according to your track's actual implementation.
