### PR TITLE
Do not intentionally exclude any exercises from the Rust test suite

### DIFF
--- a/exercises/all-your-base/.meta/tests.toml
+++ b/exercises/all-your-base/.meta/tests.toml
@@ -22,7 +22,8 @@
 "d3901c80-8190-41b9-bd86-38d988efa956" = true
 
 # 15-bit integer
-"5d42f85e-21ad-41bd-b9be-a3e8e4258bbf" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5d42f85e-21ad-41bd-b9be-a3e8e4258bbf" = false
 
 # empty list
 "d68788f7-66dd-43f8-a543-f15b6d233f83" = true
@@ -43,10 +44,12 @@
 "e21a693a-7a69-450b-b393-27415c26a016" = true
 
 # input base is negative
-"54a23be5-d99e-41cc-88e0-a650ffe5fcc2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "54a23be5-d99e-41cc-88e0-a650ffe5fcc2" = false
 
 # negative digit
-"9eccf60c-dcc9-407b-95d8-c37b8be56bb6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9eccf60c-dcc9-407b-95d8-c37b8be56bb6" = false
 
 # invalid positive digit
 "232fa4a5-e761-4939-ba0c-ed046cd0676a" = true
@@ -58,7 +61,9 @@
 "73dac367-da5c-4a37-95fe-c87fad0a4047" = true
 
 # output base is negative
-"13f81f42-ff53-4e24-89d9-37603a48ebd9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "13f81f42-ff53-4e24-89d9-37603a48ebd9" = false
 
 # both bases are negative
-"0e6c895d-8a5d-4868-a345-309d094cfe8d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0e6c895d-8a5d-4868-a345-309d094cfe8d" = false

--- a/exercises/allergies/.meta/tests.toml
+++ b/exercises/allergies/.meta/tests.toml
@@ -1,148 +1,189 @@
 [canonical-tests]
 
 # not allergic to anything
-"17fc7296-2440-4ac4-ad7b-d07c321bc5a0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "17fc7296-2440-4ac4-ad7b-d07c321bc5a0" = false
 
 # allergic only to eggs
-"07ced27b-1da5-4c2e-8ae2-cb2791437546" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "07ced27b-1da5-4c2e-8ae2-cb2791437546" = false
 
 # allergic to eggs and something else
-"5035b954-b6fa-4b9b-a487-dae69d8c5f96" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5035b954-b6fa-4b9b-a487-dae69d8c5f96" = false
 
 # allergic to something, but not eggs
-"64a6a83a-5723-4b5b-a896-663307403310" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "64a6a83a-5723-4b5b-a896-663307403310" = false
 
 # allergic to everything
 "90c8f484-456b-41c4-82ba-2d08d93231c6" = true
 
 # not allergic to anything
-"d266a59a-fccc-413b-ac53-d57cb1f0db9d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d266a59a-fccc-413b-ac53-d57cb1f0db9d" = false
 
 # allergic only to peanuts
-"ea210a98-860d-46b2-a5bf-50d8995b3f2a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ea210a98-860d-46b2-a5bf-50d8995b3f2a" = false
 
 # allergic to peanuts and something else
-"eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b" = false
 
 # allergic to something, but not peanuts
-"9152058c-ce39-4b16-9b1d-283ec6d25085" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9152058c-ce39-4b16-9b1d-283ec6d25085" = false
 
 # allergic to everything
 "d2d71fd8-63d5-40f9-a627-fbdaf88caeab" = true
 
 # not allergic to anything
-"b948b0a1-cbf7-4b28-a244-73ff56687c80" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b948b0a1-cbf7-4b28-a244-73ff56687c80" = false
 
 # allergic only to shellfish
-"9ce9a6f3-53e9-4923-85e0-73019047c567" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9ce9a6f3-53e9-4923-85e0-73019047c567" = false
 
 # allergic to shellfish and something else
-"b272fca5-57ba-4b00-bd0c-43a737ab2131" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b272fca5-57ba-4b00-bd0c-43a737ab2131" = false
 
 # allergic to something, but not shellfish
-"21ef8e17-c227-494e-8e78-470a1c59c3d8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "21ef8e17-c227-494e-8e78-470a1c59c3d8" = false
 
 # allergic to everything
 "cc789c19-2b5e-4c67-b146-625dc8cfa34e" = true
 
 # not allergic to anything
-"651bde0a-2a74-46c4-ab55-02a0906ca2f5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "651bde0a-2a74-46c4-ab55-02a0906ca2f5" = false
 
 # allergic only to strawberries
-"b649a750-9703-4f5f-b7f7-91da2c160ece" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b649a750-9703-4f5f-b7f7-91da2c160ece" = false
 
 # allergic to strawberries and something else
-"50f5f8f3-3bac-47e6-8dba-2d94470a4bc6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "50f5f8f3-3bac-47e6-8dba-2d94470a4bc6" = false
 
 # allergic to something, but not strawberries
-"23dd6952-88c9-48d7-a7d5-5d0343deb18d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "23dd6952-88c9-48d7-a7d5-5d0343deb18d" = false
 
 # allergic to everything
 "74afaae2-13b6-43a2-837a-286cd42e7d7e" = true
 
 # not allergic to anything
-"c49a91ef-6252-415e-907e-a9d26ef61723" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c49a91ef-6252-415e-907e-a9d26ef61723" = false
 
 # allergic only to tomatoes
-"b69c5131-b7d0-41ad-a32c-e1b2cc632df8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b69c5131-b7d0-41ad-a32c-e1b2cc632df8" = false
 
 # allergic to tomatoes and something else
-"1ca50eb1-f042-4ccf-9050-341521b929ec" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1ca50eb1-f042-4ccf-9050-341521b929ec" = false
 
 # allergic to something, but not tomatoes
-"e9846baa-456b-4eff-8025-034b9f77bd8e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e9846baa-456b-4eff-8025-034b9f77bd8e" = false
 
 # allergic to everything
 "b2414f01-f3ad-4965-8391-e65f54dad35f" = true
 
 # not allergic to anything
-"978467ab-bda4-49f7-b004-1d011ead947c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "978467ab-bda4-49f7-b004-1d011ead947c" = false
 
 # allergic only to chocolate
-"59cf4e49-06ea-4139-a2c1-d7aad28f8cbc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "59cf4e49-06ea-4139-a2c1-d7aad28f8cbc" = false
 
 # allergic to chocolate and something else
-"b0a7c07b-2db7-4f73-a180-565e07040ef1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b0a7c07b-2db7-4f73-a180-565e07040ef1" = false
 
 # allergic to something, but not chocolate
-"f5506893-f1ae-482a-b516-7532ba5ca9d2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f5506893-f1ae-482a-b516-7532ba5ca9d2" = false
 
 # allergic to everything
 "02debb3d-d7e2-4376-a26b-3c974b6595c6" = true
 
 # not allergic to anything
-"17f4a42b-c91e-41b8-8a76-4797886c2d96" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "17f4a42b-c91e-41b8-8a76-4797886c2d96" = false
 
 # allergic only to pollen
-"7696eba7-1837-4488-882a-14b7b4e3e399" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7696eba7-1837-4488-882a-14b7b4e3e399" = false
 
 # allergic to pollen and something else
-"9a49aec5-fa1f-405d-889e-4dfc420db2b6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9a49aec5-fa1f-405d-889e-4dfc420db2b6" = false
 
 # allergic to something, but not pollen
-"3cb8e79f-d108-4712-b620-aa146b1954a9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3cb8e79f-d108-4712-b620-aa146b1954a9" = false
 
 # allergic to everything
 "1dc3fe57-7c68-4043-9d51-5457128744b2" = true
 
 # not allergic to anything
-"d3f523d6-3d50-419b-a222-d4dfd62ce314" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d3f523d6-3d50-419b-a222-d4dfd62ce314" = false
 
 # allergic only to cats
-"eba541c3-c886-42d3-baef-c048cb7fcd8f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "eba541c3-c886-42d3-baef-c048cb7fcd8f" = false
 
 # allergic to cats and something else
-"ba718376-26e0-40b7-bbbe-060287637ea5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ba718376-26e0-40b7-bbbe-060287637ea5" = false
 
 # allergic to something, but not cats
-"3c6dbf4a-5277-436f-8b88-15a206f2d6c4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3c6dbf4a-5277-436f-8b88-15a206f2d6c4" = false
 
 # allergic to everything
 "1faabb05-2b98-4995-9046-d83e4a48a7c1" = true
 
 # no allergies
-"f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f" = false
 
 # just eggs
-"9e1a4364-09a6-4d94-990f-541a94a4c1e8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9e1a4364-09a6-4d94-990f-541a94a4c1e8" = false
 
 # just peanuts
-"8851c973-805e-4283-9e01-d0c0da0e4695" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8851c973-805e-4283-9e01-d0c0da0e4695" = false
 
 # just strawberries
-"2c8943cb-005e-435f-ae11-3e8fb558ea98" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2c8943cb-005e-435f-ae11-3e8fb558ea98" = false
 
 # eggs and peanuts
-"6fa95d26-044c-48a9-8a7b-9ee46ec32c5c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6fa95d26-044c-48a9-8a7b-9ee46ec32c5c" = false
 
 # more than eggs but not peanuts
-"19890e22-f63f-4c5c-a9fb-fb6eacddfe8e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "19890e22-f63f-4c5c-a9fb-fb6eacddfe8e" = false
 
 # lots of stuff
-"4b68f470-067c-44e4-889f-c9fe28917d2f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4b68f470-067c-44e4-889f-c9fe28917d2f" = false
 
 # everything
-"0881b7c5-9efa-4530-91bd-68370d054bc7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0881b7c5-9efa-4530-91bd-68370d054bc7" = false
 
 # no allergen score parts
-"12ce86de-b347-42a0-ab7c-2e0570f0c65b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "12ce86de-b347-42a0-ab7c-2e0570f0c65b" = false

--- a/exercises/alphametics/.meta/tests.toml
+++ b/exercises/alphametics/.meta/tests.toml
@@ -1,31 +1,40 @@
 [canonical-tests]
 
 # puzzle with three letters
-"e0c08b07-9028-4d5f-91e1-d178fead8e1a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e0c08b07-9028-4d5f-91e1-d178fead8e1a" = false
 
 # solution must have unique value for each letter
-"a504ee41-cb92-4ec2-9f11-c37e95ab3f25" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a504ee41-cb92-4ec2-9f11-c37e95ab3f25" = false
 
 # leading zero solution is invalid
-"4e3b81d2-be7b-4c5c-9a80-cd72bc6d465a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4e3b81d2-be7b-4c5c-9a80-cd72bc6d465a" = false
 
 # puzzle with two digits final carry
 "8a3e3168-d1ee-4df7-94c7-b9c54845ac3a" = true
 
 # puzzle with four letters
-"a9630645-15bd-48b6-a61e-d85c4021cc09" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a9630645-15bd-48b6-a61e-d85c4021cc09" = false
 
 # puzzle with six letters
-"3d905a86-5a52-4e4e-bf80-8951535791bd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3d905a86-5a52-4e4e-bf80-8951535791bd" = false
 
 # puzzle with seven letters
-"4febca56-e7b7-4789-97b9-530d09ba95f0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4febca56-e7b7-4789-97b9-530d09ba95f0" = false
 
 # puzzle with eight letters
-"12125a75-7284-4f9a-a5fa-191471e0d44f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "12125a75-7284-4f9a-a5fa-191471e0d44f" = false
 
 # puzzle with ten letters
-"fb05955f-38dc-477a-a0b6-5ef78969fffa" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "fb05955f-38dc-477a-a0b6-5ef78969fffa" = false
 
 # puzzle with ten letters and 199 addends
-"9a101e81-9216-472b-b458-b513a7adacf7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9a101e81-9216-472b-b458-b513a7adacf7" = false

--- a/exercises/anagram/.meta/tests.toml
+++ b/exercises/anagram/.meta/tests.toml
@@ -1,43 +1,57 @@
 [canonical-tests]
 
 # no matches
-"dd40c4d2-3c8b-44e5-992a-f42b393ec373" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "dd40c4d2-3c8b-44e5-992a-f42b393ec373" = false
 
 # detects two anagrams
-"b3cca662-f50a-489e-ae10-ab8290a09bdc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b3cca662-f50a-489e-ae10-ab8290a09bdc" = false
 
 # does not detect anagram subsets
-"a27558ee-9ba0-4552-96b1-ecf665b06556" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a27558ee-9ba0-4552-96b1-ecf665b06556" = false
 
 # detects anagram
-"64cd4584-fc15-4781-b633-3d814c4941a4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "64cd4584-fc15-4781-b633-3d814c4941a4" = false
 
 # detects three anagrams
-"99c91beb-838f-4ccd-b123-935139917283" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "99c91beb-838f-4ccd-b123-935139917283" = false
 
 # detects multiple anagrams with different case
-"78487770-e258-4e1f-a646-8ece10950d90" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "78487770-e258-4e1f-a646-8ece10950d90" = false
 
 # does not detect non-anagrams with identical checksum
-"1d0ab8aa-362f-49b7-9902-3d0c668d557b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1d0ab8aa-362f-49b7-9902-3d0c668d557b" = false
 
 # detects anagrams case-insensitively
-"9e632c0b-c0b1-4804-8cc1-e295dea6d8a8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9e632c0b-c0b1-4804-8cc1-e295dea6d8a8" = false
 
 # detects anagrams using case-insensitive subject
-"b248e49f-0905-48d2-9c8d-bd02d8c3e392" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b248e49f-0905-48d2-9c8d-bd02d8c3e392" = false
 
 # detects anagrams using case-insensitive possible matches
-"f367325c-78ec-411c-be76-e79047f4bd54" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f367325c-78ec-411c-be76-e79047f4bd54" = false
 
 # does not detect an anagram if the original word is repeated
-"7cc195ad-e3c7-44ee-9fd2-d3c344806a2c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7cc195ad-e3c7-44ee-9fd2-d3c344806a2c" = false
 
 # anagrams must use all letters exactly once
-"9878a1c9-d6ea-4235-ae51-3ea2befd6842" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9878a1c9-d6ea-4235-ae51-3ea2befd6842" = false
 
 # words are not anagrams of themselves (case-insensitive)
-"85757361-4535-45fd-ac0e-3810d40debc1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "85757361-4535-45fd-ac0e-3810d40debc1" = false
 
 # words other than themselves can be anagrams
-"a0705568-628c-4b55-9798-82e4acde51ca" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a0705568-628c-4b55-9798-82e4acde51ca" = false

--- a/exercises/armstrong-numbers/.meta/tests.toml
+++ b/exercises/armstrong-numbers/.meta/tests.toml
@@ -1,28 +1,37 @@
 [canonical-tests]
 
 # Zero is an Armstrong number
-"c1ed103c-258d-45b2-be73-d8c6d9580c7b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c1ed103c-258d-45b2-be73-d8c6d9580c7b" = false
 
 # Single digit numbers are Armstrong numbers
-"579e8f03-9659-4b85-a1a2-d64350f6b17a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "579e8f03-9659-4b85-a1a2-d64350f6b17a" = false
 
 # There are no 2 digit Armstrong numbers
-"2d6db9dc-5bf8-4976-a90b-b2c2b9feba60" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2d6db9dc-5bf8-4976-a90b-b2c2b9feba60" = false
 
 # Three digit number that is an Armstrong number
-"509c087f-e327-4113-a7d2-26a4e9d18283" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "509c087f-e327-4113-a7d2-26a4e9d18283" = false
 
 # Three digit number that is not an Armstrong number
-"7154547d-c2ce-468d-b214-4cb953b870cf" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7154547d-c2ce-468d-b214-4cb953b870cf" = false
 
 # Four digit number that is an Armstrong number
-"6bac5b7b-42e9-4ecb-a8b0-4832229aa103" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6bac5b7b-42e9-4ecb-a8b0-4832229aa103" = false
 
 # Four digit number that is not an Armstrong number
-"eed4b331-af80-45b5-a80b-19c9ea444b2e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "eed4b331-af80-45b5-a80b-19c9ea444b2e" = false
 
 # Seven digit number that is an Armstrong number
-"f971ced7-8d68-4758-aea1-d4194900b864" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f971ced7-8d68-4758-aea1-d4194900b864" = false
 
 # Seven digit number that is not an Armstrong number
-"7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18" = false

--- a/exercises/atbash-cipher/.meta/tests.toml
+++ b/exercises/atbash-cipher/.meta/tests.toml
@@ -1,43 +1,57 @@
 [canonical-tests]
 
 # encode yes
-"2f47ebe1-eab9-4d6b-b3c6-627562a31c77" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2f47ebe1-eab9-4d6b-b3c6-627562a31c77" = false
 
 # encode no
-"b4ffe781-ea81-4b74-b268-cc58ba21c739" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b4ffe781-ea81-4b74-b268-cc58ba21c739" = false
 
 # encode OMG
-"10e48927-24ab-4c4d-9d3f-3067724ace00" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "10e48927-24ab-4c4d-9d3f-3067724ace00" = false
 
 # encode spaces
-"d59b8bc3-509a-4a9a-834c-6f501b98750b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d59b8bc3-509a-4a9a-834c-6f501b98750b" = false
 
 # encode mindblowingly
-"31d44b11-81b7-4a94-8b43-4af6a2449429" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "31d44b11-81b7-4a94-8b43-4af6a2449429" = false
 
 # encode numbers
-"d503361a-1433-48c0-aae0-d41b5baa33ff" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d503361a-1433-48c0-aae0-d41b5baa33ff" = false
 
 # encode deep thought
-"79c8a2d5-0772-42d4-b41b-531d0b5da926" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "79c8a2d5-0772-42d4-b41b-531d0b5da926" = false
 
 # encode all the letters
-"9ca13d23-d32a-4967-a1fd-6100b8742bab" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9ca13d23-d32a-4967-a1fd-6100b8742bab" = false
 
 # decode exercism
-"bb50e087-7fdf-48e7-9223-284fe7e69851" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bb50e087-7fdf-48e7-9223-284fe7e69851" = false
 
 # decode a sentence
-"ac021097-cd5d-4717-8907-b0814b9e292c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ac021097-cd5d-4717-8907-b0814b9e292c" = false
 
 # decode numbers
-"18729de3-de74-49b8-b68c-025eaf77f851" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "18729de3-de74-49b8-b68c-025eaf77f851" = false
 
 # decode all the letters
-"0f30325f-f53b-415d-ad3e-a7a4f63de034" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0f30325f-f53b-415d-ad3e-a7a4f63de034" = false
 
 # decode with too many spaces
-"39640287-30c6-4c8c-9bac-9d613d1a5674" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "39640287-30c6-4c8c-9bac-9d613d1a5674" = false
 
 # decode with no spaces
-"b34edf13-34c0-49b5-aa21-0768928000d5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b34edf13-34c0-49b5-aa21-0768928000d5" = false

--- a/exercises/beer-song/.meta/tests.toml
+++ b/exercises/beer-song/.meta/tests.toml
@@ -1,25 +1,33 @@
 [canonical-tests]
 
 # first generic verse
-"5a02fd08-d336-4607-8006-246fe6fa9fb0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5a02fd08-d336-4607-8006-246fe6fa9fb0" = false
 
 # last generic verse
-"77299ca6-545e-4217-a9cc-606b342e0187" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "77299ca6-545e-4217-a9cc-606b342e0187" = false
 
 # verse with 2 bottles
-"102cbca0-b197-40fd-b548-e99609b06428" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "102cbca0-b197-40fd-b548-e99609b06428" = false
 
 # verse with 1 bottle
-"b8ef9fce-960e-4d85-a0c9-980a04ec1972" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b8ef9fce-960e-4d85-a0c9-980a04ec1972" = false
 
 # verse with 0 bottles
-"c59d4076-f671-4ee3-baaa-d4966801f90d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c59d4076-f671-4ee3-baaa-d4966801f90d" = false
 
 # first two verses
-"7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e" = false
 
 # last three verses
-"949868e7-67e8-43d3-9bb4-69277fe020fb" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "949868e7-67e8-43d3-9bb4-69277fe020fb" = false
 
 # all verses
-"bc220626-126c-4e72-8df4-fddfc0c3e458" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bc220626-126c-4e72-8df4-fddfc0c3e458" = false

--- a/exercises/binary-search/.meta/tests.toml
+++ b/exercises/binary-search/.meta/tests.toml
@@ -22,13 +22,16 @@
 "da7db20a-354f-49f7-a6a1-650a54998aa6" = true
 
 # a value smaller than the array's smallest value is not found
-"95d869ff-3daf-4c79-b622-6e805c675f97" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "95d869ff-3daf-4c79-b622-6e805c675f97" = false
 
 # a value larger than the array's largest value is not found
-"8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba" = false
 
 # nothing is found in an empty array
-"f439a0fa-cf42-4262-8ad1-64bf41ce566a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f439a0fa-cf42-4262-8ad1-64bf41ce566a" = false
 
 # nothing is found when the left and right bounds cross
 "2c353967-b56d-40b8-acff-ce43115eed64" = true

--- a/exercises/bob/.meta/tests.toml
+++ b/exercises/bob/.meta/tests.toml
@@ -1,76 +1,99 @@
 [canonical-tests]
 
 # stating something
-"e162fead-606f-437a-a166-d051915cea8e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e162fead-606f-437a-a166-d051915cea8e" = false
 
 # shouting
 "73a966dc-8017-47d6-bb32-cf07d1a5fcd9" = true
 
 # shouting gibberish
-"d6c98afd-df35-4806-b55e-2c457c3ab748" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d6c98afd-df35-4806-b55e-2c457c3ab748" = false
 
 # asking a question
-"8a2e771d-d6f1-4e3f-b6c6-b41495556e37" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8a2e771d-d6f1-4e3f-b6c6-b41495556e37" = false
 
 # asking a numeric question
-"81080c62-4e4d-4066-b30a-48d8d76920d9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "81080c62-4e4d-4066-b30a-48d8d76920d9" = false
 
 # asking gibberish
-"2a02716d-685b-4e2e-a804-2adaf281c01e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2a02716d-685b-4e2e-a804-2adaf281c01e" = false
 
 # talking forcefully
-"c02f9179-ab16-4aa7-a8dc-940145c385f7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c02f9179-ab16-4aa7-a8dc-940145c385f7" = false
 
 # using acronyms in regular speech
-"153c0e25-9bb5-4ec5-966e-598463658bcd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "153c0e25-9bb5-4ec5-966e-598463658bcd" = false
 
 # forceful question
-"a5193c61-4a92-4f68-93e2-f554eb385ec6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a5193c61-4a92-4f68-93e2-f554eb385ec6" = false
 
 # shouting numbers
