### PR TITLE
Correct lifetimes in anagrams_for signature

### DIFF
--- a/exercises/anagram/src/lib.rs
+++ b/exercises/anagram/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-pub fn anagrams_for<'a>(word: &str, possible_anagrams: &[&str]) -> HashSet<&'a str> {
+pub fn anagrams_for<'a>(word: &str, possible_anagrams: &[&'a str]) -> HashSet<&'a str> {
     unimplemented!(
         "For the '{}' word find anagrams among the following words: {:?}",
         word,


### PR DESCRIPTION
A completed solution will otherwise fail to compile, since the `HashSet` that's returned uses the `&str` references from within `possible_anagrams`.

The proposed signature is also used in [the example solution](https://github.com/exercism/rust/blob/d536862ce3eeaf2fe891e62160bb245f7a8ee79a/exercises/anagram/example.rs#L9).