### PR TITLE
fizzy: iter instead of into_iter

### DIFF
--- a/exercises/fizzy/tests/fizzy.rs
+++ b/exercises/fizzy/tests/fizzy.rs
@@ -37,7 +37,7 @@ fn test_nonsequential() {
         "fizz", "fizz", "fizz", "buzz", "buzz", "16", "8", "4", "2", "1",
     ];
     let got = fizz_buzz::<i32>()
-        .apply(collatz_12.into_iter().cloned())
+        .apply(collatz_12.iter().cloned())
         .collect::<Vec<_>>();
     assert_eq!(expect, got);
 }


### PR DESCRIPTION
clippy:
warning: this `.into_iter()` call is equivalent to `.iter()` and will not move the `array`
note: `#[warn(clippy::into_iter_on_ref)]` on by default
help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#into_iter_on_ref

Readability. Calling `into_iter` on a reference will not move out its
content into the resulting iterator, which is confusing. It is better
just call `iter` or `iter_mut` directly.