### PR TITLE
Update forth.rs

### DIFF
--- a/exercises/forth/tests/forth.rs
+++ b/exercises/forth/tests/forth.rs
@@ -359,3 +359,15 @@ fn definitions_after_ops() {
     assert!(f.eval("1 2 + : addone 1 + ; addone").is_ok());
     assert_eq!(vec![4], f.stack());
 }
+
+#[test]
+#[ignore]
+fn redefine_an_existing_word_with_another_existing_word() {
+    let mut f = Forth::new();
+    assert!(f.eval(": foo 5 ;").is_ok());
+    assert!(f.eval(": bar foo ;").is_ok());
+    assert!(f.eval(": foo 6 ;").is_ok());
+    assert!(f.eval(": bar foo ;").is_ok());
+    assert!(f.eval("bar foo").is_ok());
+    assert_eq!(vec![6, 6], f.stack());
+}


### PR DESCRIPTION
Redefine_an_existing_word_with_another_existing_word. Compare with "can_use_different_words_with_the_same_name," which defines a new word with an existing word.