### PR TITLE
Add a test to construct clock with negative 120 minutes

### DIFF
--- a/exercises/clock/tests/clock.rs
+++ b/exercises/clock/tests/clock.rs
@@ -114,7 +114,7 @@ fn test_negative_sixty_minutes_is_prev_hour() {
 #[test]
 #[ignore]
 fn test_negative_one_twenty_minutes_is_two_prev_hours() {
-    assert_eq!(Clock::new(2, -120).to_string(), "00:00");
+    assert_eq!(Clock::new(1, -120).to_string(), "23:00");
 }
 
 #[test]

--- a/exercises/clock/tests/clock.rs
+++ b/exercises/clock/tests/clock.rs
@@ -113,6 +113,12 @@ fn test_negative_sixty_minutes_is_prev_hour() {
 
 #[test]
 #[ignore]
+fn test_negative_one_twenty_minutes_is_two_prev_hours() {
+    assert_eq!(Clock::new(2, -120).to_string(), "00:00");
+}
+
+#[test]
+#[ignore]
 fn test_negative_hour_and_minutes_both_roll_over() {
     assert_eq!(Clock::new(-25, -160).to_string(), "20:20");
 }


### PR DESCRIPTION
During my own exercising found an edge case in my code where I handled subtracting 60 minutes but not any of the multiples of 60 minutes, so adding a test hoping it will help others too