### PR TITLE
minimal markdownlint CLI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: main
+      - name: Checkout code
+        uses: actions/checkout@v2
 
       - name: Run markdown lint
         run: ./bin/markdown_lint.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: main
+
       - name: Run markdown lint
         uses: xt0rted/markdownlint-problem-matcher@v1
         run: ./bin/markdown_lint.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
           ref: main
       - name: Run markdown lint
       - uses: xt0rted/markdownlint-problem-matcher@v1
-        run: ./bin/markdown_lint.sh
+      - run: ./bin/markdown_lint.sh
   compilation:
     name: Check compilation
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,8 +67,8 @@ jobs:
         with:
           ref: main
       - name: Run markdown lint
-      - uses: xt0rted/markdownlint-problem-matcher@v1
-      - run: ./bin/markdown_lint.sh
+        uses: xt0rted/markdownlint-problem-matcher@v1
+        run: ./bin/markdown_lint.sh
 
   compilation:
     name: Check compilation

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,6 @@ jobs:
           ref: main
 
       - name: Run markdown lint
-        uses: xt0rted/markdownlint-problem-matcher@v1
         run: ./bin/markdown_lint.sh
 
   compilation:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,18 @@ jobs:
       - name: Lint configlet
         run: ./bin/configlet lint
 
+  markdownlint:
+    name: markdown lint
+    runs-on: ubuntu-latest
 
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+        with:
+          ref: main
+      - name: Run markdown lint
+      - uses: xt0rted/markdownlint-problem-matcher@v1
+        run: ./bin/markdown_lint.sh
   compilation:
     name: Check compilation
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Run markdown lint
       - uses: xt0rted/markdownlint-problem-matcher@v1
       - run: ./bin/markdown_lint.sh
+
   compilation:
     name: Check compilation
     runs-on: ubuntu-latest

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -23,3 +23,11 @@ MD013: false
 # MD014/commands-show-output - Dollar signs used before commands without showing output
 MD014: false
 
+# MD039/no-space-in-links - Spaces inside link text
+MD039: true
+
+# MD040/fenced-code-language - Fenced code blocks should have a language specified
+MD040: true
+# MD042/no-empty-links - No empty links
+MD042: true
+

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,25 @@
+# Example markdownlint YAML configuration with all properties set to their default value
+
+# Default state for all rules
+default: false
+
+# Path to configuration file to extend
+extends: null
+
+# MD001/heading-increment/header-increment - Heading levels should only increment by one level at a time
+MD001: true
+# MD002/first-heading-h1/first-header-h1 - First heading should be a top-level heading
+MD002:
+  # Heading level
+  level: 1
+
+# MD003/heading-style/header-style - Heading style
+MD003:
+  # Heading style
+  style: "atx"
+
+MD009: true
+MD013: false
+# MD014/commands-show-output - Dollar signs used before commands without showing output
+MD014: false
+

--- a/bin/markdown_lint.sh
+++ b/bin/markdown_lint.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env sh
+set -e
 npx markdownlint-cli concepts/**/*.md exercises/**/*.md

--- a/bin/markdown_lint.sh
+++ b/bin/markdown_lint.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+markdownlint concepts/**/*.md --ignore node_modules

--- a/bin/markdown_lint.sh
+++ b/bin/markdown_lint.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-npx markdownlint-cli concepts/**/*.md --ignore node_modules
+npx markdownlint-cli concepts/**/*.md

--- a/bin/markdown_lint.sh
+++ b/bin/markdown_lint.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-npx markdownlint-cli concepts/**/*.md
+npx markdownlint-cli concepts/**/*.md exercises/**/*.md

--- a/bin/markdown_lint.sh
+++ b/bin/markdown_lint.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-markdownlint concepts/**/*.md --ignore node_modules
+npx markdownlint concepts/**/*.md --ignore node_modules

--- a/bin/markdown_lint.sh
+++ b/bin/markdown_lint.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-npx markdownlint concepts/**/*.md --ignore node_modules
+npx markdownlint-cli concepts/**/*.md --ignore node_modules

--- a/concepts/explicit-return/about.md
+++ b/concepts/explicit-return/about.md
@@ -1,3 +1,3 @@
-# About
+# About   
 
 TODO

--- a/concepts/explicit-return/about.md
+++ b/concepts/explicit-return/about.md
@@ -1,3 +1,3 @@
-# About   
+# About
 
 TODO

