### PR TITLE
close 1078 option cleanup

### DIFF
--- a/concepts/option/about.md
+++ b/concepts/option/about.md
@@ -2,7 +2,7 @@ The `Option` type is an enum provided by the standard library. It is useful for 
 While this may sound like `null` or `nil`, it is quite different and special.
 `Option` is distinctive to Rust. It is also quite fun to work with!
 
-`Option<T>` holds other types and has two variants `Some` and `None`.
+`Option<T>` holds other types and has two variants: `Some(T)` and `None`.
 
 For example, `Option<u32>` holds the `u32` type.
 

--- a/concepts/option/about.md
+++ b/concepts/option/about.md
@@ -19,7 +19,7 @@ There are several common idioms for using the value which might be present in an
    
     The `match` operator also lets you unpack and handle `None` cases in one statement or expression. It is an alternative to a chain of if and else statements. Using `match` can increase the readability of some sections of code.
 - `optional.map(|t| ...)` 
-   `Option::map` creates an Option with a new type created from the provided function. 
+   `Option::map` updates an Option in place, potentially with a new type, from the provided function. 
    
    **Note**: operates on the contained value if present. The binding becomes an `Option<U>`, where the given closure is `FnOnce(T) -> U`.
 - `optional.unwrap()`. 

--- a/concepts/option/about.md
+++ b/concepts/option/about.md
@@ -1,1 +1,21 @@
-TODO: add information on option concept
+The `Option` type is an enum provided by the standard library. It is useful for expressing whether a value exists or does not exist.
+While this may sound like `null` or `nil`, it is quite different and special.
+`Option` is distinctive to Rust. It is also quite fun to work with!
+
+`Option<T>` holds other types and has two variants `Some` and `None`.
+
+For example, `Option<u32>` holds the `u32` type.
+
+The below snippets demonstrate what this would look like in some Rust code.
+
+When a value exists in an `Option<u32>`:
+```rust
+let has_something: Option<u32> = Some(100);
+assert_eq!(has_something.unwrap(), 100);
+```
+
+When a value *does not* exist in an `Option<u32>`:
+```rust
+let has_nothing: Option<u32> = None;
+assert_eq!(has_nothing, None);
+```

--- a/concepts/option/about.md
+++ b/concepts/option/about.md
@@ -1,12 +1,32 @@
 The `Option` type is an enum provided by the standard library. It is useful for expressing a value which may not exist.
 While this may sound like `null` or `nil`, it is quite different and special.
-`Option` is distinctive to Rust. It is also quite fun to work with!
 
 `Option<T>` holds other types and has two variants: `Some(T)` and `None`.
 
 For example, `Option<u32>` holds the `u32` type.
 
-The below snippets demonstrate what this would look like in some Rust code.
+## Usage
+
+### Using the `T` within `Option<T>`
+
+There are several common idioms for using the value which might be present in an `Option`:
+
+- `if let Some(t) = optional { ... }`. 
+
+    The `if let` idiom extracts the value from an Option<T> and binds it to the variable `t`. This lets you use it directly in that block scope.
+
+- `match optional { Some(t) => {...}, None => {...}}`
+   
+    The `match` operator also lets you unpack and handle `None` cases in one statement or expression. It is an alternative to a chain of if and else statements. Using `match` can increase the readability of some sections of code.
+- `optional.map(|t| ...)` **Note**: operates on the contained value if present. The binding becomes an `Option<U>`, where the given closure is `FnOnce(T) -> U`.
+- `optional.unwrap()`. 
+   Unwrapping an `Option<T>` extracts `T` but will panic if `T` is not there. It is expedient in some cases.
+   **Important**: Unwrapping can ease development in the short term or in test code, but it introduces the possibility of runtime panics. It should be avoided when possible.
+
+- `optional.expect("Unexpected None found! Aborting program.)`. 
+   The `expect` method on `Option<T>` is quite similar to `unwrap()` but it will panic using the provided message if it is `None`.
+
+## Examples
 
 When a value exists in an `Option<u32>`:
 ```rust

--- a/concepts/option/about.md
+++ b/concepts/option/about.md
@@ -18,9 +18,13 @@ There are several common idioms for using the value which might be present in an
 - `match optional { Some(t) => {...}, None => {...}}`
    
     The `match` operator also lets you unpack and handle `None` cases in one statement or expression. It is an alternative to a chain of if and else statements. Using `match` can increase the readability of some sections of code.
-- `optional.map(|t| ...)` **Note**: operates on the contained value if present. The binding becomes an `Option<U>`, where the given closure is `FnOnce(T) -> U`.
+- `optional.map(|t| ...)` 
+   `Option::map` creates an Option with a new type created from the provided function. 
+   
+   **Note**: operates on the contained value if present. The binding becomes an `Option<U>`, where the given closure is `FnOnce(T) -> U`.
 - `optional.unwrap()`. 
    Unwrapping an `Option<T>` extracts `T` but will panic if `T` is not there. It is expedient in some cases.
+   
    **Important**: Unwrapping can ease development in the short term or in test code, but it introduces the possibility of runtime panics. It should be avoided when possible.
 
 - `optional.expect("Unexpected None found! Aborting program.)`. 

--- a/concepts/option/about.md
+++ b/concepts/option/about.md
@@ -1,4 +1,4 @@
-The `Option` type is an enum provided by the standard library. It is useful for expressing whether a value exists or does not exist.
+The `Option` type is an enum provided by the standard library. It is useful for expressing a value which may not exist.
 While this may sound like `null` or `nil`, it is quite different and special.
 `Option` is distinctive to Rust. It is also quite fun to work with!
 

--- a/concepts/option/introduction.md
+++ b/concepts/option/introduction.md
@@ -1,3 +1,2 @@
-TODO: the content below is copied from the exercise introduction and probably needs rewriting to a proper concept introduction
-
-## option
+The standard library provides an enum called `Option` to help you express when a value exists or does not exist.
+You'll see it referred to as `Option<T>` where `T` is the type of the value you are working with.

--- a/concepts/option/introduction.md
+++ b/concepts/option/introduction.md
@@ -1,2 +1,2 @@
-The standard library provides an enum called `Option` to help you express when a value exists or does not exist.
+The standard library provides an enum called `Option` to help you express when a value may or may not exist.
 You'll see it referred to as `Option<T>` where `T` is the type of the value you are working with.

--- a/concepts/option/links.json
+++ b/concepts/option/links.json
@@ -1,1 +1,4 @@
-[]
+[
+	{"description": "Standard library documentation", "url": "https://doc.rust-lang.org/std/option/index.html"},
+	{"description": "The RPL Book discussion Option", "url": "https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html"}
+]

--- a/concepts/option/links.json
+++ b/concepts/option/links.json
@@ -1,4 +1,4 @@
 [
 	{"description": "Standard library documentation", "url": "https://doc.rust-lang.org/std/option/index.html"},
-	{"description": "The RPL Book discussion Option", "url": "https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html"}
+	{"description": "The RPL Book discussion Option", "url": "https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html#the-option-enum-and-its-advantages-over-null-values"}
 ]


### PR DESCRIPTION
> Purpose: Provide information about the concept for a student who has completed the corresponding concept exercise to learn from and refer back to.
[introduction.md purpose](https://github.com/exercism/docs/blob/main/anatomy/tracks/concepts.md) 

I'm leaning toward keeping the `concepts/` on the shorter side for two reasons:
- I tend to want to write novels... 😄 
- it seems much easier to expand these appropriately in our merging review and when eventually soliciting student contributions

Fix #1078.