### PR TITLE
delegate shell location to env

### DIFF
--- a/_test/check-exercises.sh
+++ b/_test/check-exercises.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # test for existence and executability of the test-exercise script
 # this depends on that

--- a/bin/test-exercise
+++ b/bin/test-exercise
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test an exercise
 
 # which exercise are we testing right now?


### PR DESCRIPTION
This fixes running these scripts on NixOS and any other environment
where `bash` has been installed somewhere besides `/bin/`.