### PR TITLE
enable another markdown lint rule

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,4 +1,5 @@
 # Example markdownlint YAML configuration with all properties set to their default value
+# See here: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#rules
 
 # Default state for all rules
 default: false
@@ -19,6 +20,8 @@ MD003:
   style: "atx"
 
 MD009: true
+# no reversed links
+MD011: false
 MD013: false
 # MD014/commands-show-output - Dollar signs used before commands without showing output
 MD014: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -21,7 +21,7 @@ MD003:
 
 MD009: true
 # no reversed links
-MD011: false
+MD011: true
 MD013: false
 # MD014/commands-show-output - Dollar signs used before commands without showing output
 MD014: false


### PR DESCRIPTION
We ran into this in a PR review so I think it is reasonable to enable
it.

As an aside, I researched if markdown CLI let's you enforce reference style links. By default no.
But the underlying library does let you specify custom rules.
See another project's [implementation](https://github.com/webhintio/hint/commit/c412f9aa7ba99eb7ef6c20b7c496d629530f3ecf).

In our case, I find that too much trouble and maintenance for now.