-"a20e0c54-2224-4dde-8b10-bd2cdd4f61bc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a20e0c54-2224-4dde-8b10-bd2cdd4f61bc" = false
 
 # no letters
-"f7bc4b92-bdff-421e-a238-ae97f230ccac" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f7bc4b92-bdff-421e-a238-ae97f230ccac" = false
 
 # question with no letters
-"bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2" = false
 
 # shouting with special characters
-"496143c8-1c31-4c01-8a08-88427af85c66" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "496143c8-1c31-4c01-8a08-88427af85c66" = false
 
 # shouting with no exclamation mark
-"e6793c1c-43bd-4b8d-bc11-499aea73925f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e6793c1c-43bd-4b8d-bc11-499aea73925f" = false
 
 # statement containing question mark
-"aa8097cc-c548-4951-8856-14a404dd236a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "aa8097cc-c548-4951-8856-14a404dd236a" = false
 
 # non-letters with question
-"9bfc677d-ea3a-45f2-be44-35bc8fa3753e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9bfc677d-ea3a-45f2-be44-35bc8fa3753e" = false
 
 # prattling on
-"8608c508-f7de-4b17-985b-811878b3cf45" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8608c508-f7de-4b17-985b-811878b3cf45" = false
 
 # silence
 "bc39f7c6-f543-41be-9a43-fd1c2f753fc0" = true
 
 # prolonged silence
-"d6c47565-372b-4b09-b1dd-c40552b8378b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d6c47565-372b-4b09-b1dd-c40552b8378b" = false
 
 # alternate silence
-"4428f28d-4100-4d85-a902-e5a78cb0ecd3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4428f28d-4100-4d85-a902-e5a78cb0ecd3" = false
 
 # multiple line question
-"66953780-165b-4e7e-8ce3-4bcb80b6385a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "66953780-165b-4e7e-8ce3-4bcb80b6385a" = false
 
 # starting with whitespace
-"5371ef75-d9ea-4103-bcfa-2da973ddec1b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5371ef75-d9ea-4103-bcfa-2da973ddec1b" = false
 
 # ending with whitespace
-"05b304d6-f83b-46e7-81e0-4cd3ca647900" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "05b304d6-f83b-46e7-81e0-4cd3ca647900" = false
 
 # other whitespace
-"72bd5ad3-9b2f-4931-a988-dce1f5771de2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "72bd5ad3-9b2f-4931-a988-dce1f5771de2" = false
 
 # non-question ending with whitespace
-"12983553-8601-46a8-92fa-fcaa3bc4a2a0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "12983553-8601-46a8-92fa-fcaa3bc4a2a0" = false

--- a/exercises/book-store/.meta/tests.toml
+++ b/exercises/book-store/.meta/tests.toml
@@ -1,46 +1,61 @@
 [canonical-tests]
 
 # Only a single book
-"17146bd5-2e80-4557-ab4c-05632b6b0d01" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "17146bd5-2e80-4557-ab4c-05632b6b0d01" = false
 
 # Two of the same book
-"cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce" = false
 
 # Empty basket
-"5a86eac0-45d2-46aa-bbf0-266b94393a1a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5a86eac0-45d2-46aa-bbf0-266b94393a1a" = false
 
 # Two different books
-"158bd19a-3db4-4468-ae85-e0638a688990" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "158bd19a-3db4-4468-ae85-e0638a688990" = false
 
 # Three different books
-"f3833f6b-9332-4a1f-ad98-6c3f8e30e163" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f3833f6b-9332-4a1f-ad98-6c3f8e30e163" = false
 
 # Four different books
-"1951a1db-2fb6-4cd1-a69a-f691b6dd30a2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1951a1db-2fb6-4cd1-a69a-f691b6dd30a2" = false
 
 # Five different books
-"d70f6682-3019-4c3f-aede-83c6a8c647a3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d70f6682-3019-4c3f-aede-83c6a8c647a3" = false
 
 # Two groups of four is cheaper than group of five plus group of three
-"78cacb57-911a-45f1-be52-2a5bd428c634" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "78cacb57-911a-45f1-be52-2a5bd428c634" = false
 
 # Two groups of four is cheaper than groups of five and three
-"f808b5a4-e01f-4c0d-881f-f7b90d9739da" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f808b5a4-e01f-4c0d-881f-f7b90d9739da" = false
 
 # Group of four plus group of two is cheaper than two groups of three
-"fe96401c-5268-4be2-9d9e-19b76478007c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "fe96401c-5268-4be2-9d9e-19b76478007c" = false
 
 # Two each of first 4 books and 1 copy each of rest
-"68ea9b78-10ad-420e-a766-836a501d3633" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "68ea9b78-10ad-420e-a766-836a501d3633" = false
 
 # Two copies of each book
-"c0a779d5-a40c-47ae-9828-a340e936b866" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c0a779d5-a40c-47ae-9828-a340e936b866" = false
 
 # Three copies of first book and 2 each of remaining
-"18fd86fe-08f1-4b68-969b-392b8af20513" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "18fd86fe-08f1-4b68-969b-392b8af20513" = false
 
 # Three each of first 2 books and 2 each of remaining books
-"0b19a24d-e4cf-4ec8-9db2-8899a41af0da" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0b19a24d-e4cf-4ec8-9db2-8899a41af0da" = false
 
 # Four groups of four are cheaper than two groups each of five and three
-"bb376344-4fb2-49ab-ab85-e38d8354a58d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bb376344-4fb2-49ab-ab85-e38d8354a58d" = false

--- a/exercises/bowling/.meta/tests.toml
+++ b/exercises/bowling/.meta/tests.toml
@@ -1,22 +1,27 @@
 [canonical-tests]
 
 # should be able to score a game with all zeros
-"656ae006-25c2-438c-a549-f338e7ec7441" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "656ae006-25c2-438c-a549-f338e7ec7441" = false
 
 # should be able to score a game with no strikes or spares
-"f85dcc56-cd6b-4875-81b3-e50921e3597b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f85dcc56-cd6b-4875-81b3-e50921e3597b" = false
 
 # a spare followed by zeros is worth ten points
-"d1f56305-3ac2-4fe0-8645-0b37e3073e20" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d1f56305-3ac2-4fe0-8645-0b37e3073e20" = false
 
 # points scored in the roll after a spare are counted twice
-"0b8c8bb7-764a-4287-801a-f9e9012f8be4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0b8c8bb7-764a-4287-801a-f9e9012f8be4" = false
 
 # consecutive spares each get a one roll bonus
 "4d54d502-1565-4691-84cd-f29a09c65bea" = true
 
 # a spare in the last frame gets a one roll bonus that is counted once
-"e5c9cf3d-abbe-4b74-ad48-34051b2b08c0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e5c9cf3d-abbe-4b74-ad48-34051b2b08c0" = false
 
 # a strike earns ten points in a frame with a single roll
 "75269642-2b34-4b72-95a4-9be28ab16902" = true
@@ -28,64 +33,83 @@
 "1635e82b-14ec-4cd1-bce4-4ea14bd13a49" = true
 
 # a strike in the last frame gets a two roll bonus that is counted once
-"e483e8b6-cb4b-4959-b310-e3982030d766" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e483e8b6-cb4b-4959-b310-e3982030d766" = false
 
 # rolling a spare with the two roll bonus does not get a bonus roll
-"9d5c87db-84bc-4e01-8e95-53350c8af1f8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9d5c87db-84bc-4e01-8e95-53350c8af1f8" = false
 
 # strikes with the two roll bonus do not get bonus rolls
-"576faac1-7cff-4029-ad72-c16bcada79b5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "576faac1-7cff-4029-ad72-c16bcada79b5" = false
 
 # a strike with the one roll bonus after a spare in the last frame does not get a bonus
 "72e24404-b6c6-46af-b188-875514c0377b" = true
 
 # all strikes is a perfect game
-"62ee4c72-8ee8-4250-b794-234f1fec17b1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "62ee4c72-8ee8-4250-b794-234f1fec17b1" = false
 
 # rolls cannot score negative points
-"1245216b-19c6-422c-b34b-6e4012d7459f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1245216b-19c6-422c-b34b-6e4012d7459f" = false
 
 # a roll cannot score more than 10 points
-"5fcbd206-782c-4faa-8f3a-be5c538ba841" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5fcbd206-782c-4faa-8f3a-be5c538ba841" = false
 
 # two rolls in a frame cannot score more than 10 points
-"fb023c31-d842-422d-ad7e-79ce1db23c21" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "fb023c31-d842-422d-ad7e-79ce1db23c21" = false
 
 # bonus roll after a strike in the last frame cannot score more than 10 points
-"6082d689-d677-4214-80d7-99940189381b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6082d689-d677-4214-80d7-99940189381b" = false
 
 # two bonus rolls after a strike in the last frame cannot score more than 10 points
-"e9565fe6-510a-4675-ba6b-733a56767a45" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e9565fe6-510a-4675-ba6b-733a56767a45" = false
 
 # two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike
-"2f6acf99-448e-4282-8103-0b9c7df99c3d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2f6acf99-448e-4282-8103-0b9c7df99c3d" = false
 
 # the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike
-"6380495a-8bc4-4cdb-a59f-5f0212dbed01" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6380495a-8bc4-4cdb-a59f-5f0212dbed01" = false
 
 # second bonus roll after a strike in the last frame cannot score more than 10 points
-"2b2976ea-446c-47a3-9817-42777f09fe7e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2b2976ea-446c-47a3-9817-42777f09fe7e" = false
 
 # an unstarted game cannot be scored
-"29220245-ac8d-463d-bc19-98a94cfada8a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "29220245-ac8d-463d-bc19-98a94cfada8a" = false
 
 # an incomplete game cannot be scored
-"4473dc5d-1f86-486f-bf79-426a52ddc955" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4473dc5d-1f86-486f-bf79-426a52ddc955" = false
 
 # cannot roll if game already has ten frames
-"2ccb8980-1b37-4988-b7d1-e5701c317df3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2ccb8980-1b37-4988-b7d1-e5701c317df3" = false
 
 # bonus rolls for a strike in the last frame must be rolled before score can be calculated
-"4864f09b-9df3-4b65-9924-c595ed236f1b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4864f09b-9df3-4b65-9924-c595ed236f1b" = false
 
 # both bonus rolls for a strike in the last frame must be rolled before score can be calculated
-"537f4e37-4b51-4d1c-97e2-986eb37b2ac1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "537f4e37-4b51-4d1c-97e2-986eb37b2ac1" = false
 
 # bonus roll for a spare in the last frame must be rolled before score can be calculated
-"8134e8c1-4201-4197-bf9f-1431afcde4b9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8134e8c1-4201-4197-bf9f-1431afcde4b9" = false
 
 # cannot roll after bonus roll for spare
 "9d4a9a55-134a-4bad-bae8-3babf84bd570" = true
 
 # cannot roll after bonus rolls for strike
-"d3e02652-a799-4ae3-b53b-68582cc604be" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d3e02652-a799-4ae3-b53b-68582cc604be" = false

--- a/exercises/circular-buffer/.meta/tests.toml
+++ b/exercises/circular-buffer/.meta/tests.toml
@@ -1,10 +1,12 @@
 [canonical-tests]
 
 # reading empty buffer should fail
-"28268ed4-4ff3-45f3-820e-895b44d53dfa" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "28268ed4-4ff3-45f3-820e-895b44d53dfa" = false
 
 # can read an item just written
-"2e6db04a-58a1-425d-ade8-ac30b5f318f3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2e6db04a-58a1-425d-ade8-ac30b5f318f3" = false
 
 # each item may only be read once
 "90741fe8-a448-45ce-be2b-de009a24c144" = true
@@ -16,7 +18,8 @@
 "2af22046-3e44-4235-bfe6-05ba60439d38" = true
 
 # a read frees up capacity for another write
-"547d192c-bbf0-4369-b8fa-fc37e71f2393" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "547d192c-bbf0-4369-b8fa-fc37e71f2393" = false
 
 # read position is maintained even across multiple writes
 "04a56659-3a81-4113-816b-6ecb659b4471" = true
@@ -31,7 +34,8 @@
 "e1ac5170-a026-4725-bfbe-0cf332eddecd" = true
 
 # overwrite acts like write on non-full buffer
-"9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b" = false
 
 # overwrite replaces the oldest item on full buffer
 "880f916b-5039-475c-bd5c-83463c36a147" = true
@@ -40,4 +44,5 @@
 "bfecab5b-aca1-4fab-a2b0-cd4af2b053c3" = true
 
 # initial clear does not affect wrapping around
-"9cebe63a-c405-437b-8b62-e3fdc1ecec5a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9cebe63a-c405-437b-8b62-e3fdc1ecec5a" = false

--- a/exercises/clock/.meta/tests.toml
+++ b/exercises/clock/.meta/tests.toml
@@ -1,157 +1,209 @@
 [canonical-tests]
 
 # on the hour
-"a577bacc-106b-496e-9792-b3083ea8705e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a577bacc-106b-496e-9792-b3083ea8705e" = false
 
 # past the hour
-"b5d0c360-3b88-489b-8e84-68a1c7a4fa23" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b5d0c360-3b88-489b-8e84-68a1c7a4fa23" = false
 
 # midnight is zero hours
-"473223f4-65f3-46ff-a9f7-7663c7e59440" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "473223f4-65f3-46ff-a9f7-7663c7e59440" = false
 
 # hour rolls over
-"ca95d24a-5924-447d-9a96-b91c8334725c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ca95d24a-5924-447d-9a96-b91c8334725c" = false
 
 # hour rolls over continuously
-"f3826de0-0925-4d69-8ac8-89aea7e52b78" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f3826de0-0925-4d69-8ac8-89aea7e52b78" = false
 
 # sixty minutes is next hour
-"a02f7edf-dfd4-4b11-b21a-86de3cc6a95c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a02f7edf-dfd4-4b11-b21a-86de3cc6a95c" = false
 
 # minutes roll over
-"8f520df6-b816-444d-b90f-8a477789beb5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8f520df6-b816-444d-b90f-8a477789beb5" = false
 
 # minutes roll over continuously
-"c75c091b-47ac-4655-8d40-643767fc4eed" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c75c091b-47ac-4655-8d40-643767fc4eed" = false
 
 # hour and minutes roll over
-"06343ecb-cf39-419d-a3f5-dcbae0cc4c57" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "06343ecb-cf39-419d-a3f5-dcbae0cc4c57" = false
 
 # hour and minutes roll over continuously
-"be60810e-f5d9-4b58-9351-a9d1e90e660c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "be60810e-f5d9-4b58-9351-a9d1e90e660c" = false
 
 # hour and minutes roll over to exactly midnight
-"1689107b-0b5c-4bea-aad3-65ec9859368a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1689107b-0b5c-4bea-aad3-65ec9859368a" = false
 
 # negative hour
-"d3088ee8-91b7-4446-9e9d-5e2ad6219d91" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d3088ee8-91b7-4446-9e9d-5e2ad6219d91" = false
 
 # negative hour rolls over
-"77ef6921-f120-4d29-bade-80d54aa43b54" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "77ef6921-f120-4d29-bade-80d54aa43b54" = false
 
 # negative hour rolls over continuously
-"359294b5-972f-4546-bb9a-a85559065234" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "359294b5-972f-4546-bb9a-a85559065234" = false
 
 # negative minutes
-"509db8b7-ac19-47cc-bd3a-a9d2f30b03c0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "509db8b7-ac19-47cc-bd3a-a9d2f30b03c0" = false
 
 # negative minutes roll over
-"5d6bb225-130f-4084-84fd-9e0df8996f2a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5d6bb225-130f-4084-84fd-9e0df8996f2a" = false
 
 # negative minutes roll over continuously
-"d483ceef-b520-4f0c-b94a-8d2d58cf0484" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d483ceef-b520-4f0c-b94a-8d2d58cf0484" = false
 
 # negative sixty minutes is previous hour
-"1cd19447-19c6-44bf-9d04-9f8305ccb9ea" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1cd19447-19c6-44bf-9d04-9f8305ccb9ea" = false
 
 # negative hour and minutes both roll over
-"9d3053aa-4f47-4afc-bd45-d67a72cef4dc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9d3053aa-4f47-4afc-bd45-d67a72cef4dc" = false
 
 # negative hour and minutes both roll over continuously
-"51d41fcf-491e-4ca0-9cae-2aa4f0163ad4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "51d41fcf-491e-4ca0-9cae-2aa4f0163ad4" = false
 
 # add minutes
-"d098e723-ad29-4ef9-997a-2693c4c9d89a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d098e723-ad29-4ef9-997a-2693c4c9d89a" = false
 
 # add no minutes
-"b6ec8f38-e53e-4b22-92a7-60dab1f485f4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b6ec8f38-e53e-4b22-92a7-60dab1f485f4" = false
 
 # add to next hour
-"efd349dd-0785-453e-9ff8-d7452a8e7269" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "efd349dd-0785-453e-9ff8-d7452a8e7269" = false
 
 # add more than one hour
-"749890f7-aba9-4702-acce-87becf4ef9fe" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "749890f7-aba9-4702-acce-87becf4ef9fe" = false
 
 # add more than two hours with carry
-"da63e4c1-1584-46e3-8d18-c9dc802c1713" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "da63e4c1-1584-46e3-8d18-c9dc802c1713" = false
 
 # add across midnight
-"be167a32-3d33-4cec-a8bc-accd47ddbb71" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "be167a32-3d33-4cec-a8bc-accd47ddbb71" = false
 
 # add more than one day (1500 min = 25 hrs)
-"6672541e-cdae-46e4-8be7-a820cc3be2a8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6672541e-cdae-46e4-8be7-a820cc3be2a8" = false
 
 # add more than two days
-"1918050d-c79b-4cb7-b707-b607e2745c7e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1918050d-c79b-4cb7-b707-b607e2745c7e" = false
 
 # subtract minutes
-"37336cac-5ede-43a5-9026-d426cbe40354" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "37336cac-5ede-43a5-9026-d426cbe40354" = false
 
 # subtract to previous hour
-"0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b" = false
 
 # subtract more than an hour
-"9b4e809c-612f-4b15-aae0-1df0acb801b9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9b4e809c-612f-4b15-aae0-1df0acb801b9" = false
 
 # subtract across midnight
-"8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6" = false
 
 # subtract more than two hours
-"07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9" = false
 
 # subtract more than two hours with borrow
-"90ac8a1b-761c-4342-9c9c-cdc3ed5db097" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "90ac8a1b-761c-4342-9c9c-cdc3ed5db097" = false
 
 # subtract more than one day (1500 min = 25 hrs)
-"2149f985-7136-44ad-9b29-ec023a97a2b7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2149f985-7136-44ad-9b29-ec023a97a2b7" = false
 
 # subtract more than two days
-"ba11dbf0-ac27-4acb-ada9-3b853ec08c97" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ba11dbf0-ac27-4acb-ada9-3b853ec08c97" = false
 
 # clocks with same time
-"f2fdad51-499f-4c9b-a791-b28c9282e311" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f2fdad51-499f-4c9b-a791-b28c9282e311" = false
 
 # clocks a minute apart
-"5d409d4b-f862-4960-901e-ec430160b768" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5d409d4b-f862-4960-901e-ec430160b768" = false
 
 # clocks an hour apart
-"a6045fcf-2b52-4a47-8bb2-ef10a064cba5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a6045fcf-2b52-4a47-8bb2-ef10a064cba5" = false
 
 # clocks with hour overflow
-"66b12758-0be5-448b-a13c-6a44bce83527" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "66b12758-0be5-448b-a13c-6a44bce83527" = false
 
 # clocks with hour overflow by several days
-"2b19960c-212e-4a71-9aac-c581592f8111" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2b19960c-212e-4a71-9aac-c581592f8111" = false
 
 # clocks with negative hour
-"6f8c6541-afac-4a92-b0c2-b10d4e50269f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6f8c6541-afac-4a92-b0c2-b10d4e50269f" = false
 
 # clocks with negative hour that wraps
-"bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d" = false
 
 # clocks with negative hour that wraps multiple times
-"56c0326d-565b-4d19-a26f-63b3205778b7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "56c0326d-565b-4d19-a26f-63b3205778b7" = false
 
 # clocks with minute overflow
-"c90b9de8-ddff-4ffe-9858-da44a40fdbc2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c90b9de8-ddff-4ffe-9858-da44a40fdbc2" = false
 
 # clocks with minute overflow by several days
-"533a3dc5-59a7-491b-b728-a7a34fe325de" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "533a3dc5-59a7-491b-b728-a7a34fe325de" = false
 
 # clocks with negative minute
-"fff49e15-f7b7-4692-a204-0f6052d62636" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "fff49e15-f7b7-4692-a204-0f6052d62636" = false
 
 # clocks with negative minute that wraps
-"605c65bb-21bd-43eb-8f04-878edf508366" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "605c65bb-21bd-43eb-8f04-878edf508366" = false
 
 # clocks with negative minute that wraps multiple times
-"b87e64ed-212a-4335-91fd-56da8421d077" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b87e64ed-212a-4335-91fd-56da8421d077" = false
 
 # clocks with negative hours and minutes
-"822fbf26-1f3b-4b13-b9bf-c914816b53dd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "822fbf26-1f3b-4b13-b9bf-c914816b53dd" = false
 
 # clocks with negative hours and minutes that wrap
-"e787bccd-cf58-4a1d-841c-ff80eaaccfaa" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e787bccd-cf58-4a1d-841c-ff80eaaccfaa" = false
 
 # full clock and zeroed clock
-"96969ca8-875a-48a1-86ae-257a528c44f5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "96969ca8-875a-48a1-86ae-257a528c44f5" = false

--- a/exercises/collatz-conjecture/.meta/tests.toml
+++ b/exercises/collatz-conjecture/.meta/tests.toml
@@ -1,19 +1,25 @@
 [canonical-tests]
 
 # zero steps for one
-"540a3d51-e7a6-47a5-92a3-4ad1838f0bfd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "540a3d51-e7a6-47a5-92a3-4ad1838f0bfd" = false
 
 # divide if even
-"3d76a0a6-ea84-444a-821a-f7857c2c1859" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3d76a0a6-ea84-444a-821a-f7857c2c1859" = false
 
 # even and odd steps
-"754dea81-123c-429e-b8bc-db20b05a87b9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "754dea81-123c-429e-b8bc-db20b05a87b9" = false
 
 # large number of even and odd steps
-"ecfd0210-6f85-44f6-8280-f65534892ff6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ecfd0210-6f85-44f6-8280-f65534892ff6" = false
 
 # zero is an error
