### PR TITLE
Fix anagram.rs to be in line with clippy

### DIFF
--- a/exercises/anagram/tests/anagram.rs
+++ b/exercises/anagram/tests/anagram.rs
@@ -1,5 +1,3 @@
-use anagram;
-
 use std::collections::HashSet;
 use std::iter::FromIterator;
 


### PR DESCRIPTION
```
    Checking anagram v0.0.0 (/home/rmason/code/exercism/rust/anagram)
warning: this import is redundant
 --> tests/anagram.rs:1:1
  |
1 | use anagram;
  | ^^^^^^^^^^^^ help: remove it entirely
  |
  = note: `#[warn(clippy::single_component_path_imports)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports

warning: 1 warning emitted

    Finished dev [unoptimized + debuginfo] target(s) in 0.41s
```