### PR TITLE
remove unnecessary static lifetimes from exercise examples

### DIFF
--- a/exercises/diamond/example.rs
+++ b/exercises/diamond/example.rs
@@ -1,4 +1,4 @@
-static ABC: &'static str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+static ABC: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 pub fn get_diamond(diamond_char: char) -> Vec<String> {
     let mut result: Vec<String> = Vec::new();

--- a/exercises/nucleotide-count/example.rs
+++ b/exercises/nucleotide-count/example.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-static VALID_NUCLEOTIDES: &'static str = "ACGT";
+static VALID_NUCLEOTIDES: &str = "ACGT";
 
 fn valid(c: char) -> Result<char, char> {
     if VALID_NUCLEOTIDES.contains(c) {

--- a/exercises/pangram/example.rs
+++ b/exercises/pangram/example.rs
@@ -15,4 +15,4 @@ fn english_letter_set() -> BTreeSet<char> {
     BTreeSet::from_iter(ENGLISH_ALPHABET.chars())
 }
 
-const ENGLISH_ALPHABET: &'static str = "abcdefghijklmnopqrstuvwxyz";
+const ENGLISH_ALPHABET: &str = "abcdefghijklmnopqrstuvwxyz";

--- a/exercises/robot-name/example.rs
+++ b/exercises/robot-name/example.rs
@@ -7,8 +7,8 @@ pub struct Robot {
 
 fn generate_name() -> String {
     let mut s = String::with_capacity(5);
-    static LETTERS: &'static [u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    static NUMBERS: &'static [u8] = b"0123456789";
+    static LETTERS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    static NUMBERS: &[u8] = b"0123456789";
     for _ in 0..2 {
         s.push(*thread_rng().choose(LETTERS).unwrap() as char);
     }

--- a/exercises/roman-numerals/example.rs
+++ b/exercises/roman-numerals/example.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-static ROMAN_MAP: [(usize, &'static str); 13] = [
+static ROMAN_MAP: [(usize, &str); 13] = [
     (1, "I"),
     (4, "IV"),
     (5, "V"),

--- a/exercises/say/example.rs
+++ b/exercises/say/example.rs
@@ -1,4 +1,4 @@
-const SMALL: &'static [&'static str] = &[
+const SMALL: &[&str] = &[
     "zero",
     "one",
     "two",
@@ -21,11 +21,11 @@ const SMALL: &'static [&'static str] = &[
     "nineteen",
 ];
 
-const TENS: &'static [&'static str] = &[
+const TENS: &[&str] = &[
     "ones", "ten", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety",
 ];
 
-const SCALE: &'static [&'static str] = &[
+const SCALE: &[&str] = &[
     "",
     "thousand",
     "million",


### PR DESCRIPTION
Helps address #1012.