### PR TITLE
GitHub Actions: Also run weekly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
     branches:
     - master
   pull_request:
+  schedule:
+    # Weekly.
+    - cron: "0 0 * * 0"
 
 jobs:
   ensure-conventions:


### PR DESCRIPTION
Even if we don't have any activity on master for a while, it is still
valuable to run the CI periodically - this will keep a record of whether
there are any changes caused by new Rust toolchain releases, etc.

All our observed behaviour with our current `push` and `pull_request`
tell us that multiple entries under `on` indicate OR (the workflow runs
on any of these events)
Corroborated by documentation:
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#on

Documentation on schedule:
https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#schedule