### PR TITLE
anagram: Update README.md

### DIFF
--- a/exercises/anagram/.meta/hints.md
+++ b/exercises/anagram/.meta/hints.md
@@ -5,3 +5,7 @@ The solution is case insensitive, which means `"WOrd"` is the same as `"word"` o
 The solution cannot contain the input word. A word is always an anagram of itself, which means it is not an interesting result. Given `"hello"` and the list `["hello", "olleh"]` the answer is `["olleh"]`.
 
 You are going to have to adjust the function signature provided in the stub in order for the lifetimes to work out properly. This is intentional: what's there demonstrates the basics of lifetime syntax, and what's missing teaches how to interpret lifetime-related compiler errors.
+
+Try to limit case changes. Case changes are expensive in terms of time, so it's faster to minimize them.
+
+If sorting, consider [sort_unstable](https://doc.rust-lang.org/std/primitive.slice.html#method.sort_unstable) which is typically faster than stable sorting. When applicable, unstable sorting is preferred because it is generally faster than stable sorting and it doesn't allocate auxiliary memory.

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -15,6 +15,9 @@ The solution cannot contain the input word. A word is always an anagram of itsel
 
 You are going to have to adjust the function signature provided in the stub in order for the lifetimes to work out properly. This is intentional: what's there demonstrates the basics of lifetime syntax, and what's missing teaches how to interpret lifetime-related compiler errors.
 
+Try to limit case changes. Case changes are expensive in terms of time, so it's faster to minimize them.
+
+If sorting, consider [sort_unstable](https://doc.rust-lang.org/std/primitive.slice.html#method.sort_unstable) which is typically faster than stable sorting. When applicable, unstable sorting is preferred because it is generally faster than stable sorting and it doesn't allocate auxiliary memory.
 
 ## Rust Installation
 


### PR DESCRIPTION
Many solutions repeatedly change the case of word, and also repeatedly sort it every time it is compared with a possible anagram. Also, often a possible anagram is case-changed for comparing with the case-changed word and then case-changed again for the purposes of sorting. By minimizing the case changes and using sort_unstable the solutions are usually two to three times faster.

Another hint would be to test the lengths of word and the possible anagram before doing any case changes and sorting of the possible anagram, but I left that out as I considered it might be too much detail up front. But that is another performance tip I often find myself making.