### PR TITLE
ensure-stubs-compile: rm "remove all non-commented lines"

### DIFF
--- a/_test/ensure-stubs-compile.sh
+++ b/_test/ensure-stubs-compile.sh
@@ -42,7 +42,7 @@ for dir in $changed_exercises; do
 	sed -i -e '1i #![deny(warnings)]' $dir/tests/*.rs
 
 	if ! (cd $dir && cargo test --quiet --no-run); then
-	  echo "$exercise's stub does not compile; please make it compile or remove all non-commented lines"
+	  echo "$exercise's stub does not compile; please make it compile"
 	  broken="$broken\n$exercise"
 	fi
 


### PR DESCRIPTION
You used to be able to provide a completely empty stub file. But this
option was removed in ba54bca7f0391480fa6b8bbe2d4c63b959c9d35e.