### PR TITLE
Add HashMap import to invalid test cases for Macros

### DIFF
--- a/exercises/macros/tests/invalid/Cargo.toml
+++ b/exercises/macros/tests/invalid/Cargo.toml
@@ -45,3 +45,7 @@ path = "two-arrows.rs"
 [[bin]]
 name = "leading-comma-rs"
 path = "leading-comma.rs"
+
+[[bin]]
+name = "no-comma-rs"
+path = "no-comma.rs"

--- a/exercises/macros/tests/invalid/comma-sep.rs
+++ b/exercises/macros/tests/invalid/comma-sep.rs
@@ -3,5 +3,5 @@ use std::collections::HashMap;
 
 fn main() {
     // using only commas is invalid
-    let _hm: ::std::collections::HashMap<_, _> = hashmap!('a', 1);
+    let _hm: HashMap<_, _> = hashmap!('a', 1);
 }

--- a/exercises/macros/tests/invalid/comma-sep.rs
+++ b/exercises/macros/tests/invalid/comma-sep.rs
@@ -1,4 +1,5 @@
 use macros::hashmap;
+use std::collections::HashMap;
 
 fn main() {
     // using only commas is invalid

--- a/exercises/macros/tests/invalid/double-commas.rs
+++ b/exercises/macros/tests/invalid/double-commas.rs
@@ -1,4 +1,5 @@
 use macros::hashmap;
+use std::collections::HashMap;
 
 fn main() {
     // a single trailing comma is okay, but two is not

--- a/exercises/macros/tests/invalid/double-commas.rs
+++ b/exercises/macros/tests/invalid/double-commas.rs
@@ -3,5 +3,5 @@ use std::collections::HashMap;
 
 fn main() {
     // a single trailing comma is okay, but two is not
-    let _hm: ::std::collections::HashMap<_, _> = hashmap!('a' => 2, ,);
+    let _hm: HashMap<_, _> = hashmap!('a' => 2, ,);
 }

--- a/exercises/macros/tests/invalid/leading-comma.rs
+++ b/exercises/macros/tests/invalid/leading-comma.rs
@@ -3,5 +3,5 @@ use std::collections::HashMap;
 
 fn main() {
     // leading commas are not valid
-    let _hm: ::std::collections::HashMap<_, _> = hashmap!(, 'a' => 2);
+    let _hm: HashMap<_, _> = hashmap!(, 'a' => 2);
 }

--- a/exercises/macros/tests/invalid/leading-comma.rs
+++ b/exercises/macros/tests/invalid/leading-comma.rs
@@ -1,4 +1,5 @@
 use macros::hashmap;
+use std::collections::HashMap;
 
 fn main() {
     // leading commas are not valid

--- a/exercises/macros/tests/invalid/no-comma.rs
+++ b/exercises/macros/tests/invalid/no-comma.rs
@@ -1,0 +1,7 @@
+use macros::hashmap;
+use std::collections::HashMap;
+
+fn main() {
+    // Key value pairs must be separated by commas
+    let _hm: HashMap<_, _> = hashmap!('a' => 1 'b' => 2);
+}

--- a/exercises/macros/tests/invalid/only-arrow.rs
+++ b/exercises/macros/tests/invalid/only-arrow.rs
@@ -3,5 +3,5 @@ use std::collections::HashMap;
 
 fn main() {
     // a single random arrow is not valid
-    let _hm: ::std::collections::HashMap<(), ()> = hashmap!(=>);
+    let _hm: HashMap<(), ()> = hashmap!(=>);
 }

--- a/exercises/macros/tests/invalid/only-arrow.rs
+++ b/exercises/macros/tests/invalid/only-arrow.rs
@@ -1,4 +1,5 @@
 use macros::hashmap;
+use std::collections::HashMap;
 
 fn main() {
     // a single random arrow is not valid

--- a/exercises/macros/tests/invalid/only-comma.rs
+++ b/exercises/macros/tests/invalid/only-comma.rs
@@ -3,5 +3,5 @@ use std::collections::HashMap;
 
 fn main() {
     // a single random comma is not valid
-    let _hm: ::std::collections::HashMap<(), ()> = hashmap!(,);
+    let _hm: HashMap<(), ()> = hashmap!(,);
 }

--- a/exercises/macros/tests/invalid/only-comma.rs
+++ b/exercises/macros/tests/invalid/only-comma.rs
@@ -1,4 +1,5 @@
 use macros::hashmap;
+use std::collections::HashMap;
 
 fn main() {
     // a single random comma is not valid

--- a/exercises/macros/tests/invalid/single-argument.rs
+++ b/exercises/macros/tests/invalid/single-argument.rs
@@ -1,4 +1,5 @@
 use macros::hashmap;
+use std::collections::HashMap;
 
 fn main() {
     // a single argument is invalid

--- a/exercises/macros/tests/invalid/single-argument.rs
+++ b/exercises/macros/tests/invalid/single-argument.rs
@@ -3,5 +3,5 @@ use std::collections::HashMap;
 
 fn main() {
     // a single argument is invalid
-    let _hm: ::std::collections::HashMap<_, _> = hashmap!('a');
+    let _hm: HashMap<_, _> = hashmap!('a');
 }

--- a/exercises/macros/tests/invalid/triple-arguments.rs
+++ b/exercises/macros/tests/invalid/triple-arguments.rs
@@ -1,4 +1,5 @@
 use macros::hashmap;
+use std::collections::HashMap;
 
 fn main() {
     // three arguments are invalid

--- a/exercises/macros/tests/invalid/two-arrows.rs
+++ b/exercises/macros/tests/invalid/two-arrows.rs
@@ -1,4 +1,5 @@
 use macros::hashmap;
+use std::collections::HashMap;
 
 fn main() {
     // a trailing => isn't valid either

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -162,6 +162,12 @@ fn test_compile_fails_leading_comma() {
     simple_trybuild::compile_fail("leading-comma.rs");
 }
 
+#[test]
+#[ignore]
+fn test_compile_fails_no_comma() {
+    simple_trybuild::compile_fail("no-comma.rs");
+}
+
 mod simple_trybuild {
     use std::path::PathBuf;
     use std::process::Command;


### PR DESCRIPTION
This solution currently passes all of the tests but is incorrect:

```rust
#[macro_export]
macro_rules! hashmap {
    ( $($key:expr => $val:expr),* $(,)?) => {
        {
            use crate::HashMap;

            let mut map = HashMap::new();
            $(
                map.insert($key, $val);
            )*
            map
        }
    };
}
```

The macro accepts `hashmap!(,)` but because the solution also uses `crate::HashMap`, the invalid cases all fail to compile due to the import even if they would otherwise succeed. This PR prevents this sort of failure by providing the same imports to the negative cases as to the positive cases.