### PR TITLE
Remove all `single_component_path_imports` from tests

### DIFF
--- a/exercises/acronym/tests/acronym.rs
+++ b/exercises/acronym/tests/acronym.rs
@@ -1,5 +1,3 @@
-use acronym;
-
 #[test]
 fn empty() {
     assert_eq!(acronym::abbreviate(""), "");

--- a/exercises/alphametics/tests/alphametics.rs
+++ b/exercises/alphametics/tests/alphametics.rs
@@ -1,4 +1,3 @@
-use alphametics;
 use std::collections::HashMap;
 
 fn assert_alphametic_solution_eq(puzzle: &str, solution: &[(char, u8)]) {

--- a/exercises/dominoes/tests/dominoes.rs
+++ b/exercises/dominoes/tests/dominoes.rs
@@ -1,5 +1,3 @@
-use dominoes;
-
 use crate::CheckResult::*;
 
 type Domino = (u8, u8);

--- a/exercises/etl/tests/etl.rs
+++ b/exercises/etl/tests/etl.rs
@@ -1,5 +1,3 @@
-use etl;
-
 use std::collections::BTreeMap;
 
 #[test]

--- a/exercises/grains/tests/grains.rs
+++ b/exercises/grains/tests/grains.rs
@@ -1,5 +1,3 @@
-use grains;
-
 fn process_square_case(input: u32, expected: u64) {
     assert_eq!(grains::square(input), expected);
 }

--- a/exercises/hamming/tests/hamming.rs
+++ b/exercises/hamming/tests/hamming.rs
@@ -1,5 +1,3 @@
-use hamming;
-
 fn process_distance_case(strand_pair: [&str; 2], expected_distance: Option<usize>) {
     assert_eq!(
         hamming::hamming_distance(strand_pair[0], strand_pair[1]),

--- a/exercises/hello-world/tests/hello-world.rs
+++ b/exercises/hello-world/tests/hello-world.rs
@@ -1,5 +1,3 @@
-use hello_world;
-
 #[test]
 fn test_hello_world() {
     assert_eq!("Hello, World!", hello_world::hello());

--- a/exercises/paasio/tests/paasio.rs
+++ b/exercises/paasio/tests/paasio.rs
@@ -1,5 +1,3 @@
-use paasio;
-
 /// test a few read scenarios
 macro_rules! test_read {
     ($(#[$attr:meta])* $modname:ident ($input:expr, $len:expr)) => {

--- a/exercises/raindrops/tests/raindrops.rs
+++ b/exercises/raindrops/tests/raindrops.rs
@@ -1,5 +1,3 @@
-use raindrops;
-
 #[test]
 fn test_1() {
     assert_eq!("1", raindrops::raindrops(1));

--- a/exercises/saddle-points/tests/saddle-points.rs
+++ b/exercises/saddle-points/tests/saddle-points.rs
@@ -1,5 +1,3 @@
-use saddle_points;
-
 use saddle_points::find_saddle_points;
 
 // We don't care about order

--- a/exercises/say/tests/say.rs
+++ b/exercises/say/tests/say.rs
@@ -1,5 +1,3 @@
-use say;
-
 // Note: No tests created using 'and' with numbers.
 // Apparently Most American English does not use the 'and' with numbers,
 // where it is common in British English to use the 'and'.

--- a/exercises/sieve/tests/sieve.rs
+++ b/exercises/sieve/tests/sieve.rs
@@ -1,5 +1,3 @@
-use sieve;
-
 #[test]
 fn limit_lower_than_the_first_prime() {
     assert_eq!(sieve::primes_up_to(1), []);

--- a/exercises/tournament/tests/tournament.rs
+++ b/exercises/tournament/tests/tournament.rs
@@ -1,5 +1,3 @@
-use tournament;
-
 #[test]
 fn just_the_header_if_no_input() {
     let input = "";

--- a/exercises/word-count/tests/word-count.rs
+++ b/exercises/word-count/tests/word-count.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use word_count;
-
 fn check_word_count(s: &str, pairs: &[(&str, u32)]) {
     // The reason for the awkward code in here is to ensure that the failure
     // message for assert_eq! is as informative as possible. A simpler


### PR DESCRIPTION
I started removing some of these one by one and figured it would be
useful to just automate it:
```
rmason@thincrust ~/code/rust-exercises/exercises (master)$ find . | awk -F/ '$3 ~/Cargo.toml/ {print $2}' | while read dir; do pushd $dir; cargo clean; cargo clippy --tests -- -A clippy::all -W clippy::single_component_path_imports; popd; done 2>&1 | grep -A1 -i "warning: this import" | grep tests
 --> tests/etl.rs:1:1
 --> tests/grains.rs:1:1
 --> tests/alphametics.rs:1:1
 --> tests/say.rs:1:1
 --> tests/acronym.rs:1:1
 --> tests/hamming.rs:1:1
 --> tests/sieve.rs:1:1
 --> tests/paasio.rs:1:1
 --> tests/saddle-points.rs:1:1
 --> tests/tournament.rs:1:1
 --> tests/hello-world.rs:1:1
 --> tests/word-count.rs:3:1
 --> tests/dominoes.rs:1:1
 --> tests/raindrops.rs:1:1
```