-"7d4750e6-def9-4b86-aec7-9f7eb44f95a3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7d4750e6-def9-4b86-aec7-9f7eb44f95a3" = false
 
 # negative value is an error
-"c6c795bf-a288-45e9-86a1-841359ad426d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c6c795bf-a288-45e9-86a1-841359ad426d" = false

--- a/exercises/crypto-square/.meta/tests.toml
+++ b/exercises/crypto-square/.meta/tests.toml
@@ -1,22 +1,29 @@
 [canonical-tests]
 
 # empty plaintext results in an empty ciphertext
-"407c3837-9aa7-4111-ab63-ec54b58e8e9f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "407c3837-9aa7-4111-ab63-ec54b58e8e9f" = false
 
 # Lowercase
-"64131d65-6fd9-4f58-bdd8-4a2370fb481d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "64131d65-6fd9-4f58-bdd8-4a2370fb481d" = false
 
 # Remove spaces
-"63a4b0ed-1e3c-41ea-a999-f6f26ba447d6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "63a4b0ed-1e3c-41ea-a999-f6f26ba447d6" = false
 
 # Remove punctuation
-"1b5348a1-7893-44c1-8197-42d48d18756c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1b5348a1-7893-44c1-8197-42d48d18756c" = false
 
 # 9 character plaintext results in 3 chunks of 3 characters
-"8574a1d3-4a08-4cec-a7c7-de93a164f41a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8574a1d3-4a08-4cec-a7c7-de93a164f41a" = false
 
 # 8 character plaintext results in 3 chunks, the last one with a trailing space
-"a65d3fa1-9e09-43f9-bcec-7a672aec3eae" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a65d3fa1-9e09-43f9-bcec-7a672aec3eae" = false
 
 # 54 character plaintext results in 7 chunks, the last two with trailing spaces
-"fbcb0c6d-4c39-4a31-83f6-c473baa6af80" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "fbcb0c6d-4c39-4a31-83f6-c473baa6af80" = false

--- a/exercises/custom-set/.meta/tests.toml
+++ b/exercises/custom-set/.meta/tests.toml
@@ -10,52 +10,67 @@
 "759b9740-3417-44c3-8ca3-262b3c281043" = true
 
 # when the element is in the set
-"f83cd2d1-2a85-41bc-b6be-80adbff4be49" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f83cd2d1-2a85-41bc-b6be-80adbff4be49" = false
 
 # when the element is not in the set
-"93423fc0-44d0-4bc0-a2ac-376de8d7af34" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "93423fc0-44d0-4bc0-a2ac-376de8d7af34" = false
 
 # empty set is a subset of another empty set
-"c392923a-637b-4495-b28e-34742cd6157a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c392923a-637b-4495-b28e-34742cd6157a" = false
 
 # empty set is a subset of non-empty set
-"5635b113-be8c-4c6f-b9a9-23c485193917" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5635b113-be8c-4c6f-b9a9-23c485193917" = false
 
 # non-empty set is not a subset of empty set
-"832eda58-6d6e-44e2-92c2-be8cf0173cee" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "832eda58-6d6e-44e2-92c2-be8cf0173cee" = false
 
 # set is a subset of set with exact same elements
-"c830c578-8f97-4036-b082-89feda876131" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c830c578-8f97-4036-b082-89feda876131" = false
 
 # set is a subset of larger set with same elements
-"476a4a1c-0fd1-430f-aa65-5b70cbc810c5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "476a4a1c-0fd1-430f-aa65-5b70cbc810c5" = false
 
 # set is not a subset of set that does not contain its elements
-"d2498999-3e46-48e4-9660-1e20c3329d3d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d2498999-3e46-48e4-9660-1e20c3329d3d" = false
 
 # the empty set is disjoint with itself
-"7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc" = false
 
 # empty set is disjoint with non-empty set
-"7a2b3938-64b6-4b32-901a-fe16891998a6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7a2b3938-64b6-4b32-901a-fe16891998a6" = false
 
 # non-empty set is disjoint with empty set
-"589574a0-8b48-48ea-88b0-b652c5fe476f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "589574a0-8b48-48ea-88b0-b652c5fe476f" = false
 
 # sets are not disjoint if they share an element
-"febeaf4f-f180-4499-91fa-59165955a523" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "febeaf4f-f180-4499-91fa-59165955a523" = false
 
 # sets are disjoint if they share no elements
-"0de20d2f-c952-468a-88c8-5e056740f020" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0de20d2f-c952-468a-88c8-5e056740f020" = false
 
 # empty sets are equal
 "4bd24adb-45da-4320-9ff6-38c044e9dff8" = true
 
 # empty set is not equal to non-empty set
-"f65c0a0e-6632-4b2d-b82c-b7c6da2ec224" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f65c0a0e-6632-4b2d-b82c-b7c6da2ec224" = false
 
 # non-empty set is not equal to empty set
-"81e53307-7683-4b1e-a30c-7e49155fe3ca" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "81e53307-7683-4b1e-a30c-7e49155fe3ca" = false
 
 # sets with the same elements are equal
 "d57c5d7c-a7f3-48cc-a162-6b488c0fbbd0" = true
@@ -64,25 +79,31 @@
 "dd61bafc-6653-42cc-961a-ab071ee0ee85" = true
 
 # set is not equal to larger set with same elements
-"06059caf-9bf4-425e-aaff-88966cb3ea14" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "06059caf-9bf4-425e-aaff-88966cb3ea14" = false
 
 # add to empty set
 "8a677c3c-a658-4d39-bb88-5b5b1a9659f4" = true
 
 # add to non-empty set
-"0903dd45-904d-4cf2-bddd-0905e1a8d125" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0903dd45-904d-4cf2-bddd-0905e1a8d125" = false
 
 # adding an existing element does not change the set
-"b0eb7bb7-5e5d-4733-b582-af771476cb99" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b0eb7bb7-5e5d-4733-b582-af771476cb99" = false
 
 # intersection of two empty sets is an empty set
-"893d5333-33b8-4151-a3d4-8f273358208a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "893d5333-33b8-4151-a3d4-8f273358208a" = false
 
 # intersection of an empty set and non-empty set is an empty set
-"d739940e-def2-41ab-a7bb-aaf60f7d782c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d739940e-def2-41ab-a7bb-aaf60f7d782c" = false
 
 # intersection of a non-empty set and an empty set is an empty set
-"3607d9d8-c895-4d6f-ac16-a14956e0a4b7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3607d9d8-c895-4d6f-ac16-a14956e0a4b7" = false
 
 # intersection of two sets with no shared elements is an empty set
 "b5120abf-5b5e-41ab-aede-4de2ad85c34e" = true
@@ -91,25 +112,33 @@
 "af21ca1b-fac9-499c-81c0-92a591653d49" = true
 
 # difference of two empty sets is an empty set
-"c5e6e2e4-50e9-4bc2-b89f-c518f015b57e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c5e6e2e4-50e9-4bc2-b89f-c518f015b57e" = false
 
 # difference of empty set and non-empty set is an empty set
-"2024cc92-5c26-44ed-aafd-e6ca27d6fcd2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2024cc92-5c26-44ed-aafd-e6ca27d6fcd2" = false
 
 # difference of a non-empty set and an empty set is the non-empty set
-"e79edee7-08aa-4c19-9382-f6820974b43e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e79edee7-08aa-4c19-9382-f6820974b43e" = false
 
 # difference of two non-empty sets is a set of elements that are only in the first set
-"c5ac673e-d707-4db5-8d69-7082c3a5437e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c5ac673e-d707-4db5-8d69-7082c3a5437e" = false
 
 # union of empty sets is an empty set
-"c45aed16-5494-455a-9033-5d4c93589dc6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c45aed16-5494-455a-9033-5d4c93589dc6" = false
 
 # union of an empty set and non-empty set is the non-empty set
-"9d258545-33c2-4fcb-a340-9f8aa69e7a41" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9d258545-33c2-4fcb-a340-9f8aa69e7a41" = false
 
 # union of a non-empty set and empty set is the non-empty set
-"3aade50c-80c7-4db8-853d-75bac5818b83" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3aade50c-80c7-4db8-853d-75bac5818b83" = false
 
 # union of non-empty sets contains all unique elements
-"a00bb91f-c4b4-4844-8f77-c73e2e9df77c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a00bb91f-c4b4-4844-8f77-c73e2e9df77c" = false

--- a/exercises/diamond/.meta/tests.toml
+++ b/exercises/diamond/.meta/tests.toml
@@ -1,16 +1,21 @@
 [canonical-tests]
 
 # Degenerate case with a single 'A' row
-"202fb4cc-6a38-4883-9193-a29d5cb92076" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "202fb4cc-6a38-4883-9193-a29d5cb92076" = false
 
 # Degenerate case with no row containing 3 distinct groups of spaces
-"bd6a6d78-9302-42e9-8f60-ac1461e9abae" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bd6a6d78-9302-42e9-8f60-ac1461e9abae" = false
 
 # Smallest non-degenerate case with odd diamond side length
-"af8efb49-14ed-447f-8944-4cc59ce3fd76" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "af8efb49-14ed-447f-8944-4cc59ce3fd76" = false
 
 # Smallest non-degenerate case with even diamond side length
-"e0c19a95-9888-4d05-86a0-fa81b9e70d1d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e0c19a95-9888-4d05-86a0-fa81b9e70d1d" = false
 
 # Largest possible diamond
-"82ea9aa9-4c0e-442a-b07e-40204e925944" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "82ea9aa9-4c0e-442a-b07e-40204e925944" = false

--- a/exercises/difference-of-squares/.meta/tests.toml
+++ b/exercises/difference-of-squares/.meta/tests.toml
@@ -1,28 +1,37 @@
 [canonical-tests]
 
 # square of sum 1
-"e46c542b-31fc-4506-bcae-6b62b3268537" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e46c542b-31fc-4506-bcae-6b62b3268537" = false
 
 # square of sum 5
-"9b3f96cb-638d-41ee-99b7-b4f9c0622948" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9b3f96cb-638d-41ee-99b7-b4f9c0622948" = false
 
 # square of sum 100
-"54ba043f-3c35-4d43-86ff-3a41625d5e86" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "54ba043f-3c35-4d43-86ff-3a41625d5e86" = false
 
 # sum of squares 1
-"01d84507-b03e-4238-9395-dd61d03074b5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "01d84507-b03e-4238-9395-dd61d03074b5" = false
 
 # sum of squares 5
-"c93900cd-8cc2-4ca4-917b-dd3027023499" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c93900cd-8cc2-4ca4-917b-dd3027023499" = false
 
 # sum of squares 100
-"94807386-73e4-4d9e-8dec-69eb135b19e4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "94807386-73e4-4d9e-8dec-69eb135b19e4" = false
 
 # difference of squares 1
-"44f72ae6-31a7-437f-858d-2c0837adabb6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "44f72ae6-31a7-437f-858d-2c0837adabb6" = false
 
 # difference of squares 5
-"005cb2bf-a0c8-46f3-ae25-924029f8b00b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "005cb2bf-a0c8-46f3-ae25-924029f8b00b" = false
 
 # difference of squares 100
-"b1bf19de-9a16-41c0-a62b-1f02ecc0b036" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b1bf19de-9a16-41c0-a62b-1f02ecc0b036" = false

--- a/exercises/diffie-hellman/.meta/tests.toml
+++ b/exercises/diffie-hellman/.meta/tests.toml
@@ -1,16 +1,21 @@
 [canonical-tests]
 
 # private key is in range 1 .. p
-"1b97bf38-4307-418e-bfd2-446ffc77588d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1b97bf38-4307-418e-bfd2-446ffc77588d" = false
 
 # private key is random
-"68b2a5f7-7755-44c3-97b2-d28d21f014a9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "68b2a5f7-7755-44c3-97b2-d28d21f014a9" = false
 
 # can calculate public key using private key
-"b4161d8e-53a1-4241-ae8f-48cc86527f22" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b4161d8e-53a1-4241-ae8f-48cc86527f22" = false
 
 # can calculate secret using other party's public key
-"cd02ad45-3f52-4510-99cc-5161dad948a8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "cd02ad45-3f52-4510-99cc-5161dad948a8" = false
 
 # key exchange
-"17f13c61-a111-4075-9a1f-c2d4636dfa60" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "17f13c61-a111-4075-9a1f-c2d4636dfa60" = false

--- a/exercises/dominoes/.meta/tests.toml
+++ b/exercises/dominoes/.meta/tests.toml
@@ -1,31 +1,38 @@
 [canonical-tests]
 
 # empty input = empty output
-"31a673f2-5e54-49fe-bd79-1c1dae476c9c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "31a673f2-5e54-49fe-bd79-1c1dae476c9c" = false
 
 # singleton input = singleton output
-"4f99b933-367b-404b-8c6d-36d5923ee476" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4f99b933-367b-404b-8c6d-36d5923ee476" = false
 
 # singleton that can't be chained
 "91122d10-5ec7-47cb-b759-033756375869" = true
 
 # three elements
-"be8bc26b-fd3d-440b-8e9f-d698a0623be3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "be8bc26b-fd3d-440b-8e9f-d698a0623be3" = false
 
 # can reverse dominoes
 "99e615c6-c059-401c-9e87-ad7af11fea5c" = true
 
 # can't be chained
-"51f0c291-5d43-40c5-b316-0429069528c9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "51f0c291-5d43-40c5-b316-0429069528c9" = false
 
 # disconnected - simple
-"9a75e078-a025-4c23-8c3a-238553657f39" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9a75e078-a025-4c23-8c3a-238553657f39" = false
 
 # disconnected - double loop
-"0da0c7fe-d492-445d-b9ef-1f111f07a301" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0da0c7fe-d492-445d-b9ef-1f111f07a301" = false
 
 # disconnected - single isolated
-"b6087ff0-f555-4ea0-a71c-f9d707c5994a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b6087ff0-f555-4ea0-a71c-f9d707c5994a" = false
 
 # need backtrack
 "2174fbdc-8b48-4bac-9914-8090d06ef978" = true

--- a/exercises/etl/.meta/tests.toml
+++ b/exercises/etl/.meta/tests.toml
@@ -1,13 +1,17 @@
 [canonical-tests]
 
 # single letter
-"78a7a9f9-4490-4a47-8ee9-5a38bb47d28f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "78a7a9f9-4490-4a47-8ee9-5a38bb47d28f" = false
 
 # single score with multiple letters
-"60dbd000-451d-44c7-bdbb-97c73ac1f497" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "60dbd000-451d-44c7-bdbb-97c73ac1f497" = false
 
 # multiple scores with multiple letters
-"f5c5de0c-301f-4fdd-a0e5-df97d4214f54" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f5c5de0c-301f-4fdd-a0e5-df97d4214f54" = false
 
 # multiple scores with differing numbers of letters
-"5db8ea89-ecb4-4dcd-902f-2b418cc87b9d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5db8ea89-ecb4-4dcd-902f-2b418cc87b9d" = false

--- a/exercises/forth/.meta/tests.toml
+++ b/exercises/forth/.meta/tests.toml
@@ -7,28 +7,34 @@
 "9e69588e-a3d8-41a3-a371-ea02206c1e6e" = true
 
 # errors if there is nothing on the stack
-"52336dd3-30da-4e5c-8523-bdf9a3427657" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "52336dd3-30da-4e5c-8523-bdf9a3427657" = false
 
 # errors if there is only one value on the stack
-"06efb9a4-817a-435e-b509-06166993c1b8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "06efb9a4-817a-435e-b509-06166993c1b8" = false
 
 # can subtract two numbers
 "09687c99-7bbc-44af-8526-e402f997ccbf" = true
 
 # errors if there is nothing on the stack
-"5d63eee2-1f7d-4538-b475-e27682ab8032" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5d63eee2-1f7d-4538-b475-e27682ab8032" = false
 
 # errors if there is only one value on the stack
-"b3cee1b2-9159-418a-b00d-a1bb3765c23b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b3cee1b2-9159-418a-b00d-a1bb3765c23b" = false
 
 # can multiply two numbers
 "5df0ceb5-922e-401f-974d-8287427dbf21" = true
 
 # errors if there is nothing on the stack
-"9e004339-15ac-4063-8ec1-5720f4e75046" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9e004339-15ac-4063-8ec1-5720f4e75046" = false
 
 # errors if there is only one value on the stack
-"8ba4b432-9f94-41e0-8fae-3b3712bd51b3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8ba4b432-9f94-41e0-8fae-3b3712bd51b3" = false
 
 # can divide two numbers
 "e74c2204-b057-4cff-9aa9-31c7c97a93f5" = true
@@ -40,10 +46,12 @@
 "a5df3219-29b4-4d2f-b427-81f82f42a3f1" = true
 
 # errors if there is nothing on the stack
-"1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a" = false
 
 # errors if there is only one value on the stack
-"d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d" = false
 
 # addition and subtraction
 "ee28d729-6692-4a30-b9be-0d830c52a68c" = true
@@ -52,61 +60,79 @@
 "40b197da-fa4b-4aca-a50b-f000d19422c1" = true
 
 # copies a value on the stack
-"c5758235-6eef-4bf6-ab62-c878e50b9957" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c5758235-6eef-4bf6-ab62-c878e50b9957" = false
 
 # copies the top value on the stack
-"f6889006-5a40-41e7-beb3-43b09e5a22f4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f6889006-5a40-41e7-beb3-43b09e5a22f4" = false
 
 # errors if there is nothing on the stack
-"40b7569c-8401-4bd4-a30d-9adf70d11bc4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "40b7569c-8401-4bd4-a30d-9adf70d11bc4" = false
 
 # removes the top value on the stack if it is the only one
-"1971da68-1df2-4569-927a-72bf5bb7263c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1971da68-1df2-4569-927a-72bf5bb7263c" = false
 
 # removes the top value on the stack if it is not the only one
-"8929d9f2-4a78-4e0f-90ad-be1a0f313fd9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8929d9f2-4a78-4e0f-90ad-be1a0f313fd9" = false
 
 # errors if there is nothing on the stack
-"6dd31873-6dd7-4cb8-9e90-7daa33ba045c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6dd31873-6dd7-4cb8-9e90-7daa33ba045c" = false
 
 # swaps the top two values on the stack if they are the only ones
-"3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3" = false
 
 # swaps the top two values on the stack if they are not the only ones
-"8ce869d5-a503-44e4-ab55-1da36816ff1c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8ce869d5-a503-44e4-ab55-1da36816ff1c" = false
 
 # errors if there is nothing on the stack
-"74ba5b2a-b028-4759-9176-c5c0e7b2b154" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "74ba5b2a-b028-4759-9176-c5c0e7b2b154" = false
 
 # errors if there is only one value on the stack
-"dd52e154-5d0d-4a5c-9e5d-73eb36052bc8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "dd52e154-5d0d-4a5c-9e5d-73eb36052bc8" = false
 
 # copies the second element if there are only two
-"a2654074-ba68-4f93-b014-6b12693a8b50" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a2654074-ba68-4f93-b014-6b12693a8b50" = false
 
 # copies the second element if there are more than two
-"c5b51097-741a-4da7-8736-5c93fa856339" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c5b51097-741a-4da7-8736-5c93fa856339" = false
 
 # errors if there is nothing on the stack
-"6e1703a6-5963-4a03-abba-02e77e3181fd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6e1703a6-5963-4a03-abba-02e77e3181fd" = false
 
 # errors if there is only one value on the stack
-"ee574dc4-ef71-46f6-8c6a-b4af3a10c45f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ee574dc4-ef71-46f6-8c6a-b4af3a10c45f" = false
 
 # can consist of built-in words
-"ed45cbbf-4dbf-4901-825b-54b20dbee53b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ed45cbbf-4dbf-4901-825b-54b20dbee53b" = false
 
 # execute in the right order
 "2726ea44-73e4-436b-bc2b-5ff0c6aa014b" = true
 
 # can override other user-defined words
-"9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33" = false
 
 # can override built-in words
-"669db3f3-5bd6-4be0-83d1-618cd6e4984b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "669db3f3-5bd6-4be0-83d1-618cd6e4984b" = false
 
 # can override built-in operators
-"588de2f0-c56e-4c68-be0b-0bb1e603c500" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "588de2f0-c56e-4c68-be0b-0bb1e603c500" = false
 
 # can use different words with the same name
 "ac12aaaf-26c6-4a10-8b3c-1c958fa2914c" = true
@@ -115,25 +141,33 @@
 "53f82ef0-2750-4ccb-ac04-5d8c1aefabb1" = true
 
 # cannot redefine numbers
-"35958cee-a976-4a0f-9378-f678518fa322" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "35958cee-a976-4a0f-9378-f678518fa322" = false
 
 # errors if executing a non-existent word
-"5180f261-89dd-491e-b230-62737e09806f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5180f261-89dd-491e-b230-62737e09806f" = false
 
 # DUP is case-insensitive
-"7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6" = false
 
 # DROP is case-insensitive
-"339ed30b-f5b4-47ff-ab1c-67591a9cd336" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "339ed30b-f5b4-47ff-ab1c-67591a9cd336" = false
 
 # SWAP is case-insensitive
-"ee1af31e-1355-4b1b-bb95-f9d0b2961b87" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ee1af31e-1355-4b1b-bb95-f9d0b2961b87" = false
 
 # OVER is case-insensitive
-"acdc3a49-14c8-4cc2-945d-11edee6408fa" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "acdc3a49-14c8-4cc2-945d-11edee6408fa" = false
 
 # user-defined words are case-insensitive
-"5934454f-a24f-4efc-9fdd-5794e5f0c23c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5934454f-a24f-4efc-9fdd-5794e5f0c23c" = false
 
 # definitions are case-insensitive
-"037d4299-195f-4be7-a46d-f07ca6280a06" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "037d4299-195f-4be7-a46d-f07ca6280a06" = false

--- a/exercises/gigasecond/.meta/tests.toml
+++ b/exercises/gigasecond/.meta/tests.toml
@@ -1,16 +1,21 @@
 [canonical-tests]
 
 # date only specification of time
-"92fbe71c-ea52-4fac-bd77-be38023cacf7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "92fbe71c-ea52-4fac-bd77-be38023cacf7" = false
 
 # second test for date only specification of time
-"6d86dd16-6f7a-47be-9e58-bb9fb2ae1433" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6d86dd16-6f7a-47be-9e58-bb9fb2ae1433" = false
 
 # third test for date only specification of time
-"77eb8502-2bca-4d92-89d9-7b39ace28dd5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "77eb8502-2bca-4d92-89d9-7b39ace28dd5" = false
 
 # full time specified
