### PR TITLE
remove unneeded unit return type in exercise examples

### DIFF
--- a/exercises/react/example.rs
+++ b/exercises/react/example.rs
@@ -44,9 +44,9 @@ struct ComputeCell<'a, T: Copy> {
     cell: Cell<T>,
 
     dependencies: Vec<CellID>,
-    f: Box<dyn Fn(&[T]) -> T + 'a>,
+    f: Box<dyn 'a + Fn(&[T]) -> T>,
     callbacks_issued: usize,
-    callbacks: HashMap<CallbackID, Box<dyn FnMut(T) -> () + 'a>>,
+    callbacks: HashMap<CallbackID, Box<dyn 'a + FnMut(T)>>,
 }
 
 impl<T: Copy> Cell<T> {
@@ -60,7 +60,7 @@ impl<T: Copy> Cell<T> {
 }
 
 impl<'a, T: Copy> ComputeCell<'a, T> {
-    fn new<F: Fn(&[T]) -> T + 'a>(initial: T, dependencies: Vec<CellID>, f: F) -> Self {
+    fn new<F: 'a + Fn(&[T]) -> T>(initial: T, dependencies: Vec<CellID>, f: F) -> Self {
         ComputeCell {
             cell: Cell::new(initial),
 
@@ -90,7 +90,7 @@ impl<'a, T: Copy + PartialEq> Reactor<'a, T> {
         InputCellID(self.inputs.len() - 1)
     }
 
-    pub fn create_compute<F: Fn(&[T]) -> T + 'a>(
+    pub fn create_compute<F: 'a + Fn(&[T]) -> T>(
         &mut self,
         dependencies: &[CellID],
         compute_func: F,
@@ -161,7 +161,7 @@ impl<'a, T: Copy + PartialEq> Reactor<'a, T> {
             .is_some()
     }
 
-    pub fn add_callback<F: FnMut(T) -> () + 'a>(
+    pub fn add_callback<F: 'a + FnMut(T)>(
         &mut self,
         id: ComputeCellID,
         callback: F,

--- a/exercises/react/src/lib.rs
+++ b/exercises/react/src/lib.rs
@@ -105,7 +105,7 @@ impl<T: Copy + PartialEq> Reactor<T> {
     // * Exactly once if the compute cell's value changed as a result of the set_value call.
     //   The value passed to the callback should be the final value of the compute cell after the
     //   set_value call.
-    pub fn add_callback<F: FnMut(T) -> ()>(
+    pub fn add_callback<F: FnMut(T)>(
         &mut self,
         _id: ComputeCellID,
         _callback: F,


### PR DESCRIPTION
Helps address #1012.