### PR TITLE
anagram, pythagorean-triplet: use collect() instead of from_iter()

### DIFF
--- a/exercises/anagram/tests/anagram.rs
+++ b/exercises/anagram/tests/anagram.rs
@@ -1,10 +1,9 @@
 use std::collections::HashSet;
-use std::iter::FromIterator;
 
 fn process_anagram_case(word: &str, inputs: &[&str], expected: &[&str]) {
     let result = anagram::anagrams_for(word, inputs);
 
-    let expected: HashSet<&str> = HashSet::from_iter(expected.iter().cloned());
+    let expected: HashSet<&str> = expected.iter().cloned().collect();
 
     assert_eq!(result, expected);
 }

--- a/exercises/pythagorean-triplet/tests/pythagorean-triplet.rs
+++ b/exercises/pythagorean-triplet/tests/pythagorean-triplet.rs
@@ -1,11 +1,11 @@
 use pythagorean_triplet::find;
-use std::{collections::HashSet, iter::FromIterator};
+use std::collections::HashSet;
 
 fn process_tripletswithsum_case(sum: u32, expected: &[[u32; 3]]) {
     let triplets = find(sum);
 
     if !expected.is_empty() {
-        let expected = HashSet::from_iter(expected.iter().cloned());
+        let expected: HashSet<_> = expected.iter().cloned().collect();
 
         assert_eq!(expected, triplets);
     } else {


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#from_iter_instead_of_collect
Apparently it should be rare to call `from_iter()` directly.

This lint is a fairly recent addition (merged 17 days ago):
https://github.com/rust-lang/rust-clippy/commit/a2bf404d34529e2b916bdc514bd71309e86908bd

Observing that the necessary code change still works on 1.47.0 (note
that 1.48.0 was released very recently), it seems safe to make the
change now.