-"c9d89a7d-06f8-4e28-a305-64f1b2abc693" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c9d89a7d-06f8-4e28-a305-64f1b2abc693" = false
 
 # full time with day roll-over
-"09d4e30e-728a-4b52-9005-be44a58d9eba" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "09d4e30e-728a-4b52-9005-be44a58d9eba" = false

--- a/exercises/grade-school/.meta/tests.toml
+++ b/exercises/grade-school/.meta/tests.toml
@@ -1,22 +1,29 @@
 [canonical-tests]
 
 # Adding a student adds them to the sorted roster
-"6d0a30e4-1b4e-472e-8e20-c41702125667" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6d0a30e4-1b4e-472e-8e20-c41702125667" = false
 
 # Adding more student adds them to the sorted roster
-"233be705-dd58-4968-889d-fb3c7954c9cc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "233be705-dd58-4968-889d-fb3c7954c9cc" = false
 
 # Adding students to different grades adds them to the same sorted roster
-"75a51579-d1d7-407c-a2f8-2166e984e8ab" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "75a51579-d1d7-407c-a2f8-2166e984e8ab" = false
 
 # Roster returns an empty list if there are no students enrolled
-"a3f0fb58-f240-4723-8ddc-e644666b85cc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a3f0fb58-f240-4723-8ddc-e644666b85cc" = false
 
 # Student names with grades are displayed in the same sorted roster
-"180a8ff9-5b94-43fc-9db1-d46b4a8c93b6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "180a8ff9-5b94-43fc-9db1-d46b4a8c93b6" = false
 
 # Grade returns the students in that grade in alphabetical order
-"1bfbcef1-e4a3-49e8-8d22-f6f9f386187e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1bfbcef1-e4a3-49e8-8d22-f6f9f386187e" = false
 
 # Grade returns an empty list if there are no students in that grade
-"5e67aa3c-a3c6-4407-a183-d8fe59cd1630" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5e67aa3c-a3c6-4407-a183-d8fe59cd1630" = false

--- a/exercises/grep/.meta/tests.toml
+++ b/exercises/grep/.meta/tests.toml
@@ -1,76 +1,101 @@
 [canonical-tests]
 
 # One file, one match, no flags
-"9049fdfd-53a7-4480-a390-375203837d09" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9049fdfd-53a7-4480-a390-375203837d09" = false
 
 # One file, one match, print line numbers flag
-"76519cce-98e3-46cd-b287-aac31b1d77d6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "76519cce-98e3-46cd-b287-aac31b1d77d6" = false
 
 # One file, one match, case-insensitive flag
-"af0b6d3c-e0e8-475e-a112-c0fc10a1eb30" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "af0b6d3c-e0e8-475e-a112-c0fc10a1eb30" = false
 
 # One file, one match, print file names flag
-"ff7af839-d1b8-4856-a53e-99283579b672" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ff7af839-d1b8-4856-a53e-99283579b672" = false
 
 # One file, one match, match entire lines flag
-"8625238a-720c-4a16-81f2-924ec8e222cb" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8625238a-720c-4a16-81f2-924ec8e222cb" = false
 
 # One file, one match, multiple flags
-"2a6266b3-a60f-475c-a5f5-f5008a717d3e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2a6266b3-a60f-475c-a5f5-f5008a717d3e" = false
 
 # One file, several matches, no flags
-"842222da-32e8-4646-89df-0d38220f77a1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "842222da-32e8-4646-89df-0d38220f77a1" = false
 
 # One file, several matches, print line numbers flag
-"4d84f45f-a1d8-4c2e-a00e-0b292233828c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4d84f45f-a1d8-4c2e-a00e-0b292233828c" = false
 
 # One file, several matches, match entire lines flag
-"0a483b66-315b-45f5-bc85-3ce353a22539" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0a483b66-315b-45f5-bc85-3ce353a22539" = false
 
 # One file, several matches, case-insensitive flag
-"3d2ca86a-edd7-494c-8938-8eeed1c61cfa" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3d2ca86a-edd7-494c-8938-8eeed1c61cfa" = false
 
 # One file, several matches, inverted flag
-"1f52001f-f224-4521-9456-11120cad4432" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1f52001f-f224-4521-9456-11120cad4432" = false
 
 # One file, no matches, various flags
-"7a6ede7f-7dd5-4364-8bf8-0697c53a09fe" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7a6ede7f-7dd5-4364-8bf8-0697c53a09fe" = false
 
 # One file, one match, file flag takes precedence over line flag
-"3d3dfc23-8f2a-4e34-abd6-7b7d140291dc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3d3dfc23-8f2a-4e34-abd6-7b7d140291dc" = false
 
 # One file, several matches, inverted and match entire lines flags
-"87b21b24-b788-4d6e-a68b-7afe9ca141fe" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "87b21b24-b788-4d6e-a68b-7afe9ca141fe" = false
 
 # Multiple files, one match, no flags
-"ba496a23-6149-41c6-a027-28064ed533e5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ba496a23-6149-41c6-a027-28064ed533e5" = false
 
 # Multiple files, several matches, no flags
-"4539bd36-6daa-4bc3-8e45-051f69f5aa95" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4539bd36-6daa-4bc3-8e45-051f69f5aa95" = false
 
 # Multiple files, several matches, print line numbers flag
-"9fb4cc67-78e2-4761-8e6b-a4b57aba1938" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9fb4cc67-78e2-4761-8e6b-a4b57aba1938" = false
 
 # Multiple files, one match, print file names flag
-"aeee1ef3-93c7-4cd5-af10-876f8c9ccc73" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "aeee1ef3-93c7-4cd5-af10-876f8c9ccc73" = false
 
 # Multiple files, several matches, case-insensitive flag
-"d69f3606-7d15-4ddf-89ae-01df198e6b6c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d69f3606-7d15-4ddf-89ae-01df198e6b6c" = false
 
 # Multiple files, several matches, inverted flag
-"82ef739d-6701-4086-b911-007d1a3deb21" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "82ef739d-6701-4086-b911-007d1a3deb21" = false
 
 # Multiple files, one match, match entire lines flag
-"77b2eb07-2921-4ea0-8971-7636b44f5d29" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "77b2eb07-2921-4ea0-8971-7636b44f5d29" = false
 
 # Multiple files, one match, multiple flags
-"e53a2842-55bb-4078-9bb5-04ac38929989" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e53a2842-55bb-4078-9bb5-04ac38929989" = false
 
 # Multiple files, no matches, various flags
-"9c4f7f9a-a555-4e32-bb06-4b8f8869b2cb" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9c4f7f9a-a555-4e32-bb06-4b8f8869b2cb" = false
 
 # Multiple files, several matches, file flag takes precedence over line number flag
-"ba5a540d-bffd-481b-bd0c-d9a30f225e01" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ba5a540d-bffd-481b-bd0c-d9a30f225e01" = false
 
 # Multiple files, several matches, inverted and match entire lines flags
-"ff406330-2f0b-4b17-9ee4-4b71c31dd6d2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ff406330-2f0b-4b17-9ee4-4b71c31dd6d2" = false

--- a/exercises/hamming/.meta/tests.toml
+++ b/exercises/hamming/.meta/tests.toml
@@ -1,28 +1,37 @@
 [canonical-tests]
 
 # empty strands
-"f6dcb64f-03b0-4b60-81b1-3c9dbf47e887" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f6dcb64f-03b0-4b60-81b1-3c9dbf47e887" = false
 
 # single letter identical strands
-"54681314-eee2-439a-9db0-b0636c656156" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "54681314-eee2-439a-9db0-b0636c656156" = false
 
 # single letter different strands
-"294479a3-a4c8-478f-8d63-6209815a827b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "294479a3-a4c8-478f-8d63-6209815a827b" = false
 
 # long identical strands
-"9aed5f34-5693-4344-9b31-40c692fb5592" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9aed5f34-5693-4344-9b31-40c692fb5592" = false
 
 # long different strands
-"cd2273a5-c576-46c8-a52b-dee251c3e6e5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "cd2273a5-c576-46c8-a52b-dee251c3e6e5" = false
 
 # disallow first strand longer
-"919f8ef0-b767-4d1b-8516-6379d07fcb28" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "919f8ef0-b767-4d1b-8516-6379d07fcb28" = false
 
 # disallow second strand longer
-"8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e" = false
 
 # disallow left empty strand
-"5dce058b-28d4-4ca7-aa64-adfe4e17784c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5dce058b-28d4-4ca7-aa64-adfe4e17784c" = false
 
 # disallow right empty strand
-"38826d4b-16fb-4639-ac3e-ba027dec8b5f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "38826d4b-16fb-4639-ac3e-ba027dec8b5f" = false

--- a/exercises/hello-world/.meta/tests.toml
+++ b/exercises/hello-world/.meta/tests.toml
@@ -1,4 +1,5 @@
 [canonical-tests]
 
 # Say Hi!
-"af9ffe10-dc13-42d8-a742-e7bdafac449d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "af9ffe10-dc13-42d8-a742-e7bdafac449d" = false

--- a/exercises/high-scores/.meta/tests.toml
+++ b/exercises/high-scores/.meta/tests.toml
@@ -1,25 +1,33 @@
 [canonical-tests]
 
 # List of scores
-"1035eb93-2208-4c22-bab8-fef06769a73c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1035eb93-2208-4c22-bab8-fef06769a73c" = false
 
 # Latest score
-"6aa5dbf5-78fa-4375-b22c-ffaa989732d2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6aa5dbf5-78fa-4375-b22c-ffaa989732d2" = false
 
 # Personal best
-"b661a2e1-aebf-4f50-9139-0fb817dd12c6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b661a2e1-aebf-4f50-9139-0fb817dd12c6" = false
 
 # Personal top three from a list of scores
-"3d996a97-c81c-4642-9afc-80b80dc14015" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3d996a97-c81c-4642-9afc-80b80dc14015" = false
 
 # Personal top highest to lowest
-"1084ecb5-3eb4-46fe-a816-e40331a4e83a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1084ecb5-3eb4-46fe-a816-e40331a4e83a" = false
 
 # Personal top when there is a tie
-"e6465b6b-5a11-4936-bfe3-35241c4f4f16" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e6465b6b-5a11-4936-bfe3-35241c4f4f16" = false
 
 # Personal top when there are less than 3
-"f73b02af-c8fd-41c9-91b9-c86eaa86bce2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f73b02af-c8fd-41c9-91b9-c86eaa86bce2" = false
 
 # Personal top when there is only one
-"16608eae-f60f-4a88-800e-aabce5df2865" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "16608eae-f60f-4a88-800e-aabce5df2865" = false

--- a/exercises/isbn-verifier/.meta/tests.toml
+++ b/exercises/isbn-verifier/.meta/tests.toml
@@ -1,43 +1,55 @@
 [canonical-tests]
 
 # valid isbn number
-"0caa3eac-d2e3-4c29-8df8-b188bc8c9292" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0caa3eac-d2e3-4c29-8df8-b188bc8c9292" = false
 
 # invalid isbn check digit
-"19f76b53-7c24-45f8-87b8-4604d0ccd248" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "19f76b53-7c24-45f8-87b8-4604d0ccd248" = false
 
 # valid isbn number with a check digit of 10
-"4164bfee-fb0a-4a1c-9f70-64c6a1903dcd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4164bfee-fb0a-4a1c-9f70-64c6a1903dcd" = false
 
 # check digit is a character other than X
-"3ed50db1-8982-4423-a993-93174a20825c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3ed50db1-8982-4423-a993-93174a20825c" = false
 
 # invalid character in isbn
-"c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec" = false
 
 # X is only valid as a check digit
-"28025280-2c39-4092-9719-f3234b89c627" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "28025280-2c39-4092-9719-f3234b89c627" = false
 
 # valid isbn without separating dashes
-"f6294e61-7e79-46b3-977b-f48789a4945b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f6294e61-7e79-46b3-977b-f48789a4945b" = false
 
 # isbn without separating dashes and X as check digit
-"185ab99b-3a1b-45f3-aeec-b80d80b07f0b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "185ab99b-3a1b-45f3-aeec-b80d80b07f0b" = false
 
 # isbn without check digit and dashes
-"7725a837-ec8e-4528-a92a-d981dd8cf3e2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7725a837-ec8e-4528-a92a-d981dd8cf3e2" = false
 
 # too long isbn and no dashes
-"47e4dfba-9c20-46ed-9958-4d3190630bdf" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "47e4dfba-9c20-46ed-9958-4d3190630bdf" = false
 
 # too short isbn
 "737f4e91-cbba-4175-95bf-ae630b41fb60" = true
 
 # isbn without check digit
-"5458a128-a9b6-4ff8-8afb-674e74567cef" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5458a128-a9b6-4ff8-8afb-674e74567cef" = false
 
 # check digit of X should not be used for 0
-"70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7" = false
 
 # empty isbn
 "94610459-55ab-4c35-9b93-ff6ea1a8e562" = true
@@ -49,4 +61,5 @@
 "ed6e8d1b-382c-4081-8326-8b772c581fec" = true
 
 # input is too long but contains a valid isbn
-"fb5e48d8-7c03-4bfb-a088-b101df16fdc3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "fb5e48d8-7c03-4bfb-a088-b101df16fdc3" = false

--- a/exercises/isogram/.meta/tests.toml
+++ b/exercises/isogram/.meta/tests.toml
@@ -4,37 +4,46 @@
 "a0e97d2d-669e-47c7-8134-518a1e2c4555" = true
 
 # isogram with only lower case characters
-"9a001b50-f194-4143-bc29-2af5ec1ef652" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9a001b50-f194-4143-bc29-2af5ec1ef652" = false
 
 # word with one duplicated character
-"8ddb0ca3-276e-4f8b-89da-d95d5bae78a4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8ddb0ca3-276e-4f8b-89da-d95d5bae78a4" = false
 
 # word with one duplicated character from the end of the alphabet
-"6450b333-cbc2-4b24-a723-0b459b34fe18" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6450b333-cbc2-4b24-a723-0b459b34fe18" = false
 
 # longest reported english isogram
 "a15ff557-dd04-4764-99e7-02cc1a385863" = true
 
 # word with duplicated character in mixed case
-"f1a7f6c7-a42f-4915-91d7-35b2ea11c92e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f1a7f6c7-a42f-4915-91d7-35b2ea11c92e" = false
 
 # word with duplicated character in mixed case, lowercase first
-"14a4f3c1-3b47-4695-b645-53d328298942" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "14a4f3c1-3b47-4695-b645-53d328298942" = false
 
 # hypothetical isogrammic word with hyphen
-"423b850c-7090-4a8a-b057-97f1cadd7c42" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "423b850c-7090-4a8a-b057-97f1cadd7c42" = false
 
 # hypothetical word with duplicated character following hyphen
-"93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2" = false
 
 # isogram with duplicated hyphen
 "36b30e5c-173f-49c6-a515-93a3e825553f" = true
 
 # made-up name that is an isogram
-"cdabafa0-c9f4-4c1f-b142-689c6ee17d93" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "cdabafa0-c9f4-4c1f-b142-689c6ee17d93" = false
 
 # duplicated character in the middle
 "5fc61048-d74e-48fd-bc34-abfc21552d4d" = true
 
 # same first and last characters
-"310ac53d-8932-47bc-bbb4-b2b94f25a83e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "310ac53d-8932-47bc-bbb4-b2b94f25a83e" = false

--- a/exercises/largest-series-product/.meta/tests.toml
+++ b/exercises/largest-series-product/.meta/tests.toml
@@ -1,46 +1,61 @@
 [canonical-tests]
 
 # finds the largest product if span equals length
-"7c82f8b7-e347-48ee-8a22-f672323324d4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7c82f8b7-e347-48ee-8a22-f672323324d4" = false
 
 # can find the largest product of 2 with numbers in order
-"88523f65-21ba-4458-a76a-b4aaf6e4cb5e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "88523f65-21ba-4458-a76a-b4aaf6e4cb5e" = false
 
 # can find the largest product of 2
-"f1376b48-1157-419d-92c2-1d7e36a70b8a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f1376b48-1157-419d-92c2-1d7e36a70b8a" = false
 
 # can find the largest product of 3 with numbers in order
-"46356a67-7e02-489e-8fea-321c2fa7b4a4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "46356a67-7e02-489e-8fea-321c2fa7b4a4" = false
 
 # can find the largest product of 3
-"a2dcb54b-2b8f-4993-92dd-5ce56dece64a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a2dcb54b-2b8f-4993-92dd-5ce56dece64a" = false
 
 # can find the largest product of 5 with numbers in order
-"673210a3-33cd-4708-940b-c482d7a88f9d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "673210a3-33cd-4708-940b-c482d7a88f9d" = false
 
 # can get the largest product of a big number
-"02acd5a6-3bbf-46df-8282-8b313a80a7c9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "02acd5a6-3bbf-46df-8282-8b313a80a7c9" = false
 
 # reports zero if the only digits are zero
-"76dcc407-21e9-424c-a98e-609f269622b5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "76dcc407-21e9-424c-a98e-609f269622b5" = false
 
 # reports zero if all spans include zero
-"6ef0df9f-52d4-4a5d-b210-f6fae5f20e19" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6ef0df9f-52d4-4a5d-b210-f6fae5f20e19" = false
 
 # rejects span longer than string length
-"5d81aaf7-4f67-4125-bf33-11493cc7eab7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5d81aaf7-4f67-4125-bf33-11493cc7eab7" = false
 
 # reports 1 for empty string and empty product (0 span)
-"06bc8b90-0c51-4c54-ac22-3ec3893a079e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "06bc8b90-0c51-4c54-ac22-3ec3893a079e" = false
 
 # reports 1 for nonempty string and empty product (0 span)
-"3ec0d92e-f2e2-4090-a380-70afee02f4c0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3ec0d92e-f2e2-4090-a380-70afee02f4c0" = false
 
 # rejects empty string and nonzero span
-"6d96c691-4374-4404-80ee-2ea8f3613dd4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6d96c691-4374-4404-80ee-2ea8f3613dd4" = false
 
 # rejects invalid character in digits
-"7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74" = false
 
 # rejects negative span
-"5fe3c0e5-a945-49f2-b584-f0814b4dd1ef" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5fe3c0e5-a945-49f2-b584-f0814b4dd1ef" = false

--- a/exercises/leap/.meta/tests.toml
+++ b/exercises/leap/.meta/tests.toml
@@ -1,28 +1,37 @@
 [canonical-tests]
 
 # year not divisible by 4 in common year
-"6466b30d-519c-438e-935d-388224ab5223" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6466b30d-519c-438e-935d-388224ab5223" = false
 
 # year divisible by 2, not divisible by 4 in common year
-"ac227e82-ee82-4a09-9eb6-4f84331ffdb0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ac227e82-ee82-4a09-9eb6-4f84331ffdb0" = false
 
 # year divisible by 4, not divisible by 100 in leap year
-"4fe9b84c-8e65-489e-970b-856d60b8b78e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4fe9b84c-8e65-489e-970b-856d60b8b78e" = false
 
 # year divisible by 4 and 5 is still a leap year
-"7fc6aed7-e63c-48f5-ae05-5fe182f60a5d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7fc6aed7-e63c-48f5-ae05-5fe182f60a5d" = false
 
 # year divisible by 100, not divisible by 400 in common year
-"78a7848f-9667-4192-ae53-87b30c9a02dd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "78a7848f-9667-4192-ae53-87b30c9a02dd" = false
 
 # year divisible by 100 but not by 3 is still not a leap year
-"9d70f938-537c-40a6-ba19-f50739ce8bac" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9d70f938-537c-40a6-ba19-f50739ce8bac" = false
 
 # year divisible by 400 in leap year
-"42ee56ad-d3e6-48f1-8e3f-c84078d916fc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "42ee56ad-d3e6-48f1-8e3f-c84078d916fc" = false
 
 # year divisible by 400 but not by 125 is still a leap year
-"57902c77-6fe9-40de-8302-587b5c27121e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "57902c77-6fe9-40de-8302-587b5c27121e" = false
 
 # year divisible by 200, not divisible by 400 in common year
-"c30331f6-f9f6-4881-ad38-8ca8c12520c1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c30331f6-f9f6-4881-ad38-8ca8c12520c1" = false

--- a/exercises/luhn/.meta/tests.toml
+++ b/exercises/luhn/.meta/tests.toml
@@ -1,55 +1,73 @@
 [canonical-tests]
 
 # single digit strings can not be valid
-"792a7082-feb7-48c7-b88b-bbfec160865e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "792a7082-feb7-48c7-b88b-bbfec160865e" = false
 
 # a single zero is invalid
-"698a7924-64d4-4d89-8daa-32e1aadc271e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "698a7924-64d4-4d89-8daa-32e1aadc271e" = false
 
 # a simple valid SIN that remains valid if reversed
-"73c2f62b-9b10-4c9f-9a04-83cee7367965" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "73c2f62b-9b10-4c9f-9a04-83cee7367965" = false
 
 # a simple valid SIN that becomes invalid if reversed
-"9369092e-b095-439f-948d-498bd076be11" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9369092e-b095-439f-948d-498bd076be11" = false
 
 # a valid Canadian SIN
-"8f9f2350-1faf-4008-ba84-85cbb93ffeca" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8f9f2350-1faf-4008-ba84-85cbb93ffeca" = false
 
 # invalid Canadian SIN
-"1cdcf269-6560-44fc-91f6-5819a7548737" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1cdcf269-6560-44fc-91f6-5819a7548737" = false
 
 # invalid credit card
-"656c48c1-34e8-4e60-9a5a-aad8a367810a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "656c48c1-34e8-4e60-9a5a-aad8a367810a" = false
 
 # invalid long number with an even remainder
-"20e67fad-2121-43ed-99a8-14b5b856adb9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "20e67fad-2121-43ed-99a8-14b5b856adb9" = false
 
 # valid number with an even number of digits
-"ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa" = false
 
 # valid number with an odd number of spaces
-"ef081c06-a41f-4761-8492-385e13c8202d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ef081c06-a41f-4761-8492-385e13c8202d" = false
 
 # valid strings with a non-digit added at the end become invalid
-"bef66f64-6100-4cbb-8f94-4c9713c5e5b2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bef66f64-6100-4cbb-8f94-4c9713c5e5b2" = false
 
 # valid strings with punctuation included become invalid
-"2177e225-9ce7-40f6-b55d-fa420e62938e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2177e225-9ce7-40f6-b55d-fa420e62938e" = false
 
 # valid strings with symbols included become invalid
