### PR TITLE
dominoes, saddle-points: sort_unstable instead of sort

### DIFF
--- a/exercises/dominoes/tests/dominoes.rs
+++ b/exercises/dominoes/tests/dominoes.rs
@@ -35,9 +35,9 @@ fn check(input: &[Domino]) -> CheckResult {
         .iter()
         .map(|&d| normalize(d))
         .collect::<Vec<Domino>>();
-    output_sorted.sort();
+    output_sorted.sort_unstable();
     let mut input_sorted = input.iter().map(|&d| normalize(d)).collect::<Vec<Domino>>();
-    input_sorted.sort();
+    input_sorted.sort_unstable();
     if input_sorted != output_sorted {
         return DominoMismatch(output);
     }

--- a/exercises/saddle-points/tests/saddle-points.rs
+++ b/exercises/saddle-points/tests/saddle-points.rs
@@ -3,7 +3,7 @@ use saddle_points::find_saddle_points;
 // We don't care about order
 fn find_sorted_saddle_points(input: &[Vec<u64>]) -> Vec<(usize, usize)> {
     let mut result = saddle_points::find_saddle_points(input);
-    result.sort();
+    result.sort_unstable();
     result
 }
 


### PR DESCRIPTION
clippy:
warning: Use sort_unstable instead of sort
note: `#[warn(clippy::stable_sort_primitive)]` on by default
help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive

When sorting primitive values (integers, bools, chars, as well as
arrays, slices, and tuples of such items), it is better to use an
unstable sort than a stable sort.

Using a stable sort consumes more memory and cpu cycles. Because values
which compare equal are identical, preserving their relative order (the
guarantee that a stable sort provides) means nothing, while the extra
costs still apply.