### PR TITLE
Fix #961: Change Forth stack return type to slice

### DIFF
--- a/exercises/forth/src/lib.rs
+++ b/exercises/forth/src/lib.rs
@@ -16,7 +16,7 @@ impl Forth {
         unimplemented!()
     }
 
-    pub fn stack(&self) -> Vec<Value> {
+    pub fn stack(&self) -> &[Value] {
         unimplemented!()
     }
 


### PR DESCRIPTION
Closes #961: as discussed, this adjusts the return type to `&[Value]` in order to reduce the amount of cloning required and since it is used for tests only, it does not truly break the type's API.