-"ebf04f27-9698-45e1-9afe-7e0851d0fe8d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ebf04f27-9698-45e1-9afe-7e0851d0fe8d" = false
 
 # single zero with space is invalid
-"08195c5e-ce7f-422c-a5eb-3e45fece68ba" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "08195c5e-ce7f-422c-a5eb-3e45fece68ba" = false
 
 # more than a single zero is valid
-"12e63a3c-f866-4a79-8c14-b359fc386091" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "12e63a3c-f866-4a79-8c14-b359fc386091" = false
 
 # input digit 9 is correctly converted to output digit 9
-"ab56fa80-5de8-4735-8a4a-14dae588663e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ab56fa80-5de8-4735-8a4a-14dae588663e" = false
 
 # using ascii value for non-doubled non-digit isn't allowed
-"39a06a5a-5bad-4e0f-b215-b042d46209b1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "39a06a5a-5bad-4e0f-b215-b042d46209b1" = false
 
 # using ascii value for doubled non-digit isn't allowed
-"f94cf191-a62f-4868-bc72-7253114aa157" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f94cf191-a62f-4868-bc72-7253114aa157" = false

--- a/exercises/minesweeper/.meta/tests.toml
+++ b/exercises/minesweeper/.meta/tests.toml
@@ -10,7 +10,8 @@
 "6fbf8f6d-a03b-42c9-9a58-b489e9235478" = true
 
 # minefield with only mines
-"61aff1c4-fb31-4078-acad-cd5f1e635655" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "61aff1c4-fb31-4078-acad-cd5f1e635655" = false
 
 # mine surrounded by spaces
 "84167147-c504-4896-85d7-246b01dea7c5" = true
@@ -34,4 +35,5 @@
 "4b098563-b7f3-401c-97c6-79dd1b708f34" = true
 
 # large minefield
-"04a260f1-b40a-4e89-839e-8dd8525abe0e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "04a260f1-b40a-4e89-839e-8dd8525abe0e" = false

--- a/exercises/nth-prime/.meta/tests.toml
+++ b/exercises/nth-prime/.meta/tests.toml
@@ -1,16 +1,21 @@
 [canonical-tests]
 
 # first prime
-"75c65189-8aef-471a-81de-0a90c728160c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "75c65189-8aef-471a-81de-0a90c728160c" = false
 
 # second prime
-"2c38804c-295f-4701-b728-56dea34fd1a0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2c38804c-295f-4701-b728-56dea34fd1a0" = false
 
 # sixth prime
-"56692534-781e-4e8c-b1f9-3e82c1640259" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "56692534-781e-4e8c-b1f9-3e82c1640259" = false
 
 # big prime
-"fce1e979-0edb-412d-93aa-2c744e8f50ff" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "fce1e979-0edb-412d-93aa-2c744e8f50ff" = false
 
 # there is no zeroth prime
-"bd0a9eae-6df7-485b-a144-80e13c7d55b2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bd0a9eae-6df7-485b-a144-80e13c7d55b2" = false

--- a/exercises/nucleotide-count/.meta/tests.toml
+++ b/exercises/nucleotide-count/.meta/tests.toml
@@ -1,16 +1,21 @@
 [canonical-tests]
 
 # empty strand
-"3e5c30a8-87e2-4845-a815-a49671ade970" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3e5c30a8-87e2-4845-a815-a49671ade970" = false
 
 # can count one nucleotide in single-character input
-"a0ea42a6-06d9-4ac6-828c-7ccaccf98fec" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a0ea42a6-06d9-4ac6-828c-7ccaccf98fec" = false
 
 # strand with repeated nucleotide
-"eca0d565-ed8c-43e7-9033-6cefbf5115b5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "eca0d565-ed8c-43e7-9033-6cefbf5115b5" = false
 
 # strand with multiple nucleotides
-"40a45eac-c83f-4740-901a-20b22d15a39f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "40a45eac-c83f-4740-901a-20b22d15a39f" = false
 
 # strand with invalid nucleotides
-"b4c47851-ee9e-4b0a-be70-a86e343bd851" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b4c47851-ee9e-4b0a-be70-a86e343bd851" = false

--- a/exercises/ocr-numbers/.meta/tests.toml
+++ b/exercises/ocr-numbers/.meta/tests.toml
@@ -7,19 +7,23 @@
 "027ada25-17fd-4d78-aee6-35a19623639d" = true
 
 # Unreadable but correctly sized inputs return ?
-"3cce2dbd-01d9-4f94-8fae-419a822e89bb" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3cce2dbd-01d9-4f94-8fae-419a822e89bb" = false
 
 # Input with a number of lines that is not a multiple of four raises an error
-"cb19b733-4e36-4cf9-a4a1-6e6aac808b9a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "cb19b733-4e36-4cf9-a4a1-6e6aac808b9a" = false
 
 # Input with a number of columns that is not a multiple of three raises an error
-"235f7bd1-991b-4587-98d4-84206eec4cc6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "235f7bd1-991b-4587-98d4-84206eec4cc6" = false
 
 # Recognizes 110101100
 "4a841794-73c9-4da9-a779-1f9837faff66" = true
 
 # Garbled numbers in a string are replaced with ?
-"70c338f9-85b1-4296-a3a8-122901cdfde8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "70c338f9-85b1-4296-a3a8-122901cdfde8" = false
 
 # Recognizes 2
 "ea494ff4-3610-44d7-ab7e-72fdef0e0802" = true
@@ -49,4 +53,5 @@
 "f60cb04a-42be-494e-a535-3451c8e097a4" = true
 
 # Numbers separated by empty lines are recognized. Lines are joined by commas.
-"b73ecf8b-4423-4b36-860d-3710bdb8a491" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b73ecf8b-4423-4b36-860d-3710bdb8a491" = false

--- a/exercises/palindrome-products/.meta/tests.toml
+++ b/exercises/palindrome-products/.meta/tests.toml
@@ -1,37 +1,49 @@
 [canonical-tests]
 
 # finds the smallest palindrome from single digit factors
-"5cff78fe-cf02-459d-85c2-ce584679f887" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5cff78fe-cf02-459d-85c2-ce584679f887" = false
 
 # finds the largest palindrome from single digit factors
-"0853f82c-5fc4-44ae-be38-fadb2cced92d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0853f82c-5fc4-44ae-be38-fadb2cced92d" = false
 
 # find the smallest palindrome from double digit factors
-"66c3b496-bdec-4103-9129-3fcb5a9063e1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "66c3b496-bdec-4103-9129-3fcb5a9063e1" = false
 
 # find the largest palindrome from double digit factors
-"a10682ae-530a-4e56-b89d-69664feafe53" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a10682ae-530a-4e56-b89d-69664feafe53" = false
 
 # find smallest palindrome from triple digit factors
-"cecb5a35-46d1-4666-9719-fa2c3af7499d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "cecb5a35-46d1-4666-9719-fa2c3af7499d" = false
 
 # find the largest palindrome from triple digit factors
-"edab43e1-c35f-4ea3-8c55-2f31dddd92e5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "edab43e1-c35f-4ea3-8c55-2f31dddd92e5" = false
 
 # find smallest palindrome from four digit factors
-"4f802b5a-9d74-4026-a70f-b53ff9234e4e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4f802b5a-9d74-4026-a70f-b53ff9234e4e" = false
 
 # find the largest palindrome from four digit factors
-"787525e0-a5f9-40f3-8cb2-23b52cf5d0be" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "787525e0-a5f9-40f3-8cb2-23b52cf5d0be" = false
 
 # empty result for smallest if no palindrome in the range
-"58fb1d63-fddb-4409-ab84-a7a8e58d9ea0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "58fb1d63-fddb-4409-ab84-a7a8e58d9ea0" = false
 
 # empty result for largest if no palindrome in the range
-"9de9e9da-f1d9-49a5-8bfc-3d322efbdd02" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9de9e9da-f1d9-49a5-8bfc-3d322efbdd02" = false
 
 # error result for smallest if min is more than max
-"12e73aac-d7ee-4877-b8aa-2aa3dcdb9f8a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "12e73aac-d7ee-4877-b8aa-2aa3dcdb9f8a" = false
 
 # error result for largest if min is more than max
-"eeeb5bff-3f47-4b1e-892f-05829277bd74" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "eeeb5bff-3f47-4b1e-892f-05829277bd74" = false

--- a/exercises/pangram/.meta/tests.toml
+++ b/exercises/pangram/.meta/tests.toml
@@ -1,31 +1,41 @@
 [canonical-tests]
 
 # empty sentence
-"64f61791-508e-4f5c-83ab-05de042b0149" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "64f61791-508e-4f5c-83ab-05de042b0149" = false
 
 # perfect lower case
-"74858f80-4a4d-478b-8a5e-c6477e4e4e84" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "74858f80-4a4d-478b-8a5e-c6477e4e4e84" = false
 
 # only lower case
-"61288860-35ca-4abe-ba08-f5df76ecbdcd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "61288860-35ca-4abe-ba08-f5df76ecbdcd" = false
 
 # missing the letter 'x'
-"6564267d-8ac5-4d29-baf2-e7d2e304a743" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6564267d-8ac5-4d29-baf2-e7d2e304a743" = false
 
 # missing the letter 'h'
-"c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0" = false
 
 # with underscores
-"d835ec38-bc8f-48e4-9e36-eb232427b1df" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d835ec38-bc8f-48e4-9e36-eb232427b1df" = false
 
 # with numbers
-"8cc1e080-a178-4494-b4b3-06982c9be2a8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8cc1e080-a178-4494-b4b3-06982c9be2a8" = false
 
 # missing letters replaced by numbers
-"bed96b1c-ff95-45b8-9731-fdbdcb6ede9a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bed96b1c-ff95-45b8-9731-fdbdcb6ede9a" = false
 
 # mixed case and punctuation
-"938bd5d8-ade5-40e2-a2d9-55a338a01030" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "938bd5d8-ade5-40e2-a2d9-55a338a01030" = false
 
 # case insensitive
-"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2577bf54-83c8-402d-a64b-a2c0f7bb213a" = false

--- a/exercises/pascals-triangle/.meta/tests.toml
+++ b/exercises/pascals-triangle/.meta/tests.toml
@@ -1,10 +1,12 @@
 [canonical-tests]
 
 # zero rows
-"9920ce55-9629-46d5-85d6-4201f4a4234d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9920ce55-9629-46d5-85d6-4201f4a4234d" = false
 
 # single row
-"70d643ce-a46d-4e93-af58-12d88dd01f21" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "70d643ce-a46d-4e93-af58-12d88dd01f21" = false
 
 # two rows
 "a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd" = true
@@ -13,7 +15,8 @@
 "97206a99-79ba-4b04-b1c5-3c0fa1e16925" = true
 
 # four rows
-"565a0431-c797-417c-a2c8-2935e01ce306" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "565a0431-c797-417c-a2c8-2935e01ce306" = false
 
 # five rows
 "06f9ea50-9f51-4eb2-b9a9-c00975686c27" = true

--- a/exercises/perfect-numbers/.meta/tests.toml
+++ b/exercises/perfect-numbers/.meta/tests.toml
@@ -1,40 +1,53 @@
 [canonical-tests]
 
 # Smallest perfect number is classified correctly
-"163e8e86-7bfd-4ee2-bd68-d083dc3381a3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "163e8e86-7bfd-4ee2-bd68-d083dc3381a3" = false
 
 # Medium perfect number is classified correctly
-"169a7854-0431-4ae0-9815-c3b6d967436d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "169a7854-0431-4ae0-9815-c3b6d967436d" = false
 
 # Large perfect number is classified correctly
-"ee3627c4-7b36-4245-ba7c-8727d585f402" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ee3627c4-7b36-4245-ba7c-8727d585f402" = false
 
 # Smallest abundant number is classified correctly
-"80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e" = false
 
 # Medium abundant number is classified correctly
-"3e300e0d-1a12-4f11-8c48-d1027165ab60" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3e300e0d-1a12-4f11-8c48-d1027165ab60" = false
 
 # Large abundant number is classified correctly
-"ec7792e6-8786-449c-b005-ce6dd89a772b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ec7792e6-8786-449c-b005-ce6dd89a772b" = false
 
 # Smallest prime deficient number is classified correctly
-"e610fdc7-2b6e-43c3-a51c-b70fb37413ba" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e610fdc7-2b6e-43c3-a51c-b70fb37413ba" = false
 
 # Smallest non-prime deficient number is classified correctly
-"0beb7f66-753a-443f-8075-ad7fbd9018f3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0beb7f66-753a-443f-8075-ad7fbd9018f3" = false
 
 # Medium deficient number is classified correctly
-"1c802e45-b4c6-4962-93d7-1cad245821ef" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1c802e45-b4c6-4962-93d7-1cad245821ef" = false
 
 # Large deficient number is classified correctly
-"47dd569f-9e5a-4a11-9a47-a4e91c8c28aa" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "47dd569f-9e5a-4a11-9a47-a4e91c8c28aa" = false
 
 # Edge case (no factors other than itself) is classified correctly
-"a696dec8-6147-4d68-afad-d38de5476a56" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a696dec8-6147-4d68-afad-d38de5476a56" = false
 
 # Zero is rejected (not a natural number)
-"72445cee-660c-4d75-8506-6c40089dc302" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "72445cee-660c-4d75-8506-6c40089dc302" = false
 
 # Negative integer is rejected (not a natural number)
-"2d72ce2c-6802-49ac-8ece-c790ba3dae13" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2d72ce2c-6802-49ac-8ece-c790ba3dae13" = false

--- a/exercises/phone-number/.meta/tests.toml
+++ b/exercises/phone-number/.meta/tests.toml
@@ -1,55 +1,73 @@
 [canonical-tests]
 
 # cleans the number
-"79666dce-e0f1-46de-95a1-563802913c35" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "79666dce-e0f1-46de-95a1-563802913c35" = false
 
 # cleans numbers with dots
-"c360451f-549f-43e4-8aba-fdf6cb0bf83f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c360451f-549f-43e4-8aba-fdf6cb0bf83f" = false
 
 # cleans numbers with multiple spaces
-"08f94c34-9a37-46a2-a123-2a8e9727395d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "08f94c34-9a37-46a2-a123-2a8e9727395d" = false
 
 # invalid when 9 digits
-"598d8432-0659-4019-a78b-1c6a73691d21" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "598d8432-0659-4019-a78b-1c6a73691d21" = false
 
 # invalid when 11 digits does not start with a 1
-"57061c72-07b5-431f-9766-d97da7c4399d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "57061c72-07b5-431f-9766-d97da7c4399d" = false
 
 # valid when 11 digits and starting with 1
-"9962cbf3-97bb-4118-ba9b-38ff49c64430" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9962cbf3-97bb-4118-ba9b-38ff49c64430" = false
 
 # valid when 11 digits and starting with 1 even with punctuation
-"fa724fbf-054c-4d91-95da-f65ab5b6dbca" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "fa724fbf-054c-4d91-95da-f65ab5b6dbca" = false
 
 # invalid when more than 11 digits
-"c6a5f007-895a-4fc5-90bc-a7e70f9b5cad" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c6a5f007-895a-4fc5-90bc-a7e70f9b5cad" = false
 
 # invalid with letters
-"63f38f37-53f6-4a5f-bd86-e9b404f10a60" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "63f38f37-53f6-4a5f-bd86-e9b404f10a60" = false
 
 # invalid with punctuations
-"4bd97d90-52fd-45d3-b0db-06ab95b1244e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4bd97d90-52fd-45d3-b0db-06ab95b1244e" = false
 
 # invalid if area code starts with 0
-"d77d07f8-873c-4b17-8978-5f66139bf7d7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d77d07f8-873c-4b17-8978-5f66139bf7d7" = false
 
 # invalid if area code starts with 1
-"c7485cfb-1e7b-4081-8e96-8cdb3b77f15e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c7485cfb-1e7b-4081-8e96-8cdb3b77f15e" = false
 
 # invalid if exchange code starts with 0
-"4d622293-6976-413d-b8bf-dd8a94d4e2ac" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4d622293-6976-413d-b8bf-dd8a94d4e2ac" = false
 
 # invalid if exchange code starts with 1
-"4cef57b4-7d8e-43aa-8328-1e1b89001262" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4cef57b4-7d8e-43aa-8328-1e1b89001262" = false
 
 # invalid if area code starts with 0 on valid 11-digit number
-"9925b09c-1a0d-4960-a197-5d163cbe308c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9925b09c-1a0d-4960-a197-5d163cbe308c" = false
 
 # invalid if area code starts with 1 on valid 11-digit number
-"3f809d37-40f3-44b5-ad90-535838b1a816" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3f809d37-40f3-44b5-ad90-535838b1a816" = false
 
 # invalid if exchange code starts with 0 on valid 11-digit number
-"e08e5532-d621-40d4-b0cc-96c159276b65" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e08e5532-d621-40d4-b0cc-96c159276b65" = false
 
 # invalid if exchange code starts with 1 on valid 11-digit number
-"57b32f3d-696a-455c-8bf1-137b6d171cdf" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "57b32f3d-696a-455c-8bf1-137b6d171cdf" = false

--- a/exercises/pig-latin/.meta/tests.toml
+++ b/exercises/pig-latin/.meta/tests.toml
@@ -1,67 +1,89 @@
 [canonical-tests]
 
 # word beginning with a
-"11567f84-e8c6-4918-aedb-435f0b73db57" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "11567f84-e8c6-4918-aedb-435f0b73db57" = false
 
 # word beginning with e
-"f623f581-bc59-4f45-9032-90c3ca9d2d90" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f623f581-bc59-4f45-9032-90c3ca9d2d90" = false
 
 # word beginning with i
-"7dcb08b3-23a6-4e8a-b9aa-d4e859450d58" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7dcb08b3-23a6-4e8a-b9aa-d4e859450d58" = false
 
 # word beginning with o
-"0e5c3bff-266d-41c8-909f-364e4d16e09c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0e5c3bff-266d-41c8-909f-364e4d16e09c" = false
 
 # word beginning with u
-"614ba363-ca3c-4e96-ab09-c7320799723c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "614ba363-ca3c-4e96-ab09-c7320799723c" = false
 
 # word beginning with a vowel and followed by a qu
-"bf2538c6-69eb-4fa7-a494-5a3fec911326" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bf2538c6-69eb-4fa7-a494-5a3fec911326" = false
 
 # word beginning with p
-"e5be8a01-2d8a-45eb-abb4-3fcc9582a303" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e5be8a01-2d8a-45eb-abb4-3fcc9582a303" = false
 
 # word beginning with k
-"d36d1e13-a7ed-464d-a282-8820cb2261ce" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d36d1e13-a7ed-464d-a282-8820cb2261ce" = false
 
 # word beginning with x
-"d838b56f-0a89-4c90-b326-f16ff4e1dddc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d838b56f-0a89-4c90-b326-f16ff4e1dddc" = false
 
 # word beginning with q without a following u
-"bce94a7a-a94e-4e2b-80f4-b2bb02e40f71" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bce94a7a-a94e-4e2b-80f4-b2bb02e40f71" = false
 
 # word beginning with ch
-"c01e049a-e3e2-451c-bf8e-e2abb7e438b8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c01e049a-e3e2-451c-bf8e-e2abb7e438b8" = false
 
 # word beginning with qu
-"9ba1669e-c43f-4b93-837a-cfc731fd1425" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9ba1669e-c43f-4b93-837a-cfc731fd1425" = false
 
 # word beginning with qu and a preceding consonant
-"92e82277-d5e4-43d7-8dd3-3a3b316c41f7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "92e82277-d5e4-43d7-8dd3-3a3b316c41f7" = false
 
 # word beginning with th
-"79ae4248-3499-4d5b-af46-5cb05fa073ac" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "79ae4248-3499-4d5b-af46-5cb05fa073ac" = false
 
 # word beginning with thr
-"e0b3ae65-f508-4de3-8999-19c2f8e243e1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e0b3ae65-f508-4de3-8999-19c2f8e243e1" = false
 
 # word beginning with sch
-"20bc19f9-5a35-4341-9d69-1627d6ee6b43" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "20bc19f9-5a35-4341-9d69-1627d6ee6b43" = false
 
 # word beginning with yt
-"54b796cb-613d-4509-8c82-8fbf8fc0af9e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "54b796cb-613d-4509-8c82-8fbf8fc0af9e" = false
 
 # word beginning with xr
-"8c37c5e1-872e-4630-ba6e-d20a959b67f6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8c37c5e1-872e-4630-ba6e-d20a959b67f6" = false
 
 # y is treated like a consonant at the beginning of a word
-"a4a36d33-96f3-422c-a233-d4021460ff00" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a4a36d33-96f3-422c-a233-d4021460ff00" = false
 
 # y is treated like a vowel at the end of a consonant cluster
-"adc90017-1a12-4100-b595-e346105042c7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "adc90017-1a12-4100-b595-e346105042c7" = false
 
 # y as second letter in two letter word
-"29b4ca3d-efe5-4a95-9a54-8467f2e5e59a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "29b4ca3d-efe5-4a95-9a54-8467f2e5e59a" = false
 
 # a whole phrase
-"44616581-5ce3-4a81-82d0-40c7ab13d2cf" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "44616581-5ce3-4a81-82d0-40c7ab13d2cf" = false

--- a/exercises/poker/.meta/tests.toml
+++ b/exercises/poker/.meta/tests.toml
@@ -1,85 +1,113 @@
 [canonical-tests]
 
 # single hand always wins
-"161f485e-39c2-4012-84cf-bec0c755b66c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "161f485e-39c2-4012-84cf-bec0c755b66c" = false
 
 # highest card out of all hands wins
-"370ac23a-a00f-48a9-9965-6f3fb595cf45" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "370ac23a-a00f-48a9-9965-6f3fb595cf45" = false
 
 # a tie has multiple winners
-"d94ad5a7-17df-484b-9932-c64fc26cff52" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d94ad5a7-17df-484b-9932-c64fc26cff52" = false
 
 # multiple hands with the same high cards, tie compares next highest ranked, down to last card
-"61ed83a9-cfaa-40a5-942a-51f52f0a8725" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "61ed83a9-cfaa-40a5-942a-51f52f0a8725" = false
 
 # one pair beats high card
-"f7175a89-34ff-44de-b3d7-f6fd97d1fca4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f7175a89-34ff-44de-b3d7-f6fd97d1fca4" = false
 
 # highest pair wins
-"e114fd41-a301-4111-a9e7-5a7f72a76561" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e114fd41-a301-4111-a9e7-5a7f72a76561" = false
 
 # two pairs beats one pair
