### PR TITLE
replace TRAVIS_PULL_REQUEST with GITHUB_EVENT_NAME

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,12 +47,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # Sets TRAVIS_PULL_REQUEST to false if this is not a pull request.
-      - name: set TRAVIS_PULL_REQUEST
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: echo "TRAVIS_PULL_REQUEST=${PR_NUMBER:-false}" >> $GITHUB_ENV
-
       - name: Fetch configlet
         run: ./bin/fetch-configlet
 
@@ -93,16 +87,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           default: true
 
-      # Sets TRAVIS_PULL_REQUEST to false if this is not a pull request.
-      - name: set TRAVIS_PULL_REQUEST
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: echo "TRAVIS_PULL_REQUEST=${PR_NUMBER:-false}" >> $GITHUB_ENV
-
       # run scripts as steps
-      # TODO: the TRAVIS_PULL_REQUEST variable is a holdover from before the
-      # migration to GitHub Actions. The scripts that use it do so in order to
-      # run only on changed files.
       - name: Check exercises
         env:
           DENYWARNINGS: ${{ matrix.deny_warnings }}

--- a/_test/check-configlet-fmt.sh
+++ b/_test/check-configlet-fmt.sh
@@ -6,20 +6,15 @@
 # Check if config.json or maintainers.json were modified
 check_pattern="config.json\|config/maintainers.json"
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
     # Check the changes on the current branch against master branch
-    git diff --name-only remotes/origin/master | grep "$check_pattern"
-else
-    # Check the commits on the master branch made during the week
-    # This is because Travis cron is set to test the master branch weekly.
-    git diff --name-only "@{7 days ago}" | grep "$check_pattern"
+    if ! git diff --name-only remotes/origin/master | grep -q "$check_pattern"; then
+        echo "config.json or maintainers.json were not changed - configlet fmt is aborted."
+        exit 0
+    fi
 fi
-
-if [ $? != 0 ]; then
-    echo "config.json or maintainers.json were not changed - configlet fmt is aborted."
-
-    exit 0
-fi
+# If it's not a pull request, just always run it.
+# This script is cheap anyway.
 
 repo=$(cd "$(dirname "$0")/.." && pwd)
 configlet="${repo}/bin/configlet"

--- a/_test/check-exercise-crate.sh
+++ b/_test/check-exercise-crate.sh
@@ -4,20 +4,21 @@
 
 EXERCISE_CRATE_PATH="util/exercise"
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
     # Check the changes on the current branch against master branch
-    git diff --name-only remotes/origin/master | grep "$EXERCISE_CRATE_PATH"
-else
-    # Check the commits on the master branch made during the week
-    # This is because Travis cron is set to test the master branch weekly.
-    git diff --name-only "@{7 days ago}" | grep "$EXERCISE_CRATE_PATH"
+    if ! git diff --name-only remotes/origin/master | grep -q "$EXERCISE_CRATE_PATH"; then
+        echo "exercise crate was not modified. The script is aborted."
+        exit 0
+    fi
 fi
+# If it's not a pull request, just always run it.
+# Two scenarios:
+# 1. It's being run locally,
+#    in which case we assume the person running it really does want to run it.
+# 2. It's being run on CI for master,
+#    in which case we should check regardless of changes to exercise crate,
+#    in case there's a new toolchain release, etc.
 
-if [ $? != 0 ]; then
-    echo "exercise crate was not modified. The script is aborted."
-
-    exit 0
-fi
 
 TRACK_ROOT="$(git rev-parse --show-toplevel)"
 

--- a/_test/check-exercises.sh
+++ b/_test/check-exercises.sh
@@ -28,7 +28,7 @@ fi
 
 repo=$(cd "$(dirname "$0")/.." && pwd)
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
    files="$(git diff --diff-filter=d --name-only remotes/origin/master | grep "exercises/" | cut -d '/' -f -2 | sort -u | awk -v repo=$repo '{print repo"/"$1}')"
 else
 	files=$repo/exercises/*

--- a/_test/ensure-stubs-compile.sh
+++ b/_test/ensure-stubs-compile.sh
@@ -2,7 +2,7 @@
 
 repo=$(cd "$(dirname "$0")/.." && pwd)
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
 	changed_exercises="$(git diff --diff-filter=d --name-only remotes/origin/master | grep "exercises/" | cut -d '/' -f -2 | sort -u | awk -v repo=$repo '{print repo"/"$1}')"
 else
 	changed_exercises=$repo/exercises/*

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
   ],
   "exercises": [
     {
-      "slug": "hello-world",
+                           "slug": "hello-world",
       "uuid": "13ec1ebe-d71b-436f-ab12-25305e814171",
       "core": true,
       "auto_approve": true,

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
   ],
   "exercises": [
     {
-                           "slug": "hello-world",
+      "slug": "hello-world",
       "uuid": "13ec1ebe-d71b-436f-ab12-25305e814171",
       "core": true,
       "auto_approve": true,


### PR DESCRIPTION
When moving off of Travis in
https://github.com/exercism/rust/pull/975, there were some instances of
TRAVIS_PULL_REQUEST left over as a transitionary strategy.

Now we have been hurt by leaving TRAVIS_PULL_REQUEST in:
In https://github.com/exercism/rust/pull/1006 a new GitHub Actions job
was added that forgot to set TRAVIS_PULL_REQUEST and caused incorrect
behaviour.

So let's remove TRAVIS_PULL_REQUEST and instead change it to
GITHUB_EVENT_NAME.

Documentation:
https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables