### PR TITLE
circular-buffer, parallel-letter-frequency: use to_string()

### DIFF
--- a/exercises/circular-buffer/src/lib.rs
+++ b/exercises/circular-buffer/src/lib.rs
@@ -19,7 +19,7 @@ impl<T> CircularBuffer<T> {
         unimplemented!(
             "Construct a new CircularBuffer with the capacity to hold {}.",
             match capacity {
-                1 => format!("1 element"),
+                1 => "1 element".to_string(),
                 _ => format!("{} elements", capacity),
             }
         );

--- a/exercises/parallel-letter-frequency/src/lib.rs
+++ b/exercises/parallel-letter-frequency/src/lib.rs
@@ -5,7 +5,7 @@ pub fn frequency(input: &[&str], worker_count: usize) -> HashMap<char, usize> {
         "Count the frequency of letters in the given input '{:?}'. Ensure that you are using {} to process the input.",
         input,
         match worker_count {
-            1 => format!("1 worker"),
+            1 => "1 worker".to_string(),
             _ => format!("{} workers", worker_count),
         }
     );


### PR DESCRIPTION
clippy::useless_format
https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

Helps address https://github.com/exercism/rust/pull/1011