-"935bb4dc-a622-4400-97fa-86e7d06b1f76" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "935bb4dc-a622-4400-97fa-86e7d06b1f76" = false
 
 # both hands have two pairs, highest ranked pair wins
-"c8aeafe1-6e3d-4711-a6de-5161deca91fd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c8aeafe1-6e3d-4711-a6de-5161deca91fd" = false
 
 # both hands have two pairs, with the same highest ranked pair, tie goes to low pair
-"88abe1ba-7ad7-40f3-847e-0a26f8e46a60" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "88abe1ba-7ad7-40f3-847e-0a26f8e46a60" = false
 
 # both hands have two identically ranked pairs, tie goes to remaining card (kicker)
-"15a7a315-0577-47a3-9981-d6cf8e6f387b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "15a7a315-0577-47a3-9981-d6cf8e6f387b" = false
 
 # three of a kind beats two pair
-"21e9f1e6-2d72-49a1-a930-228e5e0195dc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "21e9f1e6-2d72-49a1-a930-228e5e0195dc" = false
 
 # both hands have three of a kind, tie goes to highest ranked triplet
-"c2fffd1f-c287-480f-bf2d-9628e63bbcc3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c2fffd1f-c287-480f-bf2d-9628e63bbcc3" = false
 
 # with multiple decks, two players can have same three of a kind, ties go to highest remaining cards
-"eb856cc2-481c-4b0d-9835-4d75d07a5d9d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "eb856cc2-481c-4b0d-9835-4d75d07a5d9d" = false
 
 # a straight beats three of a kind
-"a858c5d9-2f28-48e7-9980-b7fa04060a60" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a858c5d9-2f28-48e7-9980-b7fa04060a60" = false
 
 # aces can end a straight (10 J Q K A)
-"73c9c756-e63e-4b01-a88d-0d4491a7a0e3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "73c9c756-e63e-4b01-a88d-0d4491a7a0e3" = false
 
 # aces can start a straight (A 2 3 4 5)
-"76856b0d-35cd-49ce-a492-fe5db53abc02" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "76856b0d-35cd-49ce-a492-fe5db53abc02" = false
 
 # both hands with a straight, tie goes to highest ranked card
-"6980c612-bbff-4914-b17a-b044e4e69ea1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6980c612-bbff-4914-b17a-b044e4e69ea1" = false
 
 # even though an ace is usually high, a 5-high straight is the lowest-scoring straight
-"5135675c-c2fc-4e21-9ba3-af77a32e9ba4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5135675c-c2fc-4e21-9ba3-af77a32e9ba4" = false
 
 # flush beats a straight
-"c601b5e6-e1df-4ade-b444-b60ce13b2571" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c601b5e6-e1df-4ade-b444-b60ce13b2571" = false
 
 # both hands have a flush, tie goes to high card, down to the last one if necessary
-"4d90261d-251c-49bd-a468-896bf10133de" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4d90261d-251c-49bd-a468-896bf10133de" = false
 
 # full house beats a flush
-"3a19361d-8974-455c-82e5-f7152f5dba7c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3a19361d-8974-455c-82e5-f7152f5dba7c" = false
 
 # both hands have a full house, tie goes to highest-ranked triplet
-"eb73d0e6-b66c-4f0f-b8ba-bf96bc0a67f0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "eb73d0e6-b66c-4f0f-b8ba-bf96bc0a67f0" = false
 
 # with multiple decks, both hands have a full house with the same triplet, tie goes to the pair
-"34b51168-1e43-4c0d-9b32-e356159b4d5d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "34b51168-1e43-4c0d-9b32-e356159b4d5d" = false
 
 # four of a kind beats a full house
-"d61e9e99-883b-4f99-b021-18f0ae50c5f4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d61e9e99-883b-4f99-b021-18f0ae50c5f4" = false
 
 # both hands have four of a kind, tie goes to high quad
-"2e1c8c63-e0cb-4214-a01b-91954490d2fe" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2e1c8c63-e0cb-4214-a01b-91954490d2fe" = false
 
 # with multiple decks, both hands with identical four of a kind, tie determined by kicker
-"892ca75d-5474-495d-9f64-a6ce2dcdb7e1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "892ca75d-5474-495d-9f64-a6ce2dcdb7e1" = false
 
 # straight flush beats four of a kind
-"923bd910-dc7b-4f7d-a330-8b42ec10a3ac" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "923bd910-dc7b-4f7d-a330-8b42ec10a3ac" = false
 
 # both hands have straight flush, tie goes to highest-ranked card
-"d0927f70-5aec-43db-aed8-1cbd1b6ee9ad" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d0927f70-5aec-43db-aed8-1cbd1b6ee9ad" = false

--- a/exercises/prime-factors/.meta/tests.toml
+++ b/exercises/prime-factors/.meta/tests.toml
@@ -1,22 +1,29 @@
 [canonical-tests]
 
 # no factors
-"924fc966-a8f5-4288-82f2-6b9224819ccd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "924fc966-a8f5-4288-82f2-6b9224819ccd" = false
 
 # prime number
-"17e30670-b105-4305-af53-ddde182cb6ad" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "17e30670-b105-4305-af53-ddde182cb6ad" = false
 
 # square of a prime
-"f59b8350-a180-495a-8fb1-1712fbee1158" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f59b8350-a180-495a-8fb1-1712fbee1158" = false
 
 # cube of a prime
-"bc8c113f-9580-4516-8669-c5fc29512ceb" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bc8c113f-9580-4516-8669-c5fc29512ceb" = false
 
 # product of primes and non-primes
-"00485cd3-a3fe-4fbe-a64a-a4308fc1f870" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "00485cd3-a3fe-4fbe-a64a-a4308fc1f870" = false
 
 # product of primes
-"02251d54-3ca1-4a9b-85e1-b38f4b0ccb91" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "02251d54-3ca1-4a9b-85e1-b38f4b0ccb91" = false
 
 # factors include a large prime
-"070cf8dc-e202-4285-aa37-8d775c9cd473" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "070cf8dc-e202-4285-aa37-8d775c9cd473" = false

--- a/exercises/protein-translation/.meta/tests.toml
+++ b/exercises/protein-translation/.meta/tests.toml
@@ -1,70 +1,93 @@
 [canonical-tests]
 
 # Methionine RNA sequence
-"96d3d44f-34a2-4db4-84cd-fff523e069be" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "96d3d44f-34a2-4db4-84cd-fff523e069be" = false
 
 # Phenylalanine RNA sequence 1
-"1b4c56d8-d69f-44eb-be0e-7b17546143d9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1b4c56d8-d69f-44eb-be0e-7b17546143d9" = false
 
 # Phenylalanine RNA sequence 2
-"81b53646-bd57-4732-b2cb-6b1880e36d11" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "81b53646-bd57-4732-b2cb-6b1880e36d11" = false
 
 # Leucine RNA sequence 1
-"42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4" = false
 
 # Leucine RNA sequence 2
-"ac5edadd-08ed-40a3-b2b9-d82bb50424c4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ac5edadd-08ed-40a3-b2b9-d82bb50424c4" = false
 
 # Serine RNA sequence 1
-"8bc36e22-f984-44c3-9f6b-ee5d4e73f120" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8bc36e22-f984-44c3-9f6b-ee5d4e73f120" = false
 
 # Serine RNA sequence 2
-"5c3fa5da-4268-44e5-9f4b-f016ccf90131" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5c3fa5da-4268-44e5-9f4b-f016ccf90131" = false
 
 # Serine RNA sequence 3
-"00579891-b594-42b4-96dc-7ff8bf519606" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "00579891-b594-42b4-96dc-7ff8bf519606" = false
 
 # Serine RNA sequence 4
-"08c61c3b-fa34-4950-8c4a-133945570ef6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "08c61c3b-fa34-4950-8c4a-133945570ef6" = false
 
 # Tyrosine RNA sequence 1
-"54e1e7d8-63c0-456d-91d2-062c72f8eef5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "54e1e7d8-63c0-456d-91d2-062c72f8eef5" = false
 
 # Tyrosine RNA sequence 2
-"47bcfba2-9d72-46ad-bbce-22f7666b7eb1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "47bcfba2-9d72-46ad-bbce-22f7666b7eb1" = false
 
 # Cysteine RNA sequence 1
-"3a691829-fe72-43a7-8c8e-1bd083163f72" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3a691829-fe72-43a7-8c8e-1bd083163f72" = false
 
 # Cysteine RNA sequence 2
-"1b6f8a26-ca2f-43b8-8262-3ee446021767" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1b6f8a26-ca2f-43b8-8262-3ee446021767" = false
 
 # Tryptophan RNA sequence
-"1e91c1eb-02c0-48a0-9e35-168ad0cb5f39" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1e91c1eb-02c0-48a0-9e35-168ad0cb5f39" = false
 
 # STOP codon RNA sequence 1
-"e547af0b-aeab-49c7-9f13-801773a73557" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e547af0b-aeab-49c7-9f13-801773a73557" = false
 
 # STOP codon RNA sequence 2
-"67640947-ff02-4f23-a2ef-816f8a2ba72e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "67640947-ff02-4f23-a2ef-816f8a2ba72e" = false
 
 # STOP codon RNA sequence 3
-"9c2ad527-ebc9-4ace-808b-2b6447cb54cb" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9c2ad527-ebc9-4ace-808b-2b6447cb54cb" = false
 
 # Translate RNA strand into correct protein list
-"d0f295df-fb70-425c-946c-ec2ec185388e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d0f295df-fb70-425c-946c-ec2ec185388e" = false
 
 # Translation stops if STOP codon at beginning of sequence
-"e30e8505-97ec-4e5f-a73e-5726a1faa1f4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e30e8505-97ec-4e5f-a73e-5726a1faa1f4" = false
 
 # Translation stops if STOP codon at end of two-codon sequence
-"5358a20b-6f4c-4893-bce4-f929001710f3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5358a20b-6f4c-4893-bce4-f929001710f3" = false
 
 # Translation stops if STOP codon at end of three-codon sequence
-"ba16703a-1a55-482f-bb07-b21eef5093a3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ba16703a-1a55-482f-bb07-b21eef5093a3" = false
 
 # Translation stops if STOP codon in middle of three-codon sequence
-"4089bb5a-d5b4-4e71-b79e-b8d1f14a2911" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4089bb5a-d5b4-4e71-b79e-b8d1f14a2911" = false
 
 # Translation stops if STOP codon in middle of six-codon sequence
-"2c2a2a60-401f-4a80-b977-e0715b23b93d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2c2a2a60-401f-4a80-b977-e0715b23b93d" = false

--- a/exercises/proverb/.meta/tests.toml
+++ b/exercises/proverb/.meta/tests.toml
@@ -1,19 +1,25 @@
 [canonical-tests]
 
 # zero pieces
-"e974b73e-7851-484f-8d6d-92e07fe742fc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e974b73e-7851-484f-8d6d-92e07fe742fc" = false
 
 # one piece
-"2fcd5f5e-8b82-4e74-b51d-df28a5e0faa4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2fcd5f5e-8b82-4e74-b51d-df28a5e0faa4" = false
 
 # two pieces
-"d9d0a8a1-d933-46e2-aa94-eecf679f4b0e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d9d0a8a1-d933-46e2-aa94-eecf679f4b0e" = false
 
 # three pieces
-"c95ef757-5e94-4f0d-a6cb-d2083f5e5a83" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c95ef757-5e94-4f0d-a6cb-d2083f5e5a83" = false
 
 # full proverb
-"433fb91c-35a2-4d41-aeab-4de1e82b2126" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "433fb91c-35a2-4d41-aeab-4de1e82b2126" = false
 
 # four pieces modernized
-"c1eefa5a-e8d9-41c7-91d4-99fab6d6b9f7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c1eefa5a-e8d9-41c7-91d4-99fab6d6b9f7" = false

--- a/exercises/pythagorean-triplet/.meta/tests.toml
+++ b/exercises/pythagorean-triplet/.meta/tests.toml
@@ -1,22 +1,29 @@
 [canonical-tests]
 
 # triplets whose sum is 12
-"a19de65d-35b8-4480-b1af-371d9541e706" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a19de65d-35b8-4480-b1af-371d9541e706" = false
 
 # triplets whose sum is 108
-"48b21332-0a3d-43b2-9a52-90b2a6e5c9f5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "48b21332-0a3d-43b2-9a52-90b2a6e5c9f5" = false
 
 # triplets whose sum is 1000
-"dffc1266-418e-4daa-81af-54c3e95c3bb5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "dffc1266-418e-4daa-81af-54c3e95c3bb5" = false
 
 # no matching triplets for 1001
-"5f86a2d4-6383-4cce-93a5-e4489e79b186" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5f86a2d4-6383-4cce-93a5-e4489e79b186" = false
 
 # returns all matching triplets
-"bf17ba80-1596-409a-bb13-343bdb3b2904" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bf17ba80-1596-409a-bb13-343bdb3b2904" = false
 
 # several matching triplets
-"9d8fb5d5-6c6f-42df-9f95-d3165963ac57" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9d8fb5d5-6c6f-42df-9f95-d3165963ac57" = false
 
 # triplets for large number
-"f5be5734-8aa0-4bd1-99a2-02adcc4402b4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f5be5734-8aa0-4bd1-99a2-02adcc4402b4" = false

--- a/exercises/queen-attack/.meta/tests.toml
+++ b/exercises/queen-attack/.meta/tests.toml
@@ -1,37 +1,49 @@
 [canonical-tests]
 
 # queen with a valid position
-"3ac4f735-d36c-44c4-a3e2-316f79704203" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3ac4f735-d36c-44c4-a3e2-316f79704203" = false
 
 # queen must have positive row
-"4e812d5d-b974-4e38-9a6b-8e0492bfa7be" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4e812d5d-b974-4e38-9a6b-8e0492bfa7be" = false
 
 # queen must have row on board
-"f07b7536-b66b-4f08-beb9-4d70d891d5c8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f07b7536-b66b-4f08-beb9-4d70d891d5c8" = false
 
 # queen must have positive column
-"15a10794-36d9-4907-ae6b-e5a0d4c54ebe" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "15a10794-36d9-4907-ae6b-e5a0d4c54ebe" = false
 
 # queen must have column on board
-"6907762d-0e8a-4c38-87fb-12f2f65f0ce4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6907762d-0e8a-4c38-87fb-12f2f65f0ce4" = false
 
 # can not attack
-"33ae4113-d237-42ee-bac1-e1e699c0c007" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "33ae4113-d237-42ee-bac1-e1e699c0c007" = false
 
 # can attack on same row
-"eaa65540-ea7c-4152-8c21-003c7a68c914" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "eaa65540-ea7c-4152-8c21-003c7a68c914" = false
 
 # can attack on same column
-"bae6f609-2c0e-4154-af71-af82b7c31cea" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bae6f609-2c0e-4154-af71-af82b7c31cea" = false
 
 # can attack on first diagonal
-"0e1b4139-b90d-4562-bd58-dfa04f1746c7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0e1b4139-b90d-4562-bd58-dfa04f1746c7" = false
 
 # can attack on second diagonal
-"ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd" = false
 
 # can attack on third diagonal
-"0a71e605-6e28-4cc2-aa47-d20a2e71037a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0a71e605-6e28-4cc2-aa47-d20a2e71037a" = false
 
 # can attack on fourth diagonal
-"0790b588-ae73-4f1f-a968-dd0b34f45f86" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0790b588-ae73-4f1f-a968-dd0b34f45f86" = false

--- a/exercises/rail-fence-cipher/.meta/tests.toml
+++ b/exercises/rail-fence-cipher/.meta/tests.toml
@@ -1,19 +1,25 @@
 [canonical-tests]
 
 # encode with two rails
-"46dc5c50-5538-401d-93a5-41102680d068" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "46dc5c50-5538-401d-93a5-41102680d068" = false
 
 # encode with three rails
-"25691697-fbd8-4278-8c38-b84068b7bc29" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "25691697-fbd8-4278-8c38-b84068b7bc29" = false
 
 # encode with ending in the middle
-"384f0fea-1442-4f1a-a7c4-5cbc2044002c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "384f0fea-1442-4f1a-a7c4-5cbc2044002c" = false
 
 # decode with three rails
-"cd525b17-ec34-45ef-8f0e-4f27c24a7127" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "cd525b17-ec34-45ef-8f0e-4f27c24a7127" = false
 
 # decode with five rails
-"dd7b4a98-1a52-4e5c-9499-cbb117833507" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "dd7b4a98-1a52-4e5c-9499-cbb117833507" = false
 
 # decode with six rails
-"93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3" = false

--- a/exercises/raindrops/.meta/tests.toml
+++ b/exercises/raindrops/.meta/tests.toml
@@ -1,55 +1,73 @@
 [canonical-tests]
 
 # the sound for 1 is 1
-"1575d549-e502-46d4-a8e1-6b7bec6123d8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1575d549-e502-46d4-a8e1-6b7bec6123d8" = false
 
 # the sound for 3 is Pling
-"1f51a9f9-4895-4539-b182-d7b0a5ab2913" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1f51a9f9-4895-4539-b182-d7b0a5ab2913" = false
 
 # the sound for 5 is Plang
-"2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = false
 
 # the sound for 7 is Plong
-"d7e60daa-32ef-4c23-b688-2abff46c4806" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d7e60daa-32ef-4c23-b688-2abff46c4806" = false
 
 # the sound for 6 is Pling as it has a factor 3
-"6bb4947b-a724-430c-923f-f0dc3d62e56a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6bb4947b-a724-430c-923f-f0dc3d62e56a" = false
 
 # 2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base
-"ce51e0e8-d9d4-446d-9949-96eac4458c2d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ce51e0e8-d9d4-446d-9949-96eac4458c2d" = false
 
 # the sound for 9 is Pling as it has a factor 3
-"0dd66175-e3e2-47fc-8750-d01739856671" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0dd66175-e3e2-47fc-8750-d01739856671" = false
 
 # the sound for 10 is Plang as it has a factor 5
-"022c44d3-2182-4471-95d7-c575af225c96" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "022c44d3-2182-4471-95d7-c575af225c96" = false
 
 # the sound for 14 is Plong as it has a factor of 7
-"37ab74db-fed3-40ff-b7b9-04acdfea8edf" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "37ab74db-fed3-40ff-b7b9-04acdfea8edf" = false
 
 # the sound for 15 is PlingPlang as it has factors 3 and 5
-"31f92999-6afb-40ee-9aa4-6d15e3334d0f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "31f92999-6afb-40ee-9aa4-6d15e3334d0f" = false
 
 # the sound for 21 is PlingPlong as it has factors 3 and 7
-"ff9bb95d-6361-4602-be2c-653fe5239b54" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ff9bb95d-6361-4602-be2c-653fe5239b54" = false
 
 # the sound for 25 is Plang as it has a factor 5
-"d2e75317-b72e-40ab-8a64-6734a21dece1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d2e75317-b72e-40ab-8a64-6734a21dece1" = false
 
 # the sound for 27 is Pling as it has a factor 3
-"a09c4c58-c662-4e32-97fe-f1501ef7125c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a09c4c58-c662-4e32-97fe-f1501ef7125c" = false
 
 # the sound for 35 is PlangPlong as it has factors 5 and 7
-"bdf061de-8564-4899-a843-14b48b722789" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bdf061de-8564-4899-a843-14b48b722789" = false
 
 # the sound for 49 is Plong as it has a factor 7
-"c4680bee-69ba-439d-99b5-70c5fd1a7a83" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c4680bee-69ba-439d-99b5-70c5fd1a7a83" = false
 
 # the sound for 52 is 52
-"17f2bc9a-b65a-4d23-8ccd-266e8c271444" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "17f2bc9a-b65a-4d23-8ccd-266e8c271444" = false
 
 # the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7
-"e46677ed-ff1a-419f-a740-5c713d2830e4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e46677ed-ff1a-419f-a740-5c713d2830e4" = false
 
 # the sound for 3125 is Plang as it has a factor 5
-"13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = false

--- a/exercises/react/.meta/tests.toml
+++ b/exercises/react/.meta/tests.toml
@@ -22,13 +22,16 @@
 "abe33eaf-68ad-42a5-b728-05519ca88d2d" = true
 
 # callback cells only fire on change
-"9e5cb3a4-78e5-4290-80f8-a78612c52db2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9e5cb3a4-78e5-4290-80f8-a78612c52db2" = false
 
 # callbacks do not report already reported values
-"ada17cb6-7332-448a-b934-e3d7495c13d3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ada17cb6-7332-448a-b934-e3d7495c13d3" = false
 
 # callbacks can fire from multiple cells
-"ac271900-ea5c-461c-9add-eeebcb8c03e5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ac271900-ea5c-461c-9add-eeebcb8c03e5" = false
 
 # callbacks can be added and removed
 "95a82dcc-8280-4de3-a4cd-4f19a84e3d6f" = true

--- a/exercises/rectangles/.meta/tests.toml
+++ b/exercises/rectangles/.meta/tests.toml
@@ -1,40 +1,53 @@
 [canonical-tests]
 
 # no rows
-"485b7bab-4150-40aa-a8db-73013427d08c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "485b7bab-4150-40aa-a8db-73013427d08c" = false
 
 # no columns
-"076929ed-27e8-45dc-b14b-08279944dc49" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "076929ed-27e8-45dc-b14b-08279944dc49" = false
 
 # no rectangles
-"0a8abbd1-a0a4-4180-aa4e-65c1b1a073fa" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0a8abbd1-a0a4-4180-aa4e-65c1b1a073fa" = false
 
 # one rectangle
-"a4ba42e9-4e7f-4973-b7c7-4ce0760ac6cd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a4ba42e9-4e7f-4973-b7c7-4ce0760ac6cd" = false
 
 # two rectangles without shared parts
-"ced06550-83da-4d23-98b7-d24152e0db93" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ced06550-83da-4d23-98b7-d24152e0db93" = false
 
 # five rectangles with shared parts
-"5942d69a-a07c-41c8-8b93-2d13877c706a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5942d69a-a07c-41c8-8b93-2d13877c706a" = false
 
 # rectangle of height 1 is counted
-"82d70be4-ab37-4bf2-a433-e33778d3bbf1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "82d70be4-ab37-4bf2-a433-e33778d3bbf1" = false
 
 # rectangle of width 1 is counted
-"57f1bc0e-2782-401e-ab12-7c01d8bfc2e0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "57f1bc0e-2782-401e-ab12-7c01d8bfc2e0" = false
 
 # 1x1 square is counted
-"ef0bb65c-bd80-4561-9535-efc4067054f9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ef0bb65c-bd80-4561-9535-efc4067054f9" = false
 
 # only complete rectangles are counted
