### PR TITLE
[parallel-letter-frequency]: Clippy says to use resize or static creation

### DIFF
--- a/exercises/parallel-letter-frequency/tests/parallel-letter-frequency.rs
+++ b/exercises/parallel-letter-frequency/tests/parallel-letter-frequency.rs
@@ -62,16 +62,14 @@ fn test_case_insensitivity() {
 #[test]
 #[ignore]
 fn test_many_empty_lines() {
-    let mut v = Vec::with_capacity(1000);
-    v.resize(1000,"");
+    let v = vec![""; 1000];
     assert_eq!(frequency::frequency(&v[..], 4), HashMap::new());
 }
 
 #[test]
 #[ignore]
 fn test_many_times_same_text() {
-    let mut v = Vec::with_capacity(1000);
-    v.resize(1000, "abc");
+    let v = vec!["abc"; 1000];
     let mut hm = HashMap::new();
     hm.insert('a', 1000);
     hm.insert('b', 1000);

--- a/exercises/parallel-letter-frequency/tests/parallel-letter-frequency.rs
+++ b/exercises/parallel-letter-frequency/tests/parallel-letter-frequency.rs
@@ -63,9 +63,7 @@ fn test_case_insensitivity() {
 #[ignore]
 fn test_many_empty_lines() {
     let mut v = Vec::with_capacity(1000);
-    for _ in 0..1000 {
-        v.push("");
-    }
+    v.resize(1000,"");
     assert_eq!(frequency::frequency(&v[..], 4), HashMap::new());
 }
 
@@ -73,9 +71,7 @@ fn test_many_empty_lines() {
 #[ignore]
 fn test_many_times_same_text() {
     let mut v = Vec::with_capacity(1000);
-    for _ in 0..1000 {
-        v.push("abc");
-    }
+    v.resize(1000, "abc");
     let mut hm = HashMap::new();
     hm.insert('a', 1000);
     hm.insert('b', 1000);


### PR DESCRIPTION
For cases with identical data, the for loop is not needed