### PR TITLE
simplify struct's introduction, add to about.md

### DIFF
--- a/concepts/structs/about.md
+++ b/concepts/structs/about.md
@@ -10,9 +10,8 @@ Structs collect a fixed, heterogeneous set of data into a single unit. Structs i
 
 # Structs Overview
 
-Structs come in three flavors: structs with named fields, tuple structs, and unit structs. 
-
-Structs are defined using the `struct` keyword, followed by the capitalized name of the type the struct is describing:
+Structs are defined using the `struct` keyword, followed by the name of the type the struct is describing.
+The name may then be followed by curly braces (for a standard struct), parentheses (for a tuple struct), or a semicolon (for a unit struct).
 
 ```rust
 struct Item {}
@@ -40,6 +39,8 @@ impl Item {
 ```
 
 # Struct Flavors 
+
+Structs come in three flavors: structs with named fields (standard structs), tuple structs, and unit structs. 
 
 Structs are very much like **Tuples**. In fact, the only difference between structs and tuples has to do with what is anonymous. The general form goes like this:
 

--- a/concepts/structs/about.md
+++ b/concepts/structs/about.md
@@ -1,20 +1,52 @@
 # Structs
 
-Structs collect a fixed, heterogenous set of data into a single unit. Structs in Rust have these properties:
+Structs collect a fixed, heterogeneous set of data into a single unit. Structs in Rust have these properties:
 
 - Every struct type has a particular name.
 - Every member of a struct is called a **field**.
 - Every field of a struct has a particular name.
 - Visibility is tracked at the field level: each field may be independently public, private, or other[^1].
 
-# Tuples etc.
+
+# Structs Overview
+
+Structs come in three flavors: structs with named fields, tuple structs, and unit structs. 
+
+Structs are defined using the `struct` keyword, followed by the capitalized name of the type the struct is describing:
+
+```rust
+struct Item {}
+```
+
+Additional types are then brought into the struct body as _fields_ of the struct, each with their own type:
+
+```rust
+struct Item {
+    name: String,
+    weight: f32,
+    worth: u32,
+}
+```
+
+Lastly, methods can be defined on structs inside of an `impl` block:
+
+```rust
+impl Item {
+    // initializes and returns a new instance of our Item struct
+    fn new() -> Self {
+        unimplemented!()
+    }
+}
+```
+
+# Struct Flavors 
 
 Structs are very much like **Tuples**. In fact, the only difference between structs and tuples has to do with what is anonymous. The general form goes like this:
 
 - Structs are named and have named fields:
 
   ```rust
-  struct Foo{
+  struct Foo {
       bar: Bar,
       bat: Bat,
   }

--- a/concepts/structs/introduction.md
+++ b/concepts/structs/introduction.md
@@ -1,36 +1,3 @@
-It is often useful to group a collection of items together, and handle those groups as units. In Rust, we call such a group a struct, and each item one of the struct's fields. A struct defines the general set of fields available, but a particular example of a struct is called an instance.
+It is often useful to group a collection of items together, and handle those groups as units. 
 
-Furthermore, structs can have methods defined on them, which have access to the fields. The struct itself in that case is referred to as `self`. When a method uses `&mut self`, the fields can be changed, or mutated. When a method uses `&self`, the fields cannot be changed: they are immutable. Controlling mutability helps the borrow-checker ensure that entire classes of concurrency bug just don't happen in Rust.
-
-In this exercise, you'll be implementing two kinds of methods on a struct. The first are generally known as getters: they expose the struct's fields to the world, without letting anyone else mutate that value. In Rust, these methods idiomatically share the name of the field they expose, i.e., if we have a getter method that fetches a struct field called `name`, the method would simply be called `name()`.
-
-You'll also be implementing methods of another type, generally known as setters. These change the value of the field. Setters aren't very common in Rust--if a field can be freely modified, it is more common to just make it public--but they're useful if updating the field should have side effects, or for access control: a setter marked as `pub(crate)` allows other modules within the same crate to update a private field, which can't be affected by the outside world.
-
-Structs come in three flavors: structs with named fields, tuple structs, and unit structs. For this concept exercise, we'll be exploring the first variant: structs with named fields.
-
-Structs are defined using the `struct` keyword, followed by the capitalized name of the type the struct is describing:
-
-```rust
-struct Item {}
-```
-
-Additional types are then brought into the struct body as _fields_ of the struct, each with their own type:
-
-```rust
-struct Item {
-    name: String,
-    weight: f32,
-    worth: u32,
-}
-```
-
-Lastly, methods can be defined on structs inside of an `impl` block:
-
-```rust
-impl Item {
-    // initializes and returns a new instance of our Item struct
-    fn new() -> Self {
-        unimplemented!()
-    }
-}
-```
+In Rust, we call such a group a struct, and each item one of the struct's fields. A struct defines the general set of fields available, but a particular example of a struct is called an instance.


### PR DESCRIPTION
Close #1079.

I'm leaning towards keeping code samples out of our introduction.md's
and into `about.md`.

I like the style of introducing the concept in 1 or 2 lines of prose.