### PR TITLE
nucleotide-codons: rm unneeded return

### DIFF
--- a/exercises/nucleotide-codons/tests/codons.rs
+++ b/exercises/nucleotide-codons/tests/codons.rs
@@ -111,5 +111,5 @@ fn make_pairs() -> Vec<(&'static str, &'static str)> {
         }
     }
     pairs.sort_by(|&(_, a), &(_, b)| a.cmp(b));
-    return pairs;
+    pairs
 }


### PR DESCRIPTION
clippy:
warning: unneeded `return` statement
note: `#[warn(clippy::needless_return)]` on by default
help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

Removing the `return` and semicolon will make the code more rusty.

I understand this exercise is deprecated and that we already did this to
protein-translation in 3d3cd9a524130d6bf38212c39b5134fc7841e16e.
Clippy doesn't know this when we run it against all the exercises, so
might as well just do this to get closer to zero Clippy warnings in
tests (which we are pretty close to)