### PR TITLE
GitHub Actions: Enforce exercises' formatting; format exercises

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,6 +109,33 @@ jobs:
         run: sh ./_test/check-exercise-crate.sh
         continue-on-error: ${{ matrix.rust == 'beta' && matrix.deny_warnings == '1' }}
 
+  rustformat:
+    name: Check Rust Formatting
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+
+      - name: Rust Format Version
+        run: rustfmt --version
+
+      - name: Format
+        run: sh bin/format_exercises
+
+      - name: Diff
+        run: |
+          if ! git diff --color --exit-code; then
+            echo "Please run cargo fmt, or see the diff above:"
+            exit 1
+          fi
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/bin/format_exercises
+++ b/bin/format_exercises
@@ -1,33 +1,17 @@
-#!/bin/bash
+#!/bin/sh
 # Format existing exercises using rustfmt
 
 RUST_TRACK_REPO_PATH=$(cd "$(dirname "$0")/.." && pwd)
 
 EXERCISES_PATH="${RUST_TRACK_REPO_PATH}/exercises/"
 
-# Some exercises use custom formatting for illustration purpose and should not be formatted. 
-IGNORED_EXERCISES=(
-	"diamond" 
-	"minesweeper" 
-	"rectangles"
-)
-
-# Iterate over every exercise directory and if it is not ignored - format it
 for exercise_dir in ${EXERCISES_PATH}/*; do
-	exercise_name=${exercise_dir##*/}
-
-	if [[ " ${IGNORED_EXERCISES[*]} " == *"$exercise_name"* ]]; then
-		echo "$exercise_name - Ignored"
-	else
-		(
-			echo "$exercise_name - Formatting"
-
-			cd "$exercise_dir"
-
-			cargo fmt
-
-			[ -f example.rs ] && rustfmt example.rs
-		)
-	fi
-
+  exercise_name=$(basename $exercise_dir)
+  (
+    cd "$exercise_dir"
+    cargo fmt
+    if [ -f example.rs ]; then
+      rustfmt example.rs
+    fi
+  )
 done

