### PR TITLE
Clippy says to remove `use leap;` at the beginning

### DIFF
--- a/exercises/leap/tests/leap.rs
+++ b/exercises/leap/tests/leap.rs
@@ -1,5 +1,3 @@
-use leap;
-
 fn process_leapyear_case(year: u64, expected: bool) {
     assert_eq!(leap::is_leap_year(year), expected);
 }


### PR DESCRIPTION
```
warning: this import is redundant
 --> tests/leap.rs:1:1
  |
1 | use leap;
  | ^^^^^^^^^ help: remove it entirely
  |
  = note: `#[warn(clippy::single_component_path_imports)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports

warning: 1 warning emitted
```