-"e1e1d444-e926-4d30-9bf3-7d8ec9a9e330" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e1e1d444-e926-4d30-9bf3-7d8ec9a9e330" = false
 
 # rectangles can be of different sizes
-"ca021a84-1281-4a56-9b9b-af14113933a4" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ca021a84-1281-4a56-9b9b-af14113933a4" = false
 
 # corner is required for a rectangle to be complete
-"51f689a7-ef3f-41ae-aa2f-5ea09ad897ff" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "51f689a7-ef3f-41ae-aa2f-5ea09ad897ff" = false
 
 # large input with many rectangles
-"d78fe379-8c1b-4d3c-bdf7-29bfb6f6dc66" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d78fe379-8c1b-4d3c-bdf7-29bfb6f6dc66" = false

--- a/exercises/reverse-string/.meta/tests.toml
+++ b/exercises/reverse-string/.meta/tests.toml
@@ -1,19 +1,25 @@
 [canonical-tests]
 
 # an empty string
-"c3b7d806-dced-49ee-8543-933fd1719b1c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c3b7d806-dced-49ee-8543-933fd1719b1c" = false
 
 # a word
-"01ebf55b-bebb-414e-9dec-06f7bb0bee3c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "01ebf55b-bebb-414e-9dec-06f7bb0bee3c" = false
 
 # a capitalized word
-"0f7c07e4-efd1-4aaa-a07a-90b49ce0b746" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0f7c07e4-efd1-4aaa-a07a-90b49ce0b746" = false
 
 # a sentence with punctuation
-"71854b9c-f200-4469-9f5c-1e8e5eff5614" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "71854b9c-f200-4469-9f5c-1e8e5eff5614" = false
 
 # a palindrome
-"1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c" = false
 
 # an even-sized word
-"b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c" = false

--- a/exercises/rna-transcription/.meta/tests.toml
+++ b/exercises/rna-transcription/.meta/tests.toml
@@ -1,19 +1,25 @@
 [canonical-tests]
 
 # Empty RNA sequence
-"b4631f82-c98c-4a2f-90b3-c5c2b6c6f661" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b4631f82-c98c-4a2f-90b3-c5c2b6c6f661" = false
 
 # RNA complement of cytosine is guanine
-"a9558a3c-318c-4240-9256-5d5ed47005a6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a9558a3c-318c-4240-9256-5d5ed47005a6" = false
 
 # RNA complement of guanine is cytosine
-"6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7" = false
 
 # RNA complement of thymine is adenine
-"870bd3ec-8487-471d-8d9a-a25046488d3e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "870bd3ec-8487-471d-8d9a-a25046488d3e" = false
 
 # RNA complement of adenine is uracil
-"aade8964-02e1-4073-872f-42d3ffd74c5f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "aade8964-02e1-4073-872f-42d3ffd74c5f" = false
 
 # RNA complement
-"79ed2757-f018-4f47-a1d7-34a559392dbf" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "79ed2757-f018-4f47-a1d7-34a559392dbf" = false

--- a/exercises/robot-simulator/.meta/tests.toml
+++ b/exercises/robot-simulator/.meta/tests.toml
@@ -1,55 +1,73 @@
 [canonical-tests]
 
 # at origin facing north
-"c557c16d-26c1-4e06-827c-f6602cd0785c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c557c16d-26c1-4e06-827c-f6602cd0785c" = false
 
 # at negative position facing south
-"bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d" = false
 
 # changes north to east
-"8cbd0086-6392-4680-b9b9-73cf491e67e5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8cbd0086-6392-4680-b9b9-73cf491e67e5" = false
 
 # changes east to south
-"8abc87fc-eab2-4276-93b7-9c009e866ba1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8abc87fc-eab2-4276-93b7-9c009e866ba1" = false
 
 # changes south to west
-"3cfe1b85-bbf2-4bae-b54d-d73e7e93617a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3cfe1b85-bbf2-4bae-b54d-d73e7e93617a" = false
 
 # changes west to north
-"5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716" = false
 
 # changes north to west
-"fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63" = false
 
 # changes west to south
-"da33d734-831f-445c-9907-d66d7d2a92e2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "da33d734-831f-445c-9907-d66d7d2a92e2" = false
 
 # changes south to east
-"bd1ca4b9-4548-45f4-b32e-900fc7c19389" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bd1ca4b9-4548-45f4-b32e-900fc7c19389" = false
 
 # changes east to north
-"2de27b67-a25c-4b59-9883-bc03b1b55bba" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2de27b67-a25c-4b59-9883-bc03b1b55bba" = false
 
 # facing north increments Y
-"f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8" = false
 
 # facing south decrements Y
-"2786cf80-5bbf-44b0-9503-a89a9c5789da" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2786cf80-5bbf-44b0-9503-a89a9c5789da" = false
 
 # facing east increments X
-"84bf3c8c-241f-434d-883d-69817dbd6a48" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "84bf3c8c-241f-434d-883d-69817dbd6a48" = false
 
 # facing west decrements X
-"bb69c4a7-3bbf-4f64-b415-666fa72d7b04" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bb69c4a7-3bbf-4f64-b415-666fa72d7b04" = false
 
 # moving east and north from README
-"e34ac672-4ed4-4be3-a0b8-d9af259cbaa1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e34ac672-4ed4-4be3-a0b8-d9af259cbaa1" = false
 
 # moving west and north
-"f30e4955-4b47-4aa3-8b39-ae98cfbd515b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f30e4955-4b47-4aa3-8b39-ae98cfbd515b" = false
 
 # moving west and south
-"3e466bf6-20ab-4d79-8b51-264165182fca" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3e466bf6-20ab-4d79-8b51-264165182fca" = false
 
 # moving east and north
-"41f0bb96-c617-4e6b-acff-a4b279d44514" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "41f0bb96-c617-4e6b-acff-a4b279d44514" = false

--- a/exercises/roman-numerals/.meta/tests.toml
+++ b/exercises/roman-numerals/.meta/tests.toml
@@ -1,58 +1,77 @@
 [canonical-tests]
 
 # 1 is a single I
-"19828a3a-fbf7-4661-8ddd-cbaeee0e2178" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "19828a3a-fbf7-4661-8ddd-cbaeee0e2178" = false
 
 # 2 is two I's
-"f088f064-2d35-4476-9a41-f576da3f7b03" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f088f064-2d35-4476-9a41-f576da3f7b03" = false
 
 # 3 is three I's
-"b374a79c-3bea-43e6-8db8-1286f79c7106" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b374a79c-3bea-43e6-8db8-1286f79c7106" = false
 
 # 4, being 5 - 1, is IV
-"05a0a1d4-a140-4db1-82e8-fcc21fdb49bb" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "05a0a1d4-a140-4db1-82e8-fcc21fdb49bb" = false
 
 # 5 is a single V
-"57c0f9ad-5024-46ab-975d-de18c430b290" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "57c0f9ad-5024-46ab-975d-de18c430b290" = false
 
 # 6, being 5 + 1, is VI
-"20a2b47f-e57f-4797-a541-0b3825d7f249" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "20a2b47f-e57f-4797-a541-0b3825d7f249" = false
 
 # 9, being 10 - 1, is IX
-"ff3fb08c-4917-4aab-9f4e-d663491d083d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ff3fb08c-4917-4aab-9f4e-d663491d083d" = false
 
 # 20 is two X's
-"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2bda64ca-7d28-4c56-b08d-16ce65716cf6" = false
 
 # 48 is not 50 - 2 but rather 40 + 8
-"a1f812ef-84da-4e02-b4f0-89c907d0962c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a1f812ef-84da-4e02-b4f0-89c907d0962c" = false
 
 # 49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1
-"607ead62-23d6-4c11-a396-ef821e2e5f75" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "607ead62-23d6-4c11-a396-ef821e2e5f75" = false
 
 # 50 is a single L
-"d5b283d4-455d-4e68-aacf-add6c4b51915" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d5b283d4-455d-4e68-aacf-add6c4b51915" = false
 
 # 90, being 100 - 10, is XC
-"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = false
 
 # 100 is a single C
-"30494be1-9afb-4f84-9d71-db9df18b55e3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "30494be1-9afb-4f84-9d71-db9df18b55e3" = false
 
 # 60, being 50 + 10, is LX
-"267f0207-3c55-459a-b81d-67cec7a46ed9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "267f0207-3c55-459a-b81d-67cec7a46ed9" = false
 
 # 400, being 500 - 100, is CD
-"cdb06885-4485-4d71-8bfb-c9d0f496b404" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "cdb06885-4485-4d71-8bfb-c9d0f496b404" = false
 
 # 500 is a single D
-"6b71841d-13b2-46b4-ba97-dec28133ea80" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6b71841d-13b2-46b4-ba97-dec28133ea80" = false
 
 # 900, being 1000 - 100, is CM
-"432de891-7fd6-4748-a7f6-156082eeca2f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "432de891-7fd6-4748-a7f6-156082eeca2f" = false
 
 # 1000 is a single M
-"e6de6d24-f668-41c0-88d7-889c0254d173" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e6de6d24-f668-41c0-88d7-889c0254d173" = false
 
 # 3000 is three M's
-"bb550038-d4eb-4be2-a9ce-f21961ac3bc6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bb550038-d4eb-4be2-a9ce-f21961ac3bc6" = false

--- a/exercises/rotational-cipher/.meta/tests.toml
+++ b/exercises/rotational-cipher/.meta/tests.toml
@@ -1,22 +1,28 @@
 [canonical-tests]
 
 # rotate a by 0, same output as input
-"74e58a38-e484-43f1-9466-877a7515e10f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "74e58a38-e484-43f1-9466-877a7515e10f" = false
 
 # rotate a by 1
-"7ee352c6-e6b0-4930-b903-d09943ecb8f5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7ee352c6-e6b0-4930-b903-d09943ecb8f5" = false
 
 # rotate a by 26, same output as input
-"edf0a733-4231-4594-a5ee-46a4009ad764" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "edf0a733-4231-4594-a5ee-46a4009ad764" = false
 
 # rotate m by 13
-"e3e82cb9-2a5b-403f-9931-e43213879300" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e3e82cb9-2a5b-403f-9931-e43213879300" = false
 
 # rotate n by 13 with wrap around alphabet
-"19f9eb78-e2ad-4da4-8fe3-9291d47c1709" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "19f9eb78-e2ad-4da4-8fe3-9291d47c1709" = false
 
 # rotate capital letters
-"a116aef4-225b-4da9-884f-e8023ca6408a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a116aef4-225b-4da9-884f-e8023ca6408a" = false
 
 # rotate spaces
 "71b541bb-819c-4dc6-a9c3-132ef9bb737b" = true
@@ -28,4 +34,5 @@
 "32dd74f6-db2b-41a6-b02c-82eb4f93e549" = true
 
 # rotate all letters
-"9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9" = false

--- a/exercises/run-length-encoding/.meta/tests.toml
+++ b/exercises/run-length-encoding/.meta/tests.toml
@@ -1,40 +1,53 @@
 [canonical-tests]
 
 # empty string
-"ad53b61b-6ffc-422f-81a6-61f7df92a231" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ad53b61b-6ffc-422f-81a6-61f7df92a231" = false
 
 # single characters only are encoded without count
-"52012823-b7e6-4277-893c-5b96d42f82de" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "52012823-b7e6-4277-893c-5b96d42f82de" = false
 
 # string with no single characters
-"b7868492-7e3a-415f-8da3-d88f51f80409" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b7868492-7e3a-415f-8da3-d88f51f80409" = false
 
 # single characters mixed with repeated characters
-"859b822b-6e9f-44d6-9c46-6091ee6ae358" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "859b822b-6e9f-44d6-9c46-6091ee6ae358" = false
 
 # multiple whitespace mixed in string
-"1b34de62-e152-47be-bc88-469746df63b3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1b34de62-e152-47be-bc88-469746df63b3" = false
 
 # lowercase characters
-"abf176e2-3fbd-40ad-bb2f-2dd6d4df721a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "abf176e2-3fbd-40ad-bb2f-2dd6d4df721a" = false
 
 # empty string
-"7ec5c390-f03c-4acf-ac29-5f65861cdeb5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7ec5c390-f03c-4acf-ac29-5f65861cdeb5" = false
 
 # single characters only
-"ad23f455-1ac2-4b0e-87d0-b85b10696098" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ad23f455-1ac2-4b0e-87d0-b85b10696098" = false
 
 # string with no single characters
-"21e37583-5a20-4a0e-826c-3dee2c375f54" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "21e37583-5a20-4a0e-826c-3dee2c375f54" = false
 
 # single characters with repeated characters
-"1389ad09-c3a8-4813-9324-99363fba429c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1389ad09-c3a8-4813-9324-99363fba429c" = false
 
 # multiple whitespace mixed in string
-"3f8e3c51-6aca-4670-b86c-a213bf4706b0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3f8e3c51-6aca-4670-b86c-a213bf4706b0" = false
 
 # lower case string
-"29f721de-9aad-435f-ba37-7662df4fb551" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "29f721de-9aad-435f-ba37-7662df4fb551" = false
 
 # encode followed by decode gives original string
-"2a762efd-8695-4e04-b0d6-9736899fbc16" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2a762efd-8695-4e04-b0d6-9736899fbc16" = false

--- a/exercises/saddle-points/.meta/tests.toml
+++ b/exercises/saddle-points/.meta/tests.toml
@@ -1,28 +1,37 @@
 [canonical-tests]
 
 # Can identify single saddle point
-"3e374e63-a2e0-4530-a39a-d53c560382bd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3e374e63-a2e0-4530-a39a-d53c560382bd" = false
 
 # Can identify that empty matrix has no saddle points
-"6b501e2b-6c1f-491f-b1bb-7f278f760534" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6b501e2b-6c1f-491f-b1bb-7f278f760534" = false
 
 # Can identify lack of saddle points when there are none
-"8c27cc64-e573-4fcb-a099-f0ae863fb02f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8c27cc64-e573-4fcb-a099-f0ae863fb02f" = false
 
 # Can identify multiple saddle points in a column
-"6d1399bd-e105-40fd-a2c9-c6609507d7a3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6d1399bd-e105-40fd-a2c9-c6609507d7a3" = false
 
 # Can identify multiple saddle points in a row
-"3e81dce9-53b3-44e6-bf26-e328885fd5d1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3e81dce9-53b3-44e6-bf26-e328885fd5d1" = false
 
 # Can identify saddle point in bottom right corner
-"88868621-b6f4-4837-bb8b-3fad8b25d46b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "88868621-b6f4-4837-bb8b-3fad8b25d46b" = false
 
 # Can identify saddle points in a non square matrix
-"5b9499ca-fcea-4195-830a-9c4584a0ee79" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5b9499ca-fcea-4195-830a-9c4584a0ee79" = false
 
 # Can identify that saddle points in a single column matrix are those with the minimum value
-"ee99ccd2-a1f1-4283-ad39-f8c70f0cf594" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ee99ccd2-a1f1-4283-ad39-f8c70f0cf594" = false
 
 # Can identify that saddle points in a single row matrix are those with the maximum value
-"63abf709-a84b-407f-a1b3-456638689713" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "63abf709-a84b-407f-a1b3-456638689713" = false

--- a/exercises/say/.meta/tests.toml
+++ b/exercises/say/.meta/tests.toml
@@ -13,34 +13,45 @@
 "f541dd8e-f070-4329-92b4-b7ce2fcf06b4" = true
 
 # twenty-two
-"d78601eb-4a84-4bfa-bf0e-665aeb8abe94" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d78601eb-4a84-4bfa-bf0e-665aeb8abe94" = false
 
 # one hundred
-"e417d452-129e-4056-bd5b-6eb1df334dce" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e417d452-129e-4056-bd5b-6eb1df334dce" = false
 
 # one hundred twenty-three
-"d6924f30-80ba-4597-acf6-ea3f16269da8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d6924f30-80ba-4597-acf6-ea3f16269da8" = false
 
 # one thousand
-"3d83da89-a372-46d3-b10d-de0c792432b3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3d83da89-a372-46d3-b10d-de0c792432b3" = false
 
 # one thousand two hundred thirty-four
-"865af898-1d5b-495f-8ff0-2f06d3c73709" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "865af898-1d5b-495f-8ff0-2f06d3c73709" = false
 
 # one million
-"b6a3f442-266e-47a3-835d-7f8a35f6cf7f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b6a3f442-266e-47a3-835d-7f8a35f6cf7f" = false
 
 # one million two thousand three hundred forty-five
-"2cea9303-e77e-4212-b8ff-c39f1978fc70" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2cea9303-e77e-4212-b8ff-c39f1978fc70" = false
 
 # one billion
-"3e240eeb-f564-4b80-9421-db123f66a38f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3e240eeb-f564-4b80-9421-db123f66a38f" = false
 
 # a big number
-"9a43fed1-c875-4710-8286-5065d73b8a9e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9a43fed1-c875-4710-8286-5065d73b8a9e" = false
 
 # numbers below zero are out of range
-"49a6a17b-084e-423e-994d-a87c0ecc05ef" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "49a6a17b-084e-423e-994d-a87c0ecc05ef" = false
 
 # numbers above 999,999,999,999 are out of range
-"4d6492eb-5853-4d16-9d34-b0f61b261fd9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4d6492eb-5853-4d16-9d34-b0f61b261fd9" = false

--- a/exercises/scale-generator/.meta/tests.toml
+++ b/exercises/scale-generator/.meta/tests.toml
@@ -1,43 +1,56 @@
 [canonical-tests]
 
 # Chromatic scale with sharps
-"10ea7b14-8a49-40be-ac55-7c62b55f9b47" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "10ea7b14-8a49-40be-ac55-7c62b55f9b47" = false
 
 # Chromatic scale with flats
-"af8381de-9a72-4efd-823a-48374dbfe76f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "af8381de-9a72-4efd-823a-48374dbfe76f" = false
 
 # Simple major scale
-"6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e" = false
 
 # Major scale with sharps
-"13a92f89-a83e-40b5-b9d4-01136931ba02" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "13a92f89-a83e-40b5-b9d4-01136931ba02" = false
 
 # Major scale with flats
-"aa3320f6-a761-49a1-bcf6-978e0c81080a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "aa3320f6-a761-49a1-bcf6-978e0c81080a" = false
 
 # Minor scale with sharps
-"63daeb2f-c3f9-4c45-92be-5bf97f61ff94" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "63daeb2f-c3f9-4c45-92be-5bf97f61ff94" = false
 
 # Minor scale with flats
-"616594d0-9c48-4301-949e-af1d4fad16fd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "616594d0-9c48-4301-949e-af1d4fad16fd" = false
 
 # Dorian mode
-"390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a" = false
 
 # Mixolydian mode
-"846d0862-0f3e-4f3b-8a2d-9cc74f017848" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "846d0862-0f3e-4f3b-8a2d-9cc74f017848" = false
 
 # Lydian mode
-"7d49a8bb-b5f7-46ad-a207-83bd5032291a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7d49a8bb-b5f7-46ad-a207-83bd5032291a" = false
 
 # Phrygian mode
-"a4e4dac5-1891-4160-a19f-bb06d653d4d0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a4e4dac5-1891-4160-a19f-bb06d653d4d0" = false
 
 # Locrian mode
-"ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa" = false
 
 # Harmonic minor
-"70517400-12b7-4530-b861-fa940ae69ee8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "70517400-12b7-4530-b861-fa940ae69ee8" = false
 
 # Octatonic
 "37114c0b-c54d-45da-9f4b-3848201470b0" = true

--- a/exercises/scrabble-score/.meta/tests.toml
+++ b/exercises/scrabble-score/.meta/tests.toml
@@ -1,34 +1,44 @@
 [canonical-tests]
 
 # lowercase letter
-"f46cda29-1ca5-4ef2-bd45-388a767e3db2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f46cda29-1ca5-4ef2-bd45-388a767e3db2" = false
 
 # uppercase letter
-"f7794b49-f13e-45d1-a933-4e48459b2201" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f7794b49-f13e-45d1-a933-4e48459b2201" = false
 
 # valuable letter
-"eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa" = false
 
 # short word
-"f3c8c94e-bb48-4da2-b09f-e832e103151e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f3c8c94e-bb48-4da2-b09f-e832e103151e" = false
 
 # short, valuable word
-"71e3d8fa-900d-4548-930e-68e7067c4615" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "71e3d8fa-900d-4548-930e-68e7067c4615" = false
 
 # medium word
 "d3088ad9-570c-4b51-8764-c75d5a430e99" = true
 
 # medium, valuable word
-"fa20c572-ad86-400a-8511-64512daac352" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "fa20c572-ad86-400a-8511-64512daac352" = false
 
 # long, mixed-case word
-"9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967" = false
 
 # english-like word
-"1e34e2c3-e444-4ea7-b598-3c2b46fd2c10" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1e34e2c3-e444-4ea7-b598-3c2b46fd2c10" = false
 
 # empty input
-"4efe3169-b3b6-4334-8bae-ff4ef24a7e4f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4efe3169-b3b6-4334-8bae-ff4ef24a7e4f" = false
 
 # entire alphabet available
-"3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7" = false

--- a/exercises/series/.meta/tests.toml
+++ b/exercises/series/.meta/tests.toml
@@ -1,31 +1,41 @@
 [canonical-tests]
 
 # slices of one from one
-"7ae7a46a-d992-4c2a-9c15-a112d125ebad" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7ae7a46a-d992-4c2a-9c15-a112d125ebad" = false
 
 # slices of one from two
-"3143b71d-f6a5-4221-aeae-619f906244d2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3143b71d-f6a5-4221-aeae-619f906244d2" = false
 
 # slices of two
-"dbb68ff5-76c5-4ccd-895a-93dbec6d5805" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "dbb68ff5-76c5-4ccd-895a-93dbec6d5805" = false
 
 # slices of two overlap
-"19bbea47-c987-4e11-a7d1-e103442adf86" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "19bbea47-c987-4e11-a7d1-e103442adf86" = false
 
 # slices can include duplicates
-"8e17148d-ba0a-4007-a07f-d7f87015d84c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8e17148d-ba0a-4007-a07f-d7f87015d84c" = false
 
 # slices of a long series
-"bd5b085e-f612-4f81-97a8-6314258278b0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "bd5b085e-f612-4f81-97a8-6314258278b0" = false
 
 # slice length is too large
-"6d235d85-46cf-4fae-9955-14b6efef27cd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6d235d85-46cf-4fae-9955-14b6efef27cd" = false
 
 # slice length cannot be zero
-"d34004ad-8765-4c09-8ba1-ada8ce776806" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d34004ad-8765-4c09-8ba1-ada8ce776806" = false
 
 # slice length cannot be negative
