### PR TITLE
Add key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -1345,6 +1345,31 @@
       "blurb": "Structs: fixed-size collections of heterogenous data"
     }
   ],
-  "key_features": [],
+  "key_features": [
+    {
+      "title": "Performance",
+      "content": "Rust is blazingly fast and memory-efficient; it has no runtime or garbage collector."
+    },
+    {
+      "title": "Reliability",
+      "content": "Rust’s rich type system and ownership model guarantee memory-safety and thread-safety."
+    },
+    {
+      "title": "Productivity",
+      "content": "Rust has great documentation, a friendly compiler with useful error messages, and top-notch tooling."
+    },
+    {
+      "title": "Cargo",
+      "content": "Rust's package manager and build tool is best-in-class."
+    },
+    {
+      "title": "Write Once, Run Anywhere",
+      "content": "Rust compiles by default to a single static executable, and cross-compilation is easy."
+    },
+    {
+      "title": "❤︎",
+      "content": "Stack Overflow's most-loved language every year since 2016."
+    }
+  ],
   "tags": []
 }


### PR DESCRIPTION
Closes #1087.

@ErikSchierboom this omits the icons, because there is still no
documentation about what icons are available. It's listed as a
TODO in the documentation.