### PR TITLE
Add new missing-argument.rs test for Macros

### DIFF
--- a/exercises/macros/tests/invalid/Cargo.toml
+++ b/exercises/macros/tests/invalid/Cargo.toml
@@ -49,3 +49,7 @@ path = "leading-comma.rs"
 [[bin]]
 name = "no-comma-rs"
 path = "no-comma.rs"
+
+[[bin]]
+name = "missing-argument-rs"
+path = "missing-argument.rs"

--- a/exercises/macros/tests/invalid/missing-argument.rs
+++ b/exercises/macros/tests/invalid/missing-argument.rs
@@ -1,0 +1,7 @@
+use macros::hashmap;
+use std::collections::HashMap;
+
+fn main() {
+    // an argument should come between each pair of commas
+    let _hm: HashMap<_, _> = hashmap!('a' => 1, , 'b' => 2);
+}

--- a/exercises/macros/tests/macros.rs
+++ b/exercises/macros/tests/macros.rs
@@ -168,6 +168,12 @@ fn test_compile_fails_no_comma() {
     simple_trybuild::compile_fail("no-comma.rs");
 }
 
+#[test]
+#[ignore]
+fn test_compile_fails_missing_argument() {
+    simple_trybuild::compile_fail("missing-argument.rs");
+}
+
 mod simple_trybuild {
     use std::path::PathBuf;
     use std::process::Command;


### PR DESCRIPTION
Another test to catch an invalid student solution. Thanks to @bobahop for catching it.

```rust
#[macro_export]
macro_rules! hashmap {
    ( $($key:expr => $val:expr$(,)?),* ) => {{
        let mut hash_map = ::std::collections::HashMap::new();
        $(
            hash_map.insert($key, $val);
        )*
        hash_map
    }};
}
```