### PR TITLE
Changes to Xorcism discussed in #1040

### DIFF
--- a/config.json
+++ b/config.json
@@ -814,7 +814,7 @@
       "uuid": "0520ad82-75d9-450c-9267-d9758b3b0513",
       "core": false,
       "unlocked_by": "luhn",
-      "difficulty": 7,
+      "difficulty": 10,
       "topics": [
         "bitwise",
         "generics",

--- a/exercises/xorcism/.meta/description.md
+++ b/exercises/xorcism/.meta/description.md
@@ -49,9 +49,16 @@ These traits will be useful:
 
 - [`AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html)
 - [`Borrow`](https://doc.rust-lang.org/std/borrow/trait.Borrow.html)
-- [`ExactSizeIterator`](https://doc.rust-lang.org/std/iter/trait.ExactSizeIterator.html)
 - [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)
 - [`Sized`](https://doc.rust-lang.org/std/marker/trait.Sized.html)
+
+## Lifetime of `munge` return value
+
+Due to the usage of the `impl Trait` feature, lifetime management may be a bit
+tricky when implementing the `munge` method. You may find it easier to write
+your own `struct` with an `Iterator` implementation and return that concrete
+type, at least to get started. Ultimately, it's a good idea to try and implement
+the solution using `Iterator` combinators directly.
 
 ## Bonus Tests
 

--- a/exercises/xorcism/.meta/description.md
+++ b/exercises/xorcism/.meta/description.md
@@ -52,14 +52,6 @@ These traits will be useful:
 - [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)
 - [`Sized`](https://doc.rust-lang.org/std/marker/trait.Sized.html)
 
-## Lifetime of `munge` return value
-
-Due to the usage of the `impl Trait` feature, lifetime management may be a bit
-tricky when implementing the `munge` method. You may find it easier to write
-your own `struct` with an `Iterator` implementation and return that concrete
-type, at least to get started. Ultimately, it's a good idea to try and implement
-the solution using `Iterator` combinators directly.
-
 ## Bonus Tests
 
 This exercise contains bonus tests, behind the `io` feature flag. To enable

--- a/exercises/xorcism/.meta/hints.md
+++ b/exercises/xorcism/.meta/hints.md
@@ -1,0 +1,7 @@
+## Lifetime of `munge` return value
+
+Due to the usage of the `impl Trait` feature, lifetime management may be a bit
+tricky when implementing the `munge` method. You may find it easier to write
+your own `struct` with an `Iterator` implementation and return that concrete
+type, at least to get started. Ultimately, it's a good idea to try and implement
+the solution using `Iterator` combinators directly.

--- a/exercises/xorcism/README.md
+++ b/exercises/xorcism/README.md
@@ -54,14 +54,6 @@ These traits will be useful:
 - [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)
 - [`Sized`](https://doc.rust-lang.org/std/marker/trait.Sized.html)
 
-## Lifetime of `munge` return value
-
-Due to the usage of the `impl Trait` feature, lifetime management may be a bit
-tricky when implementing the `munge` method. You may find it easier to write
-your own `struct` with an `Iterator` implementation and return that concrete
-type, at least to get started. Ultimately, it's a good idea to try and implement
-the solution using `Iterator` combinators directly.
-
 ## Bonus Tests
 
 This exercise contains bonus tests, behind the `io` feature flag. To enable
@@ -88,6 +80,14 @@ appropriate direction. They use these traits:
 
 - [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html)
 - [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html)
+
+## Lifetime of `munge` return value
+
+Due to the usage of the `impl Trait` feature, lifetime management may be a bit
+tricky when implementing the `munge` method. You may find it easier to write
+your own `struct` with an `Iterator` implementation and return that concrete
+type, at least to get started. Ultimately, it's a good idea to try and implement
+the solution using `Iterator` combinators directly.
 
 ## Rust Installation
 

--- a/exercises/xorcism/README.md
+++ b/exercises/xorcism/README.md
@@ -51,7 +51,6 @@ These traits will be useful:
 
 - [`AsRef`](https://doc.rust-lang.org/std/convert/trait.AsRef.html)
 - [`Borrow`](https://doc.rust-lang.org/std/borrow/trait.Borrow.html)
-- [`ExactSizeIterator`](https://doc.rust-lang.org/std/iter/trait.ExactSizeIterator.html)
 - [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)
 - [`Sized`](https://doc.rust-lang.org/std/marker/trait.Sized.html)
 

--- a/exercises/xorcism/README.md
+++ b/exercises/xorcism/README.md
@@ -89,6 +89,7 @@ your own `struct` with an `Iterator` implementation and return that concrete
 type, at least to get started. Ultimately, it's a good idea to try and implement
 the solution using `Iterator` combinators directly.
 
+
 ## Rust Installation
 
 Refer to the [exercism help page][help-page] for Rust installation and learning

--- a/exercises/xorcism/README.md
+++ b/exercises/xorcism/README.md
@@ -55,6 +55,14 @@ These traits will be useful:
 - [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html)
 - [`Sized`](https://doc.rust-lang.org/std/marker/trait.Sized.html)
 
+## Lifetime of `munge` return value
+
+Due to the usage of the `impl Trait` feature, lifetime management may be a bit
+tricky when implementing the `munge` method. You may find it easier to write
+your own `struct` with an `Iterator` implementation and return that concrete
+type, at least to get started. Ultimately, it's a good idea to try and implement
+the solution using `Iterator` combinators directly.
+
 ## Bonus Tests
 
 This exercise contains bonus tests, behind the `io` feature flag. To enable

--- a/exercises/xorcism/example.rs
+++ b/exercises/xorcism/example.rs
@@ -61,7 +61,8 @@ impl<'a> Xorcism<'a> {
     {
         let key = self.key;
         let pos = &mut self.pos;
-        data.into_iter().map(move |d| d.borrow() ^ next_key_byte(key, pos))
+        data.into_iter()
+            .map(move |d| d.borrow() ^ next_key_byte(key, pos))
     }
 
     /// Convert this into a [`Writer`]

--- a/exercises/xorcism/example.rs
+++ b/exercises/xorcism/example.rs
@@ -17,47 +17,17 @@ pub struct Xorcism<'a> {
     pos: usize,
 }
 
-/// For composability, it is important that `munge` returns an iterator compatible with its input.
-///
-/// However, `impl Trait` syntax can specify only a single non-auto trait.
-/// Therefore, we define this output trait with generic implementations on all compatible types,
-/// and return that instead.
-pub trait MungeOutput: Iterator<Item = u8> + ExactSizeIterator {}
-impl<T> MungeOutput for T where T: Iterator<Item = u8> + ExactSizeIterator {}
-
-/// WARNING: This could be construed as abusing the type system
-///
-/// We need to be able to assert that a particular iterator has
-/// an exact size. We need this because `iter::Zip` implements
-/// `ExactSizeIterator` only if both its inputs implement `ExactSizeIterator`, evne though
-/// it will always terminate on the shorter of them.
-///
-/// We wouldn't need this type if negative trait bounds were possible, but it looks like
-/// even in a post-chalk world, those are not likely to be added to the language, as they
-/// could make new trait implementations into a breaking change.
-///
-/// Essentially, this type is used to assert that an infinite iterator has an exact size,
-/// of "the biggest number".
-struct AssertExactSizeIterator<I>(I);
-
-impl<I> Iterator for AssertExactSizeIterator<I>
-where
-    I: Iterator,
-{
-    type Item = <I as Iterator>::Item;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
+/// Ideally this would be a method, but we run into lifetime
+/// issues with that. For more information, see:
+/// https://github.com/rust-lang/rust/issues/80518
+fn next_key_byte(key: &[u8], pos: &mut usize) -> u8 {
+    let b = key[*pos];
+    *pos += 1;
+    if *pos >= key.len() {
+        *pos = 0;
     }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        // oops, all 1s
-        const SIZE: usize = !0;
-        (SIZE, Some(SIZE))
-    }
+    b
 }
-
-impl<I> ExactSizeIterator for AssertExactSizeIterator<I> where I: Iterator {}
 
 impl<'a> Xorcism<'a> {
     /// Create a new Xorcism munger from a key
@@ -69,29 +39,13 @@ impl<'a> Xorcism<'a> {
         Xorcism { key, pos: 0 }
     }
 
-    /// Increase the stored pos by the specified amount, returning the old value.
-    fn incr_pos(&mut self, by: usize) -> usize {
-        let old_pos = self.pos;
-        self.pos += by;
-        old_pos
-    }
-
-    /// Produce the key iterator, offset by `pos`.
-    fn key<'b>(&mut self, pos: usize) -> impl 'b + MungeOutput
-    where
-        'a: 'b,
-    {
-        AssertExactSizeIterator(self.key.iter().copied().cycle().skip(pos))
-    }
-
     /// XOR each byte of the input buffer with a byte from the key.
     ///
     /// Note that this is stateful: repeated calls are likely to produce different results,
     /// even with identical inputs.
     pub fn munge_in_place(&mut self, data: &mut [u8]) {
-        let pos = self.incr_pos(data.len());
-        for (d, k) in data.iter_mut().zip(self.key(pos)) {
-            *d ^= k;
+        for d in data.iter_mut() {
+            *d ^= next_key_byte(self.key, &mut self.pos);
         }
     }
 
@@ -99,16 +53,15 @@ impl<'a> Xorcism<'a> {
     ///
     /// Note that this is stateful: repeated calls are likely to produce different results,
     /// even with identical inputs.
-    pub fn munge<'b, Data, B>(&mut self, data: Data) -> impl 'b + MungeOutput
+    pub fn munge<'b, Data, B>(&'b mut self, data: Data) -> impl 'b + Iterator<Item = u8>
     where
-        'a: 'b,
         Data: IntoIterator<Item = B>,
-        <Data as IntoIterator>::IntoIter: 'b + ExactSizeIterator,
+        <Data as IntoIterator>::IntoIter: 'b,
         B: Borrow<u8>,
     {
-        let data = data.into_iter();
-        let pos = self.incr_pos(data.len());
-        data.zip(self.key(pos)).map(|(d, k)| d.borrow() ^ k)
+        let key = self.key;
+        let pos = &mut self.pos;
+        data.into_iter().map(move |d| d.borrow() ^ next_key_byte(key, pos))
     }
 
     /// Convert this into a [`Writer`]

--- a/exercises/xorcism/src/lib.rs
+++ b/exercises/xorcism/src/lib.rs
@@ -6,14 +6,6 @@ pub struct Xorcism<'a> {
     _phantom: std::marker::PhantomData<&'a u8>,
 }
 
-/// For composability, it is important that `munge` returns an iterator compatible with its input.
-///
-/// However, `impl Trait` syntax can specify only a single non-auto trait.
-/// Therefore, we define this output trait with generic implementations on all compatible types,
-/// and return that instead.
-pub trait MungeOutput: Iterator<Item = u8> + ExactSizeIterator {}
-impl<T> MungeOutput for T where T: Iterator<Item = u8> + ExactSizeIterator {}
-
 impl<'a> Xorcism<'a> {
     /// Create a new Xorcism munger from a key
     ///
@@ -37,7 +29,7 @@ impl<'a> Xorcism<'a> {
     ///
     /// Should accept anything which has a cheap conversion to a byte iterator.
     /// Shouldn't matter whether the byte iterator's values are owned or borrowed.
-    pub fn munge<Data>(&mut self, data: Data) -> impl MungeOutput {
+    pub fn munge<Data>(&mut self, data: Data) -> impl Iterator<Item = u8> {
         unimplemented!();
         // this empty iterator silences a compiler complaint that
         // () doesn't implement ExactSizeIterator

--- a/exercises/xorcism/tests/xorcism.rs
+++ b/exercises/xorcism/tests/xorcism.rs
@@ -59,14 +59,6 @@ fn munge_identity() {
 
 #[test]
 #[ignore]
-fn munge_output_has_len() {
-    let mut xs = Xorcism::new(&[0]);
-    let data = "The output must have a definite length";
-    assert_eq!(xs.munge(data.as_bytes()).len(), 38);
-}
-
-#[test]
-#[ignore]
 fn statefulness() {
     // we expect Xorcism to be stateful: at the end of a munging run, the key has rotated.
     // this means that until the key has completely rotated around, equal inputs will produce

--- a/exercises/xorcism/tests/xorcism.rs
+++ b/exercises/xorcism/tests/xorcism.rs
@@ -6,7 +6,48 @@ use std::io::{Read, Write};
 use xorcism::Xorcism;
 
 #[test]
-fn identity() {
+fn munge_in_place_identity() {
+    let mut xs = Xorcism::new(&[0]);
+    let input = "This is super-secret, cutting edge encryption, folks.".as_bytes();
+    let mut output = input.to_owned();
+    xs.munge_in_place(&mut output);
+
+    assert_eq!(&input, &output);
+}
+
+#[test]
+#[ignore]
+fn munge_in_place_roundtrip() {
+    let mut xs1 = Xorcism::new(&[1, 2, 3, 4, 5]);
+    let mut xs2 = Xorcism::new(&[1, 2, 3, 4, 5]);
+    let input = "This is super-secret, cutting edge encryption, folks.".as_bytes();
+    let mut cipher = input.to_owned();
+    xs1.munge_in_place(&mut cipher);
+    assert_ne!(&input, &cipher);
+    let mut output = cipher;
+    xs2.munge_in_place(&mut output);
+    assert_eq!(&input, &output);
+}
+
+#[test]
+#[ignore]
+fn munge_in_place_stateful() {
+    let mut xs = Xorcism::new(&[1, 2, 3, 4, 5]);
+    let input = "This is super-secret, cutting edge encryption, folks.".as_bytes();
+
+    let mut cipher1 = input.to_owned();
+    let mut cipher2 = input.to_owned();
+    xs.munge_in_place(&mut cipher1);
+    xs.munge_in_place(&mut cipher2);
+
+    assert_ne!(&input, &cipher1);
+    assert_ne!(&input, &cipher2);
+    assert_ne!(&cipher1, &cipher2);
+}
+
+#[test]
+#[ignore]
+fn munge_identity() {
     let mut xs = Xorcism::new(&[0]);
     let data = "This is super-secret, cutting edge encryption, folks.";
 


### PR DESCRIPTION
This should implement all of the changes discussed in #1040, barring one. Outside of a comment around `impl Trait` and removing the link to `ExactSizeIterator`, I did not modify the instructions in README.md. I believe with the change in tests to focus on `munge_in_place` first, the user will have sufficient ramp-up experience implementing the simpler exercise before jumping into the more complex one.