--- a/exercises/acronym/tests/acronym.rs
+++ b/exercises/acronym/tests/acronym.rs
@@ -30,7 +30,10 @@ fn punctuation() {
 #[test]
 #[ignore]
 fn all_caps_word() {
-    assert_eq!(acronym::abbreviate("GNU Image Manipulation Program"), "GIMP");
+    assert_eq!(
+        acronym::abbreviate("GNU Image Manipulation Program"),
+        "GIMP"
+    );
 }
 
 #[test]
@@ -52,7 +55,9 @@ fn punctuation_without_whitespace() {
 #[ignore]
 fn very_long_abbreviation() {
     assert_eq!(
-        acronym::abbreviate("Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me"),
+        acronym::abbreviate(
+            "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me"
+        ),
         "ROTFLSHTMDCOALM"
     );
 }
@@ -69,17 +74,11 @@ fn consecutive_delimiters() {
 #[test]
 #[ignore]
 fn apostrophes() {
-    assert_eq!(
-        acronym::abbreviate("Halley's Comet"),
-        "HC"
-    );
+    assert_eq!(acronym::abbreviate("Halley's Comet"), "HC");
 }
 
 #[test]
 #[ignore]
 fn underscore_emphasis() {
-    assert_eq!(
-        acronym::abbreviate("The Road _Not_ Taken"),
-        "TRNT"
-    );
+    assert_eq!(acronym::abbreviate("The Road _Not_ Taken"), "TRNT");
 }

--- a/exercises/all-your-base/example.rs
+++ b/exercises/all-your-base/example.rs
@@ -55,7 +55,7 @@ pub fn convert<P: AsRef<[Digit]>>(
     if let Some(&invalid) = digits.as_ref().iter().find(|&num| *num >= from_base) {
         return Err(Error::InvalidDigit(invalid));
     }
-    
+
     // convert all digits into a single large number
     let mut immediate: Digit = digits
         .as_ref()
@@ -75,6 +75,6 @@ pub fn convert<P: AsRef<[Digit]>>(
     res.reverse();
     if res.is_empty() {
         res.push(0);
-    } 
+    }
     Ok(res)
 }

--- a/exercises/bob/tests/bob.rs
+++ b/exercises/bob/tests/bob.rs
@@ -8,14 +8,12 @@ fn test_stating_something() {
     process_response_case("Tom-ay-to, tom-aaaah-to.", "Whatever.");
 }
 
-
 #[test]
 #[ignore]
 /// ending with whitespace
 fn test_ending_with_whitespace() {
     process_response_case("Okay if like my  spacebar  quite a bit?   ", "Sure.");
 }
-
 
 #[test]
 #[ignore]
@@ -24,7 +22,6 @@ fn test_shouting_numbers() {
     process_response_case("1, 2, 3 GO!", "Whoa, chill out!");
 }
 
-
 #[test]
 #[ignore]
 /// other whitespace
@@ -32,14 +29,15 @@ fn test_other_whitespace() {
     process_response_case("\r\r 	", "Fine. Be that way!");
 }
 
-
 #[test]
 #[ignore]
 /// shouting with special characters
 fn test_shouting_with_special_characters() {
-    process_response_case("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!", "Whoa, chill out!");
+    process_response_case(
+        "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!",
+        "Whoa, chill out!",
+    );
 }
-
 
 #[test]
 #[ignore]
@@ -48,7 +46,6 @@ fn test_talking_forcefully() {
     process_response_case("Hi there!", "Whatever.");
 }
 
-
 #[test]
 #[ignore]
 /// prattling on
@@ -56,14 +53,12 @@ fn test_prattling_on() {
     process_response_case("Wait! Hang on. Are you going to be OK?", "Sure.");
 }
 
-
 #[test]
 #[ignore]
 /// forceful question
 fn test_forceful_question() {
-   process_response_case("WHAT'S GOING ON?", "Calm down, I know what I'm doing!");
+    process_response_case("WHAT'S GOING ON?", "Calm down, I know what I'm doing!");
 }
-
 
 #[test]
 #[ignore]
@@ -72,14 +67,12 @@ fn test_shouting_with_no_exclamation_mark() {
     process_response_case("I HATE THE DENTIST", "Whoa, chill out!");
 }
 
-
 #[test]
 #[ignore]
 /// asking gibberish
 fn test_asking_gibberish() {
     process_response_case("fffbbcbeab?", "Sure.");
 }
-
 
 #[test]
 #[ignore]
@@ -88,14 +81,12 @@ fn test_question_with_no_letters() {
     process_response_case("4?", "Sure.");
 }
 
-
 #[test]
 #[ignore]
 /// no letters
 fn test_no_letters() {
     process_response_case("1, 2, 3", "Whatever.");
 }
-
 
 #[test]
 #[ignore]
@@ -104,23 +95,26 @@ fn test_statement_containing_question_mark() {
     process_response_case("Ending with ? means a question.", "Whatever.");
 }
 
-
 //NEW
 #[test]
 #[ignore]
 /// multiple line question
 fn test_multiple_line_question() {
-    process_response_case("\rDoes this cryogenic chamber make me look fat?\rNo.", "Whatever.");
+    process_response_case(
+        "\rDoes this cryogenic chamber make me look fat?\rNo.",
+        "Whatever.",
+    );
 }
-
 
 #[test]
 #[ignore]
 /// non-question ending with whitespace
 fn test_nonquestion_ending_with_whitespace() {
-    process_response_case("This is a statement ending with whitespace      ", "Whatever.");
+    process_response_case(
+        "This is a statement ending with whitespace      ",
+        "Whatever.",
+    );
 }
-
 
 #[test]
 #[ignore]
@@ -129,14 +123,12 @@ fn test_shouting() {
     process_response_case("WATCH OUT!", "Whoa, chill out!");
 }
 
-
 #[test]
 #[ignore]
 /// non-letters with question
 fn test_nonletters_with_question() {
     process_response_case(":) ?", "Sure.");
 }
-
 
 #[test]
 #[ignore]
@@ -145,14 +137,12 @@ fn test_shouting_gibberish() {
     process_response_case("FCECDFCAAB", "Whoa, chill out!");
 }
 
-
 #[test]
 #[ignore]
 /// asking a question
 fn test_asking_a_question() {
     process_response_case("Does this cryogenic chamber make me look fat?", "Sure.");
 }
-
 
 #[test]
 #[ignore]
@@ -161,14 +151,12 @@ fn test_asking_a_numeric_question() {
     process_response_case("You are, what, like 15?", "Sure.");
 }
 
-
 #[test]
 #[ignore]
 /// silence
 fn test_silence() {
     process_response_case("", "Fine. Be that way!");
 }
-
 
 #[test]
 #[ignore]
@@ -177,14 +165,15 @@ fn test_starting_with_whitespace() {
     process_response_case("         hmmmmmmm...", "Whatever.");
 }
 
-
 #[test]
 #[ignore]
 /// using acronyms in regular speech
 fn test_using_acronyms_in_regular_speech() {
-    process_response_case("It's OK if you don't want to go work for NASA.", "Whatever.");
+    process_response_case(
+        "It's OK if you don't want to go work for NASA.",
+        "Whatever.",
+    );
 }
-
 
 #[test]
 #[ignore]
@@ -193,11 +182,9 @@ fn test_alternate_silence() {
     process_response_case("										", "Fine. Be that way!");
 }
 
-
 #[test]
 #[ignore]
 /// prolonged silence
 fn test_prolonged_silence() {
     process_response_case("          ", "Fine. Be that way!");
 }
-

--- a/exercises/bowling/tests/bowling.rs
+++ b/exercises/bowling/tests/bowling.rs
@@ -432,7 +432,6 @@ fn cannot_roll_after_bonus_roll_for_strike() {
     assert_eq!(game.roll(2), Err(Error::GameComplete));
 }
 
-
 #[test]
 #[ignore]
 fn last_two_strikes_followed_by_only_last_bonus_with_non_strike_points() {

--- a/exercises/decimal/example.rs
+++ b/exercises/decimal/example.rs
@@ -76,7 +76,7 @@ impl Decimal {
             lower_precision.decimal_index += precision_difference;
         }
         match one.decimal_index.cmp(&two.decimal_index) {
-            std::cmp::Ordering::Equal => {},
+            std::cmp::Ordering::Equal => {}
             std::cmp::Ordering::Less => expand(&mut one, &two),
             std::cmp::Ordering::Greater => expand(&mut two, &one),
         }
@@ -118,7 +118,13 @@ macro_rules! auto_impl_decimal_ops {
 
 auto_impl_decimal_ops!(Add, add, |s, o| s + o, |s, _| s);
 auto_impl_decimal_ops!(Sub, sub, |s, o| s - o, |s, _| s);
-auto_impl_decimal_ops!(#[allow(clippy::suspicious_arithmetic_impl)] Mul, mul, |s, o| s * o, |s, o| s + o);
+auto_impl_decimal_ops!(
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    Mul,
+    mul,
+    |s, o| s * o,
+    |s, o| s + o
+);
 
 macro_rules! auto_impl_decimal_cow {
     ($trait:ident, $func_name:ident, $digits_operation:expr, $return_type:ty) => {

--- a/exercises/diamond/tests/diamond.rs
+++ b/exercises/diamond/tests/diamond.rs
@@ -1,4 +1,3 @@
-
 use diamond::*;
 
 #[test]
@@ -9,21 +8,37 @@ fn test_a() {
 #[test]
 #[ignore]
 fn test_b() {
-    assert_eq!(get_diamond('B'), vec![" A ", "B B", " A "]);
+    #[rustfmt::skip]
+    assert_eq!(
+        get_diamond('B'),
+        vec![
+            " A ",
+            "B B",
+            " A ",
+        ]
+    );
 }
 
 #[test]
 #[ignore]
 fn test_c() {
+    #[rustfmt::skip]
     assert_eq!(
         get_diamond('C'),
-        vec!["  A  ", " B B ", "C   C", " B B ", "  A  "]
+        vec![
+            "  A  ",
+            " B B ",
+            "C   C",
+            " B B ",
+            "  A  ",
+        ]
     );
 }
 
 #[test]
 #[ignore]
 fn test_d() {
+    #[rustfmt::skip]
     assert_eq!(
         get_diamond('D'),
         vec![

--- a/exercises/dot-dsl/example.rs
+++ b/exercises/dot-dsl/example.rs
@@ -104,7 +104,6 @@ pub mod graph {
                     self.attrs.get(name).map(|v| v.as_ref())
                 }
             }
-
         }
     }
 }

--- a/exercises/forth/example.rs
+++ b/exercises/forth/example.rs
@@ -172,10 +172,12 @@ impl Forth {
         for t in code.iter() {
             match t {
                 Term::Number(_) => resolved_def.push_back(t.clone()),
-                Term::Word(s) => if let Some(cs) = self.defs.get(s) {
-                    resolved_def.append(&mut cs.clone());
-                } else {
-                    resolved_def.push_back(t.clone());
+                Term::Word(s) => {
+                    if let Some(cs) = self.defs.get(s) {
+                        resolved_def.append(&mut cs.clone());
+                    } else {
+                        resolved_def.push_back(t.clone());
+                    }
                 }
                 _ => {
                     eprintln!("Nested definition in {}", name);

--- a/exercises/forth/tests/forth.rs
+++ b/exercises/forth/tests/forth.rs
@@ -359,4 +359,3 @@ fn definitions_after_ops() {
     assert!(f.eval("1 2 + : addone 1 + ; addone").is_ok());
     assert_eq!(vec![4], f.stack());
 }
-

--- a/exercises/minesweeper/example.rs
+++ b/exercises/minesweeper/example.rs
@@ -1,7 +1,7 @@
 struct Board {
     pieces: Vec<Vec<char>>,
     num_rows: usize,
-    num_cols: usize
+    num_cols: usize,
 }
 
 impl Board {
@@ -11,10 +11,16 @@ impl Board {
 
     fn annotated_row(&self, y: usize) -> String {
         self.pieces[y]
-                  .iter()
-                  .enumerate()
-                  .map(|(x,&c)| if c == ' ' {self.count_neighbouring_mines_char(x, y)} else {c})
-                  .collect::<String>()
+            .iter()
+            .enumerate()
+            .map(|(x, &c)| {
+                if c == ' ' {
+                    self.count_neighbouring_mines_char(x, y)
+                } else {
+                    c
+                }
+            })
+            .collect::<String>()
     }
 
     fn count_neighbouring_mines_char(&self, x: usize, y: usize) -> char {
@@ -40,16 +46,21 @@ pub fn annotate(pieces: &[&str]) -> Vec<String> {
         return Vec::new();
     }
     let pieces_vec = pieces.iter().map(|&r| r.chars().collect()).collect();
-    Board {pieces: pieces_vec, num_rows: pieces.len(), num_cols: pieces[0].len()}.annotated()
+    Board {
+        pieces: pieces_vec,
+        num_rows: pieces.len(),
+        num_cols: pieces[0].len(),
+    }
+    .annotated()
 }
 
 fn neighbouring_points(x: usize, limit: usize) -> Vec<usize> {
     let mut offsets = vec![x];
     if x >= 1 {
-        offsets.push(x-1);
+        offsets.push(x - 1);
     }
-    if x+2 <= limit {
-        offsets.push(x+1);
+    if x + 2 <= limit {
+        offsets.push(x + 1);
     }
     offsets
 }

--- a/exercises/minesweeper/tests/minesweeper.rs
+++ b/exercises/minesweeper/tests/minesweeper.rs
@@ -1,5 +1,3 @@
-
-
 use minesweeper::annotate;
 
 fn remove_annotations(board: &[&str]) -> Vec<String> {
@@ -7,10 +5,12 @@ fn remove_annotations(board: &[&str]) -> Vec<String> {
 }
 
 fn remove_annotations_in_row(row: &str) -> String {
-    row.chars().map(|ch| match ch {
-        '*' => '*',
-        _ => ' '
-    }).collect()
+    row.chars()
+        .map(|ch| match ch {
+            '*' => '*',
+            _ => ' ',
+        })
+        .collect()
 }
 
 fn run_test(test_case: &[&str]) {
@@ -22,6 +22,7 @@ fn run_test(test_case: &[&str]) {
 
 #[test]
 fn no_rows() {
+    #[rustfmt::skip]
     run_test(&[
     ]);
 }
@@ -29,6 +30,7 @@ fn no_rows() {
 #[test]
 #[ignore]
 fn no_columns() {
+    #[rustfmt::skip]
     run_test(&[
         "",
     ]);
@@ -37,6 +39,7 @@ fn no_columns() {
 #[test]
 #[ignore]
 fn no_mines() {
+    #[rustfmt::skip]
     run_test(&[
         "   ",
         "   ",
@@ -47,6 +50,7 @@ fn no_mines() {
 #[test]
 #[ignore]
 fn board_with_only_mines() {
+    #[rustfmt::skip]
     run_test(&[
         "***",
         "***",
@@ -57,6 +61,7 @@ fn board_with_only_mines() {
 #[test]
 #[ignore]
 fn mine_surrounded_by_spaces() {
+    #[rustfmt::skip]
     run_test(&[
         "111",
         "1*1",
@@ -67,6 +72,7 @@ fn mine_surrounded_by_spaces() {
 #[test]
 #[ignore]
 fn space_surrounded_by_mines() {
+    #[rustfmt::skip]
     run_test(&[
         "***",
         "*8*",
@@ -77,6 +83,7 @@ fn space_surrounded_by_mines() {
 #[test]
 #[ignore]
 fn horizontal_line() {
+    #[rustfmt::skip]
     run_test(&[
         "1*2*1",
     ]);
@@ -85,6 +92,7 @@ fn horizontal_line() {
 #[test]
 #[ignore]
 fn horizontal_line_mines_at_edges() {
+    #[rustfmt::skip]
     run_test(&[
         "*1 1*",
     ]);
@@ -93,6 +101,7 @@ fn horizontal_line_mines_at_edges() {
 #[test]
 #[ignore]
 fn vertical_line() {
+    #[rustfmt::skip]
     run_test(&[
         "1",
         "*",
@@ -105,6 +114,7 @@ fn vertical_line() {
 #[test]
 #[ignore]
 fn vertical_line_mines_at_edges() {
+    #[rustfmt::skip]
     run_test(&[
         "*",
         "1",
@@ -117,6 +127,7 @@ fn vertical_line_mines_at_edges() {
 #[test]
 #[ignore]
 fn cross() {
+    #[rustfmt::skip]
     run_test(&[
         " 2*2 ",
         "25*52",
@@ -129,6 +140,7 @@ fn cross() {
 #[test]
 #[ignore]
 fn large_board() {
+    #[rustfmt::skip]
     run_test(&[
         "1*22*1",
         "12*322",

--- a/exercises/ocr-numbers/tests/ocr-numbers.rs
+++ b/exercises/ocr-numbers/tests/ocr-numbers.rs
@@ -1,8 +1,8 @@
 use ocr_numbers as ocr;
 
 #[test]
-#[rustfmt::skip]
 fn input_with_lines_not_multiple_of_four_is_error() {
+    #[rustfmt::skip]
     let input = " _ \n".to_string() +
                 "| |\n" +
                 "   ";
@@ -12,8 +12,8 @@ fn input_with_lines_not_multiple_of_four_is_error() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn input_with_columns_not_multiple_of_three_is_error() {
+    #[rustfmt::skip]
     let input = "    \n".to_string() +
                 "   |\n" +
                 "   |\n" +
@@ -24,8 +24,8 @@ fn input_with_columns_not_multiple_of_three_is_error() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn unrecognized_characters_return_question_mark() {
+    #[rustfmt::skip]
     let input = "   \n".to_string() +
                 "  _\n" +
                 "  |\n" +
@@ -36,8 +36,8 @@ fn unrecognized_characters_return_question_mark() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn recognizes_0() {
+    #[rustfmt::skip]
     let input = " _ \n".to_string() +
                 "| |\n" +
                 "|_|\n" +
@@ -48,8 +48,8 @@ fn recognizes_0() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn recognizes_1() {
+    #[rustfmt::skip]
     let input = "   \n".to_string() +
                 "  |\n" +
                 "  |\n" +
@@ -60,8 +60,8 @@ fn recognizes_1() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn recognizes_2() {
+    #[rustfmt::skip]
     let input = " _ \n".to_string() +
                 " _|\n" +
                 "|_ \n" +
@@ -72,8 +72,8 @@ fn recognizes_2() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn recognizes_3() {
+    #[rustfmt::skip]
     let input = " _ \n".to_string() +
                 " _|\n" +
                 " _|\n" +
@@ -84,8 +84,8 @@ fn recognizes_3() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn recognizes_4() {
+    #[rustfmt::skip]
     let input = "   \n".to_string() +
                 "|_|\n" +
                 "  |\n" +
@@ -96,8 +96,8 @@ fn recognizes_4() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn recognizes_5() {
+    #[rustfmt::skip]
     let input = " _ \n".to_string() +
                 "|_ \n" +
                 " _|\n" +
@@ -108,8 +108,8 @@ fn recognizes_5() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn recognizes_6() {
+    #[rustfmt::skip]
     let input = " _ \n".to_string() +
                 "|_ \n" +
                 "|_|\n" +
@@ -120,8 +120,8 @@ fn recognizes_6() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn recognizes_7() {
+    #[rustfmt::skip]
     let input = " _ \n".to_string() +
                 "  |\n" +
                 "  |\n" +
@@ -132,8 +132,8 @@ fn recognizes_7() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn recognizes_8() {
+    #[rustfmt::skip]
     let input = " _ \n".to_string() +
                 "|_|\n" +
                 "|_|\n" +
@@ -144,8 +144,8 @@ fn recognizes_8() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn recognizes_9() {
+    #[rustfmt::skip]
     let input = " _ \n".to_string() +
                 "|_|\n" +
                 " _|\n" +
@@ -156,8 +156,8 @@ fn recognizes_9() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn recognizes_110101100() {
+    #[rustfmt::skip]
     let input = "       _     _        _  _ \n".to_string() +
                 "  |  || |  || |  |  || || |\n" +
                 "  |  ||_|  ||_|  |  ||_||_|\n" +
@@ -168,8 +168,8 @@ fn recognizes_110101100() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn replaces_only_garbled_numbers_with_question_mark() {
+    #[rustfmt::skip]
     let input = "       _     _           _ \n".to_string() +
                 "  |  || |  || |     || || |\n" +
                 "  |  | _|  ||_|  |  ||_||_|\n" +
@@ -180,8 +180,8 @@ fn replaces_only_garbled_numbers_with_question_mark() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn recognizes_string_of_decimal_numbers() {
+    #[rustfmt::skip]
     let input = "    _  _     _  _  _  _  _  _ \n".to_string() +
                 "  | _| _||_||_ |_   ||_||_|| |\n" +
                 "  ||_  _|  | _||_|  ||_| _||_|\n" +
@@ -192,8 +192,8 @@ fn recognizes_string_of_decimal_numbers() {
 
 #[test]
 #[ignore]
-#[rustfmt::skip]
 fn numbers_across_multiple_lines_are_joined_by_commas() {
+    #[rustfmt::skip]
     let input = "    _  _ \n".to_string() +
                 "  | _| _|\n" +
                 "  ||_  _|\n" +

--- a/exercises/paasio/tests/paasio.rs
+++ b/exercises/paasio/tests/paasio.rs
@@ -167,22 +167,28 @@ test_write!(#[ignore] write_string (
     |d: &[u8]| d.len()
 ));
 
-test_read!(#[ignore]
-read_byte_literal(
-    &[1_u8, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144][..],
-    |d: &[u8]| d.len()
-));
-test_write!(#[ignore]
-write_byte_literal(
-    &[2_u8, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61,][..],
-    |d: &[u8]| d.len()
-));
+test_read!(
+    #[ignore]
+    read_byte_literal(
+        &[1_u8, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144][..],
+        |d: &[u8]| d.len()
+    )
+);
+test_write!(
+    #[ignore]
+    write_byte_literal(
+        &[2_u8, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61,][..],
+        |d: &[u8]| d.len()
+    )
+);
 
-test_read!(#[ignore]
-read_file(
-    ::std::fs::File::open("README.md").expect("readme must be present"),
-    |f: &::std::fs::File| f.metadata().expect("metadata must be present").len() as usize
-));
+test_read!(
+    #[ignore]
+    read_file(
+        ::std::fs::File::open("README.md").expect("readme must be present"),
+        |f: &::std::fs::File| f.metadata().expect("metadata must be present").len() as usize
+    )
+);
 
 #[test]
 #[ignore]

--- a/exercises/palindrome-products/example.rs
+++ b/exercises/palindrome-products/example.rs
@@ -43,12 +43,12 @@ pub fn palindrome_products(min: u64, max: u64) -> Option<(Palindrome, Palindrome
                     None => Some((Palindrome::new(a, b), Palindrome::new(a, b))),
                     Some((mut minp, mut maxp)) => {
                         match (a * b).cmp(&minp.value()) {
-                            std::cmp::Ordering::Greater => {},
+                            std::cmp::Ordering::Greater => {}
                             std::cmp::Ordering::Less => minp = Palindrome::new(a, b),
                             std::cmp::Ordering::Equal => minp.insert(a, b),
                         }
                         match (a * b).cmp(&maxp.value()) {
-                            std::cmp::Ordering::Less => {},
+                            std::cmp::Ordering::Less => {}
                             std::cmp::Ordering::Greater => maxp = Palindrome::new(a, b),
                             std::cmp::Ordering::Equal => maxp.insert(a, b),
                         }

--- a/exercises/parallel-letter-frequency/tests/parallel-letter-frequency.rs
+++ b/exercises/parallel-letter-frequency/tests/parallel-letter-frequency.rs
@@ -129,4 +129,3 @@ fn test_non_integer_multiple_of_threads() {
     hm.insert('c', 999);
     assert_eq!(frequency::frequency(&v[..], 4), hm);
 }
-

--- a/exercises/poker/example.rs
+++ b/exercises/poker/example.rs
@@ -1,5 +1,5 @@
-use std::{cmp::Ordering, convert::TryFrom};
 use std::fmt;
+use std::{cmp::Ordering, convert::TryFrom};
 
 use counter::Counter;
 
@@ -11,7 +11,8 @@ pub fn winning_hands<'a>(hands: &[&'a str]) -> Option<Vec<&'a str>> {
     let mut hands = hands
         .into_iter()
         .map(|source| Hand::try_from(*source))
-        .collect::<Result<Vec<_>, _>>().ok()?;
+        .collect::<Result<Vec<_>, _>>()
+        .ok()?;
     hands.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Less));
     hands.last().map(|last| {
         hands
@@ -216,7 +217,10 @@ impl PokerHand {
             }
 
             let rank_counter = cards.iter().map(|c| c.rank).collect::<Counter<_>>();
-            let mut rc_iter = rank_counter.most_common().into_iter().map(|(_rank, count)| count);
+            let mut rc_iter = rank_counter
+                .most_common()
+                .into_iter()
+                .map(|(_rank, count)| count);
             let rc_most = rc_iter.next();
             let rc_second = rc_iter.next();
 
@@ -256,7 +260,6 @@ struct Hand<'a> {
 }
 
 impl<'a> Hand<'a> {
-
     fn cmp_high_card(&self, other: &Hand, card: usize) -> Ordering {
         let mut ordering = self.cards[card]
             .rank

--- a/exercises/rail-fence-cipher/tests/rail-fence-cipher.rs
+++ b/exercises/rail-fence-cipher/tests/rail-fence-cipher.rs
@@ -88,9 +88,5 @@ fn test_decode_with_six_rails() {
 /// this text is possibly one of the most famous haiku of all time, by
 /// Matsuo Bashō (松尾芭蕉)
 fn test_encode_wide_characters() {
-    process_encode_case(
-        "古池蛙飛び込む水の音",
-        3,
-        "古びの池飛込水音蛙む",
-    );
+    process_encode_case("古池蛙飛び込む水の音", 3, "古びの池飛込水音蛙む");
 }

--- a/exercises/rectangles/example.rs
+++ b/exercises/rectangles/example.rs
@@ -19,7 +19,7 @@ const CONN_DOWN: u8 = 0x8;
 #[derive(PartialEq, Eq, Hash)]
 struct Point {
     x: usize,
-    y: usize
+    y: usize,
 }
 
 #[derive(PartialEq, Eq, Hash)]
@@ -27,21 +27,21 @@ struct Line {
     x1: usize,
     y1: usize,
     x2: usize,
-    y2: usize
+    y2: usize,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy)]
 enum Symbol {
-    Corner, // '+'
+    Corner,  // '+'
     Connect, // '|' or '-' depending on direction
-    Other // ' ', or anything really
+    Other,   // ' ', or anything really
 }
 
 // The input area.
 struct RealArea {
     width: usize,
     height: usize,
-    chars: Vec<Vec<char>>
+    chars: Vec<Vec<char>>,
 }
 
 trait Area {
@@ -52,13 +52,17 @@ trait Area {
 
 // For horizontal scanning
 impl Area for RealArea {
-    fn width(&self) -> usize { self.width }
-    fn height(&self) -> usize { self.height }
+    fn width(&self) -> usize {
+        self.width
+    }
+    fn height(&self) -> usize {
+        self.height
+    }
     fn symbol_at(&self, x: usize, y: usize) -> Symbol {
         match self.chars[y][x] {
             '+' => Symbol::Corner,
             '-' => Symbol::Connect,
-            _ => Symbol::Other
+            _ => Symbol::Other,
         }
     }
 }
@@ -67,13 +71,17 @@ struct TransposedArea<'a>(&'a RealArea);
 
 // For vertical scanning
 impl<'a> Area for TransposedArea<'a> {
-    fn width(&self) -> usize { self.0.height }
-    fn height(&self) -> usize { self.0.width }
+    fn width(&self) -> usize {
+        self.0.height
+    }
+    fn height(&self) -> usize {
+        self.0.width
+    }
     fn symbol_at(&self, x: usize, y: usize) -> Symbol {
         match self.0.chars[x][y] {
             '+' => Symbol::Corner,
             '|' => Symbol::Connect,
-            _ => Symbol::Other
+            _ => Symbol::Other,
         }
     }
 }
@@ -81,17 +89,17 @@ impl<'a> Area for TransposedArea<'a> {
 // Information about connections.
 struct Connections {
     lines: HashSet<Line>,
-    points: HashMap<Point, u8>
+    points: HashMap<Point, u8>,
 }
 
 pub fn count(lines: &[&str]) -> usize {
     if lines.is_empty() || lines[0].is_empty() {
-        return 0
+        return 0;
     }
     let area = RealArea {
         width: lines[0].len(),
         height: lines.len(),
-        chars: lines.iter().map(|line| line.chars().collect()).collect()
+        chars: lines.iter().map(|line| line.chars().collect()).collect(),
     };
     let area_transposed = TransposedArea(&area);
     let mut conns = scan_connected(&area);
@@ -100,29 +108,55 @@ pub fn count(lines: &[&str]) -> usize {
     // The transposed connections have their coordinate system wrong,
     // correct this.
     for l in conns_transposed.lines {
-        conns.lines.insert(Line{x1: l.y1, y1: l.x1, x2: l.y2, y2: l.x2});
+        conns.lines.insert(Line {
+            x1: l.y1,
+            y1: l.x1,
+            x2: l.y2,
+            y2: l.x2,
+        });
     }
     for (p, tcf) in conns_transposed.points {
-        let cf = conns.points.entry(Point{x: p.y, y: p.x}).or_insert(0);
+        let cf = conns.points.entry(Point { x: p.y, y: p.x }).or_insert(0);
         *cf |= tcf << 2
     }
 
     let mut total = 0;
-    for (tl_p, tl_cf) in conns.points.iter() { // top left point and connection flags
-        if tl_cf & (CONN_RIGHT|CONN_DOWN) == CONN_RIGHT|CONN_DOWN {
+    for (tl_p, tl_cf) in conns.points.iter() {
+        // top left point and connection flags
+        if tl_cf & (CONN_RIGHT | CONN_DOWN) == CONN_RIGHT | CONN_DOWN {
             for (br_p, br_cf) in conns.points.iter() {
                 // left, right, top, bottom of potential rectangle
                 let l = tl_p.x;
                 let r = br_p.x;
                 let t = tl_p.y;
                 let b = br_p.y;
-                let is_rect =
-                    br_cf & (CONN_LEFT|CONN_UP) == CONN_LEFT|CONN_UP &&
-                    r > l && b > t &&
-                    conns.lines.contains(&Line{x1: l, y1: t, x2: l, y2: b}) &&
-                    conns.lines.contains(&Line{x1: l, y1: t, x2: r, y2: t}) &&
-                    conns.lines.contains(&Line{x1: l, y1: b, x2: r, y2: b}) &&
-                    conns.lines.contains(&Line{x1: r, y1: t, x2: r, y2: b});
+                let is_rect = br_cf & (CONN_LEFT | CONN_UP) == CONN_LEFT | CONN_UP
+                    && r > l
+                    && b > t
+                    && conns.lines.contains(&Line {
+                        x1: l,
+                        y1: t,
+                        x2: l,
+                        y2: b,
+                    })
+                    && conns.lines.contains(&Line {
+                        x1: l,
+                        y1: t,
+                        x2: r,
+                        y2: t,
+                    })
+                    && conns.lines.contains(&Line {
+                        x1: l,
+                        y1: b,
+                        x2: r,
+                        y2: b,
+                    })
+                    && conns.lines.contains(&Line {
+                        x1: r,
+                        y1: t,
+                        x2: r,
+                        y2: b,
+                    });
                 if is_rect {
                     total += 1
                 }
@@ -133,9 +167,9 @@ pub fn count(lines: &[&str]) -> usize {
 }
 
 fn scan_connected(area: &dyn Area) -> Connections {
-    let mut conns = Connections{
+    let mut conns = Connections {
         lines: HashSet::new(),
-        points: HashMap::new()
+        points: HashMap::new(),
     };
     let mut connected: Vec<usize> = vec![];
     for y in 0..area.height() {
@@ -144,13 +178,18 @@ fn scan_connected(area: &dyn Area) -> Connections {
             let sym = area.symbol_at(x, y);
             if sym == Symbol::Corner {
                 for prev in connected.iter() {
-                    conns.lines.insert(Line{x1: *prev, y1: y, x2: x, y2: y});
+                    conns.lines.insert(Line {
+                        x1: *prev,
+                        y1: y,
+                        x2: x,
+                        y2: y,
+                    });
                 }
                 if let Some(last) = connected.last() {
-                    let cf = conns.points.get_mut(&Point{x: *last, y}).unwrap();
+                    let cf = conns.points.get_mut(&Point { x: *last, y }).unwrap();
                     *cf |= CONN_RIGHT;
                 }
-                let cf = conns.points.entry(Point{x, y}).or_insert(0);
+                let cf = conns.points.entry(Point { x, y }).or_insert(0);
                 if !connected.is_empty() {
                     *cf |= CONN_LEFT;
                 }

--- a/exercises/rectangles/tests/rectangles.rs
+++ b/exercises/rectangles/tests/rectangles.rs
@@ -1,5 +1,3 @@
-
-
 use rectangles::count;
 
 #[test]
@@ -25,81 +23,88 @@ fn test_empty_area() {
 #[test]
 #[ignore]
 fn test_one_rectangle() {
+    #[rustfmt::skip]
     let lines = &[
         "+-+",
         "| |",
         "+-+",
-        ];
+    ];
     assert_eq!(1, count(lines))
 }
 
 #[test]
 #[ignore]
 fn test_two_rectangles_no_shared_parts() {
+    #[rustfmt::skip]
     let lines = &[
         "  +-+",
         "  | |",
         "+-+-+",
         "| |  ",
-        "+-+  "
-        ];
+        "+-+  ",
+    ];
     assert_eq!(2, count(lines))
 }
 
 #[test]
 #[ignore]
 fn test_five_rectangles_three_regions() {
+    #[rustfmt::skip]
     let lines = &[
         "  +-+",
         "  | |",
         "+-+-+",
         "| | |",
-        "+-+-+"
-        ];
+        "+-+-+",
+    ];
     assert_eq!(5, count(lines))
 }
 
 #[test]
 #[ignore]
 fn rectangle_of_height_1() {
+    #[rustfmt::skip]
     let lines = &[
         "+--+",
-        "+--+"
-        ];
+        "+--+",
+    ];
     assert_eq!(1, count(lines))
 }
 
 #[test]
 #[ignore]
 fn rectangle_of_width_1() {
+    #[rustfmt::skip]
     let lines = &[
         "++",
         "||",
-        "++"
-        ];
+        "++",
+    ];
     assert_eq!(1, count(lines))
 }
 
 #[test]
 #[ignore]
 fn unit_square() {
+    #[rustfmt::skip]
     let lines = &[
         "++",
-        "++"
-        ];
+        "++",
+    ];
     assert_eq!(1, count(lines))
 }
 
 #[test]
 #[ignore]
 fn test_incomplete_rectangles() {
+    #[rustfmt::skip]
     let lines = &[
         "  +-+",
         "    |",
         "+-+-+",
         "| | -",
-        "+-+-+"
-        ];
+        "+-+-+",
+    ];
     assert_eq!(1, count(lines))
 }
 
@@ -111,8 +116,8 @@ fn test_complicated() {
         "|      |    |",
         "+---+--+    |",
         "|   |       |",
-        "+---+-------+"
-        ];
+        "+---+-------+",
+    ];
     assert_eq!(3, count(lines))
 }
 
@@ -124,8 +129,8 @@ fn test_not_so_complicated() {
         "|      |    |",
         "+------+    |",
         "|   |       |",
-        "+---+-------+"
-        ];
+        "+---+-------+",
+    ];
     assert_eq!(2, count(lines))
 }
 
@@ -140,7 +145,7 @@ fn test_large_input_with_many_rectangles() {
         "+---+--+--+-+",
         "+---+--+--+-+",
         "+------+  | |",
-        "          +-+"
-        ];
+        "          +-+",
+    ];
     assert_eq!(60, count(lines))
 }

--- a/exercises/scale-generator/example.rs
+++ b/exercises/scale-generator/example.rs
@@ -320,7 +320,6 @@ pub mod note {
             .into();
         }
     }
-
 }
 
 #[derive(Debug)]

--- a/exercises/two-bucket/example.rs
+++ b/exercises/two-bucket/example.rs
@@ -31,7 +31,12 @@ pub struct BucketStats {
 }
 
 /// Solve the bucket problem
-pub fn solve(capacity_1: u8, capacity_2: u8, goal: u8, start_bucket: &Bucket) -> Option<BucketStats> {
+pub fn solve(
+    capacity_1: u8,
+    capacity_2: u8,
+    goal: u8,
+    start_bucket: &Bucket,
+) -> Option<BucketStats> {
     let state = match *start_bucket {
         Bucket::One => (capacity_1, 0),
         Bucket::Two => (0, capacity_2),

--- a/exercises/two-bucket/src/lib.rs
+++ b/exercises/two-bucket/src/lib.rs
@@ -17,7 +17,12 @@ pub struct BucketStats {
 }
 
 /// Solve the bucket problem
-pub fn solve(capacity_1: u8, capacity_2: u8, goal: u8, start_bucket: &Bucket) -> Option<BucketStats> {
+pub fn solve(
+    capacity_1: u8,
+    capacity_2: u8,
+    goal: u8,
+    start_bucket: &Bucket,
+) -> Option<BucketStats> {
     unimplemented!(
         "Given one bucket of capacity {}, another of capacity {}, starting with {:?}, find pours to reach {}, or None if impossible",
         capacity_1,

--- a/exercises/two-bucket/tests/two-bucket.rs
+++ b/exercises/two-bucket/tests/two-bucket.rs
@@ -80,10 +80,7 @@ fn goal_equal_to_other_bucket() {
 #[test]
 #[ignore]
 fn not_possible_to_reach_the_goal() {
-    assert_eq!(
-        solve(6, 15, 5, &Bucket::One),
-        None
-    );
+    assert_eq!(solve(6, 15, 5, &Bucket::One), None);
 }
 
 #[test]

--- a/exercises/wordy/tests/wordy.rs
+++ b/exercises/wordy/tests/wordy.rs
@@ -162,7 +162,7 @@ fn reject_prefix_notation() {
 
 #[test]
 #[ignore]
-#[cfg(feature="exponentials")]
+#[cfg(feature = "exponentials")]
 fn exponential() {
     let command = "What is 2 raised to the 5th power?";
     assert_eq!(Some(32), answer(command));
@@ -170,7 +170,7 @@ fn exponential() {
 
 #[test]
 #[ignore]
-#[cfg(feature="exponentials")]
+#[cfg(feature = "exponentials")]
 fn addition_and_exponential() {
     let command = "What is 1 plus 2 raised to the 2nd power?";
     assert_eq!(Some(9), answer(command));

--- a/exercises/xorcism/tests/xorcism.rs
+++ b/exercises/xorcism/tests/xorcism.rs
@@ -1,9 +1,9 @@
+use hexlit::hex;
 use rstest::rstest;
 use rstest_reuse::{self, *};
 #[cfg(feature = "io")]
 use std::io::{Read, Write};
 use xorcism::Xorcism;
-use hexlit::hex;
 
 #[test]
 fn identity() {


### PR DESCRIPTION
Part of #659 

To be discussed before merging: Is there any chance at all that a contributor may have a version of `rustfmt` that is different from that run by GitHub Actions, and therefore causes hardship on them in complying with `rustfmt`?