### PR TITLE
Add test for Poker `test_dupicate_hands_always_tie()`

### DIFF
--- a/exercises/practice/poker/tests/poker.rs
+++ b/exercises/practice/poker/tests/poker.rs
@@ -28,6 +28,16 @@ fn test_single_hand_always_wins() {
 
 #[test]
 #[ignore]
+fn test_duplicate_hands_always_tie() {
+    let input = &["3S 4S 5D 6H JH", "3S 4S 5D 6H JH", "3S 4S 5D 6H JH"];
+    assert_eq!(
+        &winning_hands(input).expect("This test should produce Some value",),
+        input
+    )
+}
+
+#[test]
+#[ignore]
 fn test_highest_card_of_all_hands_wins() {
     test(
         &["4D 5S 6S 8D 3C", "2S 4C 7S 9H 10H", "3S 4S 5D 6H JH"],


### PR DESCRIPTION
In the Poker practice exercise, returning the correct number of hands isn't tested. If three duplicate hands are given, only one needs to be returned, currently.

In `test_three_of_a_kind_cascade_ranks()`, the possibility of using multiple decks is allowed, so this corner condition is technically possible. However, the primary motivation is to make sure that the right number of hands are returned in the `Vec`.

Alternatively `hs_from()` function could use a `BinaryHeap` instead of a `HashSet`.