### PR TITLE
grade-school: update to fix clippy lints

### DIFF
--- a/exercises/grade-school/example.rs
+++ b/exercises/grade-school/example.rs
@@ -23,7 +23,7 @@ impl School {
         s
     }
 
-    pub fn grade(&self, grade: u32) -> Option<Vec<String>> {
-        self.grades.get(&grade).map(|v| v.to_vec())
+    pub fn grade(&self, grade: u32) -> Vec<String> {
+        self.grades.get(&grade).map(|v| v.to_vec()).unwrap_or_default()
     }
 }

--- a/exercises/grade-school/example.rs
+++ b/exercises/grade-school/example.rs
@@ -24,6 +24,9 @@ impl School {
     }
 
     pub fn grade(&self, grade: u32) -> Vec<String> {
-        self.grades.get(&grade).map(|v| v.to_vec()).unwrap_or_default()
+        self.grades
+            .get(&grade)
+            .map(|v| v.to_vec())
+            .unwrap_or_default()
     }
 }

--- a/exercises/grade-school/src/lib.rs
+++ b/exercises/grade-school/src/lib.rs
@@ -1,3 +1,10 @@
+// This annotation prevents Clippy from warning us that `School` has a
+// `fn new()` with no arguments, but doesn't implement the `Default` trait.
+//
+// Normally, it's good practice to just do what Clippy tells you, but in this
+// case, we want to keep things relatively simple. The `Default` trait is not the point
+// of this exercise.
+#[allow(clippy::new_without_default)]
 pub struct School {}
 
 impl School {
@@ -13,11 +20,11 @@ impl School {
         unimplemented!()
     }
 
-    // If grade returned an `Option<&Vec<String>>`,
-    // the internal implementation would be forced to keep a `Vec<String>` to lend out.
-    // By returning an owned vector instead,
-    // the internal implementation is free to use whatever it chooses.
-    pub fn grade(&self, grade: u32) -> Option<Vec<String>> {
+    // If `grade` returned a reference, `School` would be forced to keep a `Vec<String>`
+    // internally to lend out. By returning an owned vector of owned `String`s instead,
+    // the internal structure can be completely arbitrary. The tradeoff is that some data
+    // must be copied each time `grade` is called.
+    pub fn grade(&self, grade: u32) -> Vec<String> {
         unimplemented!("Return the list of students in {}", grade)
     }
 }

--- a/exercises/grade-school/tests/grade-school.rs
+++ b/exercises/grade-school/tests/grade-school.rs
@@ -1,7 +1,7 @@
 use grade_school as school;
 
-fn some_strings(v: &[&str]) -> Option<Vec<String>> {
-    Some(v.iter().map(|s| s.to_string()).collect())
+fn to_owned(v: &[&str]) -> Vec<String> {
+    v.iter().map(|s| s.to_string()).collect()
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn test_grades_when_several_students_have_the_same_grade() {
 #[ignore]
 fn test_grade_for_empty_school() {
     let s = school::School::new();
-    assert_eq!(s.grade(1), None);
+    assert_eq!(s.grade(1), Vec::<String>::new());
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn test_grade_for_empty_school() {
 fn test_grade_when_no_students_have_that_grade() {
     let mut s = school::School::new();
     s.add(7, "Logan");
-    assert_eq!(s.grade(1), None);
+    assert_eq!(s.grade(1), Vec::<String>::new());
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn test_grade_when_no_students_have_that_grade() {
 fn test_grade_for_one_student() {
     let mut s = school::School::new();
     s.add(2, "Aimee");
-    assert_eq!(s.grade(2), some_strings(&["Aimee"]));
+    assert_eq!(s.grade(2), to_owned(&["Aimee"]));
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn test_grade_returns_students_sorted_by_name() {
     s.add(2, "James");
     s.add(2, "Blair");
     s.add(2, "Paul");
-    assert_eq!(s.grade(2), some_strings(&["Blair", "James", "Paul"]));
+    assert_eq!(s.grade(2), to_owned(&["Blair", "James", "Paul"]));
 }
 
 #[test]
@@ -78,6 +78,6 @@ fn test_add_students_to_different_grades() {
     s.add(3, "Chelsea");
     s.add(7, "Logan");
     assert_eq!(s.grades(), vec![3, 7]);
-    assert_eq!(s.grade(3), some_strings(&["Chelsea"]));
-    assert_eq!(s.grade(7), some_strings(&["Logan"]));
+    assert_eq!(s.grade(3), to_owned(&["Chelsea"]));
+    assert_eq!(s.grade(7), to_owned(&["Logan"]));
 }


### PR DESCRIPTION
Also update the hint about why `grade` doesn't return a reference.

Fixes CI failures on `master` branch.