-"10ab822d-8410-470a-a85d-23fbeb549e54" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "10ab822d-8410-470a-a85d-23fbeb549e54" = false
 
 # empty series is invalid
-"c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2" = false

--- a/exercises/sieve/.meta/tests.toml
+++ b/exercises/sieve/.meta/tests.toml
@@ -1,16 +1,20 @@
 [canonical-tests]
 
 # no primes under two
-"88529125-c4ce-43cc-bb36-1eb4ddd7b44f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "88529125-c4ce-43cc-bb36-1eb4ddd7b44f" = false
 
 # find first prime
-"4afe9474-c705-4477-9923-840e1024cc2b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "4afe9474-c705-4477-9923-840e1024cc2b" = false
 
 # find primes up to 10
-"974945d8-8cd9-4f00-9463-7d813c7f17b7" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "974945d8-8cd9-4f00-9463-7d813c7f17b7" = false
 
 # limit is prime
 "2e2417b7-3f3a-452a-8594-b9af08af6d82" = true
 
 # find primes up to 1000
-"92102a05-4c7c-47de-9ed0-b7d5fcd00f21" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "92102a05-4c7c-47de-9ed0-b7d5fcd00f21" = false

--- a/exercises/simple-cipher/.meta/tests.toml
+++ b/exercises/simple-cipher/.meta/tests.toml
@@ -1,37 +1,49 @@
 [canonical-tests]
 
 # Can encode
-"b8bdfbe1-bea3-41bb-a999-b41403f2b15d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b8bdfbe1-bea3-41bb-a999-b41403f2b15d" = false
 
 # Can decode
-"3dff7f36-75db-46b4-ab70-644b3f38b81c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3dff7f36-75db-46b4-ab70-644b3f38b81c" = false
 
 # Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method
-"8143c684-6df6-46ba-bd1f-dea8fcb5d265" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8143c684-6df6-46ba-bd1f-dea8fcb5d265" = false
 
 # Key is made only of lowercase letters
-"defc0050-e87d-4840-85e4-51a1ab9dd6aa" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "defc0050-e87d-4840-85e4-51a1ab9dd6aa" = false
 
 # Can encode
-"565e5158-5b3b-41dd-b99d-33b9f413c39f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "565e5158-5b3b-41dd-b99d-33b9f413c39f" = false
 
 # Can decode
-"d44e4f6a-b8af-4e90-9d08-fd407e31e67b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d44e4f6a-b8af-4e90-9d08-fd407e31e67b" = false
 
 # Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method
-"70a16473-7339-43df-902d-93408c69e9d1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "70a16473-7339-43df-902d-93408c69e9d1" = false
 
 # Can double shift encode
-"69a1458b-92a6-433a-a02d-7beac3ea91f9" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "69a1458b-92a6-433a-a02d-7beac3ea91f9" = false
 
 # Can wrap on encode
-"21d207c1-98de-40aa-994f-86197ae230fb" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "21d207c1-98de-40aa-994f-86197ae230fb" = false
 
 # Can wrap on decode
-"a3d7a4d7-24a9-4de6-bdc4-a6614ced0cb3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a3d7a4d7-24a9-4de6-bdc4-a6614ced0cb3" = false
 
 # Can encode messages longer than the key
-"e31c9b8c-8eb6-45c9-a4b5-8344a36b9641" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e31c9b8c-8eb6-45c9-a4b5-8344a36b9641" = false
 
 # Can decode messages longer than the key
-"93cfaae0-17da-4627-9a04-d6d1e1be52e3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "93cfaae0-17da-4627-9a04-d6d1e1be52e3" = false

--- a/exercises/space-age/.meta/tests.toml
+++ b/exercises/space-age/.meta/tests.toml
@@ -1,25 +1,33 @@
 [canonical-tests]
 
 # age on Earth
-"84f609af-5a91-4d68-90a3-9e32d8a5cd34" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "84f609af-5a91-4d68-90a3-9e32d8a5cd34" = false
 
 # age on Mercury
-"ca20c4e9-6054-458c-9312-79679ffab40b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ca20c4e9-6054-458c-9312-79679ffab40b" = false
 
 # age on Venus
-"502c6529-fd1b-41d3-8fab-65e03082b024" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "502c6529-fd1b-41d3-8fab-65e03082b024" = false
 
 # age on Mars
-"9ceadf5e-a0d5-4388-9d40-2c459227ceb8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "9ceadf5e-a0d5-4388-9d40-2c459227ceb8" = false
 
 # age on Jupiter
-"42927dc3-fe5e-4f76-a5b5-f737fc19bcde" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "42927dc3-fe5e-4f76-a5b5-f737fc19bcde" = false
 
 # age on Saturn
-"8469b332-7837-4ada-b27c-00ee043ebcad" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8469b332-7837-4ada-b27c-00ee043ebcad" = false
 
 # age on Uranus
-"999354c1-76f8-4bb5-a672-f317b6436743" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "999354c1-76f8-4bb5-a672-f317b6436743" = false
 
 # age on Neptune
-"80096d30-a0d4-4449-903e-a381178355d8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "80096d30-a0d4-4449-903e-a381178355d8" = false

--- a/exercises/spiral-matrix/.meta/tests.toml
+++ b/exercises/spiral-matrix/.meta/tests.toml
@@ -4,16 +4,21 @@
 "8f584201-b446-4bc9-b132-811c8edd9040" = true
 
 # trivial spiral
-"e40ae5f3-e2c9-4639-8116-8a119d632ab2" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e40ae5f3-e2c9-4639-8116-8a119d632ab2" = false
 
 # spiral of size 2
-"cf05e42d-eb78-4098-a36e-cdaf0991bc48" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "cf05e42d-eb78-4098-a36e-cdaf0991bc48" = false
 
 # spiral of size 3
-"1c475667-c896-4c23-82e2-e033929de939" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1c475667-c896-4c23-82e2-e033929de939" = false
 
 # spiral of size 4
-"05ccbc48-d891-44f5-9137-f4ce462a759d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "05ccbc48-d891-44f5-9137-f4ce462a759d" = false
 
 # spiral of size 5
-"f4d2165b-1738-4e0c-bed0-c459045ae50d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f4d2165b-1738-4e0c-bed0-c459045ae50d" = false

--- a/exercises/sublist/.meta/tests.toml
+++ b/exercises/sublist/.meta/tests.toml
@@ -1,28 +1,36 @@
 [canonical-tests]
 
 # empty lists
-"97319c93-ebc5-47ab-a022-02a1980e1d29" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "97319c93-ebc5-47ab-a022-02a1980e1d29" = false
 
 # empty list within non empty list
-"de27dbd4-df52-46fe-a336-30be58457382" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "de27dbd4-df52-46fe-a336-30be58457382" = false
 
 # non empty list contains empty list
-"5487cfd1-bc7d-429f-ac6f-1177b857d4fb" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5487cfd1-bc7d-429f-ac6f-1177b857d4fb" = false
 
 # list equals itself
-"1f390b47-f6b2-4a93-bc23-858ba5dda9a6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1f390b47-f6b2-4a93-bc23-858ba5dda9a6" = false
 
 # different lists
-"7ed2bfb2-922b-4363-ae75-f3a05e8274f5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7ed2bfb2-922b-4363-ae75-f3a05e8274f5" = false
 
 # false start
-"3b8a2568-6144-4f06-b0a1-9d266b365341" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3b8a2568-6144-4f06-b0a1-9d266b365341" = false
 
 # consecutive
-"dc39ed58-6311-4814-be30-05a64bc8d9b1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "dc39ed58-6311-4814-be30-05a64bc8d9b1" = false
 
 # sublist at start
-"d1270dab-a1ce-41aa-b29d-b3257241ac26" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d1270dab-a1ce-41aa-b29d-b3257241ac26" = false
 
 # sublist in middle
 "81f3d3f7-4f25-4ada-bcdc-897c403de1b6" = true
@@ -31,22 +39,29 @@
 "43bcae1e-a9cf-470e-923e-0946e04d8fdd" = true
 
 # at start of superlist
-"76cf99ed-0ff0-4b00-94af-4dfb43fe5caa" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "76cf99ed-0ff0-4b00-94af-4dfb43fe5caa" = false
 
 # in middle of superlist
-"b83989ec-8bdf-4655-95aa-9f38f3e357fd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b83989ec-8bdf-4655-95aa-9f38f3e357fd" = false
 
 # at end of superlist
-"26f9f7c3-6cf6-4610-984a-662f71f8689b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "26f9f7c3-6cf6-4610-984a-662f71f8689b" = false
 
 # first list missing element from second list
-"0a6db763-3588-416a-8f47-76b1cedde31e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0a6db763-3588-416a-8f47-76b1cedde31e" = false
 
 # second list missing element from first list
-"83ffe6d8-a445-4a3c-8795-1e51a95e65c3" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "83ffe6d8-a445-4a3c-8795-1e51a95e65c3" = false
 
 # order matters to a list
-"0d7ee7c1-0347-45c8-9ef5-b88db152b30b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0d7ee7c1-0347-45c8-9ef5-b88db152b30b" = false
 
 # same digits but different numbers
-"5f47ce86-944e-40f9-9f31-6368aad70aa6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5f47ce86-944e-40f9-9f31-6368aad70aa6" = false

--- a/exercises/sum-of-multiples/.meta/tests.toml
+++ b/exercises/sum-of-multiples/.meta/tests.toml
@@ -46,4 +46,5 @@
 "c423ae21-a0cb-4ec7-aeb1-32971af5b510" = true
 
 # solutions using include-exclude must extend to cardinality greater than 3
-"17053ba9-112f-4ac0-aadb-0519dd836342" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "17053ba9-112f-4ac0-aadb-0519dd836342" = false

--- a/exercises/triangle/.meta/tests.toml
+++ b/exercises/triangle/.meta/tests.toml
@@ -1,58 +1,77 @@
 [canonical-tests]
 
 # all sides are equal
-"8b2c43ac-7257-43f9-b552-7631a91988af" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8b2c43ac-7257-43f9-b552-7631a91988af" = false
 
 # any side is unequal
-"33eb6f87-0498-4ccf-9573-7f8c3ce92b7b" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "33eb6f87-0498-4ccf-9573-7f8c3ce92b7b" = false
 
 # no sides are equal
-"c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87" = false
 
 # all zero sides is not a triangle
-"16e8ceb0-eadb-46d1-b892-c50327479251" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "16e8ceb0-eadb-46d1-b892-c50327479251" = false
 
 # sides may be floats
-"3022f537-b8e5-4cc1-8f12-fd775827a00c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3022f537-b8e5-4cc1-8f12-fd775827a00c" = false
 
 # last two sides are equal
-"cbc612dc-d75a-4c1c-87fc-e2d5edd70b71" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "cbc612dc-d75a-4c1c-87fc-e2d5edd70b71" = false
 
 # first two sides are equal
-"e388ce93-f25e-4daf-b977-4b7ede992217" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e388ce93-f25e-4daf-b977-4b7ede992217" = false
 
 # first and last sides are equal
-"d2080b79-4523-4c3f-9d42-2da6e81ab30f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d2080b79-4523-4c3f-9d42-2da6e81ab30f" = false
 
 # equilateral triangles are also isosceles
-"8d71e185-2bd7-4841-b7e1-71689a5491d8" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8d71e185-2bd7-4841-b7e1-71689a5491d8" = false
 
 # no sides are equal
-"840ed5f8-366f-43c5-ac69-8f05e6f10bbb" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "840ed5f8-366f-43c5-ac69-8f05e6f10bbb" = false
 
 # first triangle inequality violation
-"2eba0cfb-6c65-4c40-8146-30b608905eae" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2eba0cfb-6c65-4c40-8146-30b608905eae" = false
 
 # second triangle inequality violation
-"278469cb-ac6b-41f0-81d4-66d9b828f8ac" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "278469cb-ac6b-41f0-81d4-66d9b828f8ac" = false
 
 # third triangle inequality violation
-"90efb0c7-72bb-4514-b320-3a3892e278ff" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "90efb0c7-72bb-4514-b320-3a3892e278ff" = false
 
 # sides may be floats
-"adb4ee20-532f-43dc-8d31-e9271b7ef2bc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "adb4ee20-532f-43dc-8d31-e9271b7ef2bc" = false
 
 # no sides are equal
-"e8b5f09c-ec2e-47c1-abec-f35095733afb" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e8b5f09c-ec2e-47c1-abec-f35095733afb" = false
 
 # all sides are equal
-"2510001f-b44d-4d18-9872-2303e7977dc1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2510001f-b44d-4d18-9872-2303e7977dc1" = false
 
 # two sides are equal
-"c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e" = false
 
 # may not violate triangle inequality
-"70ad5154-0033-48b7-af2c-b8d739cd9fdc" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "70ad5154-0033-48b7-af2c-b8d739cd9fdc" = false
 
 # sides may be floats
-"26d9d59d-f8f1-40d3-ad58-ae4d54123d7d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "26d9d59d-f8f1-40d3-ad58-ae4d54123d7d" = false

--- a/exercises/two-bucket/.meta/tests.toml
+++ b/exercises/two-bucket/.meta/tests.toml
@@ -1,19 +1,25 @@
 [canonical-tests]
 
 # Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one
-"a6f2b4ba-065f-4dca-b6f0-e3eee51cb661" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a6f2b4ba-065f-4dca-b6f0-e3eee51cb661" = false
 
 # Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two
-"6c4ea451-9678-4926-b9b3-68364e066d40" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "6c4ea451-9678-4926-b9b3-68364e066d40" = false
 
 # Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one
-"3389f45e-6a56-46d5-9607-75aa930502ff" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3389f45e-6a56-46d5-9607-75aa930502ff" = false
 
 # Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two
-"fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1" = false
 
 # Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two
-"0ee1f57e-da84-44f7-ac91-38b878691602" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "0ee1f57e-da84-44f7-ac91-38b878691602" = false
 
 # Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two
-"eb329c63-5540-4735-b30b-97f7f4df0f84" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "eb329c63-5540-4735-b30b-97f7f4df0f84" = false

--- a/exercises/two-fer/.meta/tests.toml
+++ b/exercises/two-fer/.meta/tests.toml
@@ -1,10 +1,13 @@
 [canonical-tests]
 
 # no name given
-"1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce" = false
 
 # a name given
-"b4c6dbb8-b4fb-42c2-bafd-10785abe7709" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "b4c6dbb8-b4fb-42c2-bafd-10785abe7709" = false
 
 # another name given
-"3549048d-1a6e-4653-9a79-b0bda163e8d5" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3549048d-1a6e-4653-9a79-b0bda163e8d5" = false

--- a/exercises/variable-length-quantity/.meta/tests.toml
+++ b/exercises/variable-length-quantity/.meta/tests.toml
@@ -1,79 +1,105 @@
 [canonical-tests]
 
 # zero
-"35c9db2e-f781-4c52-b73b-8e76427defd0" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "35c9db2e-f781-4c52-b73b-8e76427defd0" = false
 
 # arbitrary single byte
-"be44d299-a151-4604-a10e-d4b867f41540" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "be44d299-a151-4604-a10e-d4b867f41540" = false
 
 # largest single byte
-"ea399615-d274-4af6-bbef-a1c23c9e1346" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "ea399615-d274-4af6-bbef-a1c23c9e1346" = false
 
 # smallest double byte
-"77b07086-bd3f-4882-8476-8dcafee79b1c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "77b07086-bd3f-4882-8476-8dcafee79b1c" = false
 
 # arbitrary double byte
-"63955a49-2690-4e22-a556-0040648d6b2d" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "63955a49-2690-4e22-a556-0040648d6b2d" = false
 
 # largest double byte
-"29da7031-0067-43d3-83a7-4f14b29ed97a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "29da7031-0067-43d3-83a7-4f14b29ed97a" = false
 
 # smallest triple byte
-"3345d2e3-79a9-4999-869e-d4856e3a8e01" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3345d2e3-79a9-4999-869e-d4856e3a8e01" = false
 
 # arbitrary triple byte
-"5df0bc2d-2a57-4300-a653-a75ee4bd0bee" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5df0bc2d-2a57-4300-a653-a75ee4bd0bee" = false
 
 # largest triple byte
-"f51d8539-312d-4db1-945c-250222c6aa22" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f51d8539-312d-4db1-945c-250222c6aa22" = false
 
 # smallest quadruple byte
-"da78228b-544f-47b7-8bfe-d16b35bbe570" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "da78228b-544f-47b7-8bfe-d16b35bbe570" = false
 
 # arbitrary quadruple byte
-"11ed3469-a933-46f1-996f-2231e05d7bb6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "11ed3469-a933-46f1-996f-2231e05d7bb6" = false
 
 # largest quadruple byte
-"d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c" = false
 
 # smallest quintuple byte
-"91a18b33-24e7-4bfb-bbca-eca78ff4fc47" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "91a18b33-24e7-4bfb-bbca-eca78ff4fc47" = false
 
 # arbitrary quintuple byte
-"5f34ff12-2952-4669-95fe-2d11b693d331" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5f34ff12-2952-4669-95fe-2d11b693d331" = false
 
 # maximum 32-bit integer input
-"7489694b-88c3-4078-9864-6fe802411009" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7489694b-88c3-4078-9864-6fe802411009" = false
 
 # two single-byte values
-"f9b91821-cada-4a73-9421-3c81d6ff3661" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "f9b91821-cada-4a73-9421-3c81d6ff3661" = false
 
 # two multi-byte values
-"68694449-25d2-4974-ba75-fa7bb36db212" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "68694449-25d2-4974-ba75-fa7bb36db212" = false
 
 # many multi-byte values
-"51a06b5c-de1b-4487-9a50-9db1b8930d85" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "51a06b5c-de1b-4487-9a50-9db1b8930d85" = false
 
 # one byte
-"baa73993-4514-4915-bac0-f7f585e0e59a" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "baa73993-4514-4915-bac0-f7f585e0e59a" = false
 
 # two bytes
-"72e94369-29f9-46f2-8c95-6c5b7a595aee" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "72e94369-29f9-46f2-8c95-6c5b7a595aee" = false
 
 # three bytes
-"df5a44c4-56f7-464e-a997-1db5f63ce691" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "df5a44c4-56f7-464e-a997-1db5f63ce691" = false
 
 # four bytes
-"1bb58684-f2dc-450a-8406-1f3452aa1947" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "1bb58684-f2dc-450a-8406-1f3452aa1947" = false
 
 # maximum 32-bit integer
-"cecd5233-49f1-4dd1-a41a-9840a40f09cd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "cecd5233-49f1-4dd1-a41a-9840a40f09cd" = false
 
 # incomplete sequence causes error
-"e7d74ba3-8b8e-4bcb-858d-d08302e15695" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e7d74ba3-8b8e-4bcb-858d-d08302e15695" = false
 
 # incomplete sequence causes error, even if value is zero
-"aa378291-9043-4724-bc53-aca1b4a3fcb6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "aa378291-9043-4724-bc53-aca1b4a3fcb6" = false
 
 # multiple values
-"a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee" = false

--- a/exercises/word-count/.meta/tests.toml
+++ b/exercises/word-count/.meta/tests.toml
@@ -1,28 +1,36 @@
 [canonical-tests]
 
 # count one word
-"61559d5f-2cad-48fb-af53-d3973a9ee9ef" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "61559d5f-2cad-48fb-af53-d3973a9ee9ef" = false
 
 # count one of each word
-"5abd53a3-1aed-43a4-a15a-29f88c09cbbd" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "5abd53a3-1aed-43a4-a15a-29f88c09cbbd" = false
 
 # multiple occurrences of a word
-"2a3091e5-952e-4099-9fac-8f85d9655c0e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "2a3091e5-952e-4099-9fac-8f85d9655c0e" = false
 
 # handles cramped lists
-"e81877ae-d4da-4af4-931c-d923cd621ca6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "e81877ae-d4da-4af4-931c-d923cd621ca6" = false
 
 # handles expanded lists
-"7349f682-9707-47c0-a9af-be56e1e7ff30" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "7349f682-9707-47c0-a9af-be56e1e7ff30" = false
 
 # ignore punctuation
-"a514a0f2-8589-4279-8892-887f76a14c82" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "a514a0f2-8589-4279-8892-887f76a14c82" = false
 
 # include numbers
-"d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e" = false
 
 # normalize case
-"dac6bc6a-21ae-4954-945d-d7f716392dbf" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "dac6bc6a-21ae-4954-945d-d7f716392dbf" = false
 
 # with apostrophes
 "4185a902-bdb0-4074-864c-f416e42a0f19" = true
@@ -31,10 +39,12 @@
 "be72af2b-8afe-4337-b151-b297202e4a7b" = true
 
 # substrings from the beginning
-"8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6" = false
 
 # multiple spaces not detected as a word
 "c5f4ef26-f3f7-4725-b314-855c04fb4c13" = true
 
 # alternating word separators not detected as a word
-"50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360" = false

--- a/exercises/wordy/.meta/tests.toml
+++ b/exercises/wordy/.meta/tests.toml
@@ -37,13 +37,15 @@
 "4f4a5749-ef0c-4f60-841f-abcfaf05d2ae" = true
 
 # multiple multiplication
-"312d908c-f68f-42c9-aa75-961623cc033f" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "312d908c-f68f-42c9-aa75-961623cc033f" = false
 
 # addition and multiplication
 "38e33587-8940-4cc1-bc28-bfd7e3966276" = true
 
 # multiple division
-"3c854f97-9311-46e8-b574-92b60d17d394" = false
+# this test may not be in the suite but has not been intentionally rejected
+# "3c854f97-9311-46e8-b574-92b60d17d394" = false
 
 # unknown operation
 "3ad3e433-8af7-41ec-aa9b-97b42ab49357" = true


### PR DESCRIPTION
Per [slack](https://exercism-team.slack.com/archives/CR91YFNG3/p1602838984216700?thread_ts=1602837142.216600&cid=CR91YFNG3), `tests.toml` has these semantics:

- a test whose uuid's value is `true` has been implemented in the test suite
- a test whose uuid's value is `false` has been rejected for the test suite
- a test whose uuid is missing from `tests.toml` is new, and has been neither
  approved nor rejected.

Before, the assumption was that no tests in the suite were rejected.
Therefore, it is not appropriate for any test to be labeled `false`.
Therefore, we comment out those lines by this script:

```bash
fd -uutf tests.toml -x \
    sed -E -i -e '/"?[-a-zA-Z0-9]+"? = false/ {
        i '\#' this test may not be in the suite but has not been intentionally rejected
        s/^/# /
    }'
```