--- a/concepts/option/about.md
+++ b/concepts/option/about.md
@@ -13,23 +13,23 @@ For example, `Option<u32>` holds the `u32` type.
 
 There are several common idioms for using the value which might be present in an `Option`:
 
-- `if let Some(t) = optional { ... }`. 
+- `if let Some(t) = optional { ... }`.
 
     The `if let` idiom extracts the value from an Option<T> and binds it to the variable `t`. This lets you use it directly in that block scope.
 
 - `match optional { Some(t) => {...}, None => {...}}`
-   
+
     The `match` operator also lets you unpack and handle `None` cases in one statement or expression. It is an alternative to a chain of if and else statements. Using `match` can increase the readability of some sections of code.
-- `optional.map(|t| ...)` 
-   `Option::map` updates an Option in place, potentially with a new type, from the provided function. 
-   
+- `optional.map(|t| ...)`
+   `Option::map` updates an Option in place, potentially with a new type, from the provided function.
+
    **Note**: operates on the contained value if present. The binding becomes an `Option<U>`, where the given closure is `FnOnce(T) -> U`.
-- `optional.unwrap()`. 
+- `optional.unwrap()`.
    Unwrapping an `Option<T>` extracts `T` but will panic if `T` is not there. It is expedient in some cases.
-   
+
    **Important**: Unwrapping can ease development in the short term or in test code, but it introduces the possibility of runtime panics. It should be avoided when possible.
 
-- `optional.expect("Unexpected None found! Aborting program.)`. 
+- `optional.expect("Unexpected None found! Aborting program.)`.
    The `expect` method on `Option<T>` is quite similar to `unwrap()` but it will panic using the provided message if it is `None`.
 
 ## Examples

--- a/concepts/structs/about.md
+++ b/concepts/structs/about.md
@@ -38,9 +38,9 @@ impl Item {
 }
 ```
 
-# Struct Flavors 
+# Struct Flavors
 
-Structs come in three flavors: structs with named fields (standard structs), tuple structs, and unit structs. 
+Structs come in three flavors: structs with named fields (standard structs), tuple structs, and unit structs.
 
 Structs are very much like **Tuples**. In fact, the only difference between structs and tuples has to do with what is anonymous. The general form goes like this:
 

--- a/concepts/structs/introduction.md
+++ b/concepts/structs/introduction.md
@@ -1,5 +1,5 @@
 # Introduction
 
-It is often useful to group a collection of items together, and handle those groups as units. 
+It is often useful to group a collection of items together, and handle those groups as units.
 
 In Rust, we call such a group a struct, and each item one of the struct's fields. A struct defines the general set of fields available, but a particular example of a struct is called an instance.

--- a/exercises/practice/hello-world/GETTING_STARTED.md
+++ b/exercises/practice/hello-world/GETTING_STARTED.md
@@ -14,13 +14,13 @@ section from exercism is also useful.
 
 Run the test suite. It can be run with `cargo`, which is installed with rust.
 
-```
+```sh
 $ cargo test
 ```
 
 This will compile the `hello-world` crate and run the test, which fails.
 
-```
+```sh
 running 1 test
 test test_hello_world ... FAILED
 
@@ -42,7 +42,7 @@ The `test_hello_world` failure states that it is expecting the value,
 `"Hello, World!"`, to be returned from `hello()`.
 The left side of the assertion (at line 5) should be equal to the right side.
 
-```
+```sh
 ---- test_hello_world stdout ----
 thread 'test_hello_world' panicked at 'assertion failed: `(left == right)`
 (left: `"Hello, World!"`, right: `"Goodbye, World!"`)', tests/hello-world.rs:5
@@ -63,7 +63,7 @@ pub fn hello() -> &'static str {
 
 Run the test again. This time, it will pass.
 
-```
+```sh
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
@@ -87,6 +87,6 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 Once the test is passing, you can submit your code with the following
 command:
 
-```
+```sh
 $ exercism submit src/lib.rs
 ```


### PR DESCRIPTION
This was much easier to configure and it look's like we can preserve the shell runner script pattern.
By that I mean ./bin/markdown_lint.sh does the work. And a contributor can run it locally too.
Close #1132.

## questions
- can I lint hidden files (.meta/design.md)? yes, will need to modify invocation
- can I exclude legacy files? Yes
- can I start with a small subset of linting rules? yes. 
- what is the CLI? Using: https://github.com/igorshubovych/markdownlint-cli#markdownlint-cli