### PR TITLE
anagram: add hint that lifetime errors are expected

### DIFF
--- a/exercises/anagram/.meta/hints.md
+++ b/exercises/anagram/.meta/hints.md
@@ -3,3 +3,5 @@
 The solution is case insensitive, which means `"WOrd"` is the same as `"word"` or `"woRd"`. It may help to take a peek at the [std library](https://doc.rust-lang.org/std/primitive.char.html) for functions that can convert between them.
 
 The solution cannot contain the input word. A word is always an anagram of itself, which means it is not an interesting result. Given `"hello"` and the list `["hello", "olleh"]` the answer is `["olleh"]`.
+
+You are going to have to adjust the function signature provided in the stub in order for the lifetimes to work out properly. This is intentional: what's there demonstrates the basics of lifetime syntax, and what's missing teaches how to interpret lifetime-related compiler errors.

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -13,6 +13,8 @@ The solution is case insensitive, which means `"WOrd"` is the same as `"word"` o
 
 The solution cannot contain the input word. A word is always an anagram of itself, which means it is not an interesting result. Given `"hello"` and the list `["hello", "olleh"]` the answer is `["olleh"]`.
 
+You are going to have to adjust the function signature provided in the stub in order for the lifetimes to work out properly. This is intentional: what's there demonstrates the basics of lifetime syntax, and what's missing teaches how to interpret lifetime-related compiler errors.
+
 
 ## Rust Installation
 


### PR DESCRIPTION
We've had several instances, most recently #988, of students opening issues or pull requests addressing the fact that the function signature in the stub of anagram is insufficient for a real implementation in the compiler. This PR should make it more clear that this is an intentional learning point.