### PR TITLE
doubly-linked-list: Allow should_implement_trait

### DIFF
--- a/exercises/doubly-linked-list/example.rs
+++ b/exercises/doubly-linked-list/example.rs
@@ -139,6 +139,7 @@ impl<T> Cursor<'_, T> {
         }
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<&mut T> {
         // safe as node.next is a valid potential pointer
         unsafe { self._step(|node| node.next) }

--- a/exercises/doubly-linked-list/src/lib.rs
+++ b/exercises/doubly-linked-list/src/lib.rs
@@ -42,6 +42,7 @@ impl<T> Cursor<'_, T> {
         unimplemented!()
     }
 
+    #[allow(clippy::should_implement_trait)]
     /// Move one position forward (towards the back) and
     /// return a reference to the new position
     pub fn next(&mut self) -> Option<&mut T> {

--- a/exercises/doubly-linked-list/src/lib.rs
+++ b/exercises/doubly-linked-list/src/lib.rs
@@ -42,9 +42,9 @@ impl<T> Cursor<'_, T> {
         unimplemented!()
     }
 
-    #[allow(clippy::should_implement_trait)]
     /// Move one position forward (towards the back) and
     /// return a reference to the new position
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<&mut T> {
         unimplemented!()
     }


### PR DESCRIPTION
It's understandable that clippy says the `next` here conflicts with
Iterator's `next`, but I really think that's the best name for it unless
we go with something like `forward` and `back`.

There is one other example of Cursors on the internet:
https://contain-rs.github.io/linked-list/linked_list/struct.Cursor.html
This one also uses `next`, so it seems they did not find a better
solution to this than we could.

Helps address https://github.com/exercism/rust/pull/1011
Helps address https://github.com/exercism/rust/pull/1012