### PR TITLE
phone-number, scale-generator: use range::contains

### DIFF
--- a/exercises/phone-number/example.rs
+++ b/exercises/phone-number/example.rs
@@ -3,8 +3,7 @@ pub fn number(user_number: &str) -> Option<String> {
 
     let number_len = filtered_number.len();
 
-    if number_len < 10
-        || number_len > 11
+    if !(10..=11).contains(&number_len)
         || (filtered_number.len() == 11 && !filtered_number.starts_with('1'))
     {
         return None;

--- a/exercises/scale-generator/example.rs
+++ b/exercises/scale-generator/example.rs
@@ -244,7 +244,7 @@ pub mod note {
             let mut iter = lc.chars();
 
             let mut note = match iter.next() {
-                Some(c) if 'a' <= c && 'g' >= c => Note {
+                Some(c) if ('a'..='g').contains(&c) => Note {
                     tonic: match c {
                         'a' => Root::A,
                         'b' => Root::B,


### PR DESCRIPTION
I'm honestly not really convinced by the phone-number one but I guess
it's one fewer mention of number_len so it's fine.

https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains