### PR TITLE
Clippy beta fixes

### DIFF
--- a/exercises/practice/react/src/lib.rs
+++ b/exercises/practice/react/src/lib.rs
@@ -1,29 +1,29 @@
-/// `InputCellID` is a unique identifier for an input cell.
+/// `InputCellId` is a unique identifier for an input cell.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct InputCellID();
-/// `ComputeCellID` is a unique identifier for a compute cell.
-/// Values of type `InputCellID` and `ComputeCellID` should not be mutually assignable,
+pub struct InputCellId();
+/// `ComputeCellId` is a unique identifier for a compute cell.
+/// Values of type `InputCellId` and `ComputeCellId` should not be mutually assignable,
 /// demonstrated by the following tests:
 ///
 /// ```compile_fail
 /// let mut r = react::Reactor::new();
-/// let input: react::ComputeCellID = r.create_input(111);
+/// let input: react::ComputeCellId = r.create_input(111);
 /// ```
 ///
 /// ```compile_fail
 /// let mut r = react::Reactor::new();
 /// let input = r.create_input(111);
-/// let compute: react::InputCellID = r.create_compute(&[react::CellID::Input(input)], |_| 222).unwrap();
+/// let compute: react::InputCellId = r.create_compute(&[react::CellId::Input(input)], |_| 222).unwrap();
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct ComputeCellID();
+pub struct ComputeCellId();
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct CallbackID();
+pub struct CallbackId();
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum CellID {
-    Input(InputCellID),
-    Compute(ComputeCellID),
+pub enum CellId {
+    Input(InputCellId),
+    Compute(ComputeCellId),
 }
 
 #[derive(Debug, PartialEq)]
@@ -45,7 +45,7 @@ impl<T: Copy + PartialEq> Reactor<T> {
     }
 
     // Creates an input cell with the specified initial value, returning its ID.
-    pub fn create_input(&mut self, _initial: T) -> InputCellID {
+    pub fn create_input(&mut self, _initial: T) -> InputCellId {
         unimplemented!()
     }
 
@@ -64,20 +64,20 @@ impl<T: Copy + PartialEq> Reactor<T> {
     // time they will continue to exist as long as the Reactor exists.
     pub fn create_compute<F: Fn(&[T]) -> T>(
         &mut self,
-        _dependencies: &[CellID],
+        _dependencies: &[CellId],
         _compute_func: F,
-    ) -> Result<ComputeCellID, CellID> {
+    ) -> Result<ComputeCellId, CellId> {
         unimplemented!()
     }
 
     // Retrieves the current value of the cell, or None if the cell does not exist.
     //
-    // You may wonder whether it is possible to implement `get(&self, id: CellID) -> Option<&Cell>`
+    // You may wonder whether it is possible to implement `get(&self, id: CellId) -> Option<&Cell>`
     // and have a `value(&self)` method on `Cell`.
     //
     // It turns out this introduces a significant amount of extra complexity to this exercise.
     // We chose not to cover this here, since this exercise is probably enough work as-is.
-    pub fn value(&self, id: CellID) -> Option<T> {
+    pub fn value(&self, id: CellId) -> Option<T> {
         unimplemented!("Get the value of the cell whose id is {:?}", id)
     }
 
@@ -85,11 +85,11 @@ impl<T: Copy + PartialEq> Reactor<T> {
     //
     // Returns false if the cell does not exist.
     //
-    // Similarly, you may wonder about `get_mut(&mut self, id: CellID) -> Option<&mut Cell>`, with
+    // Similarly, you may wonder about `get_mut(&mut self, id: CellId) -> Option<&mut Cell>`, with
     // a `set_value(&mut self, new_value: T)` method on `Cell`.
     //
     // As before, that turned out to add too much extra complexity.
-    pub fn set_value(&mut self, _id: InputCellID, _new_value: T) -> bool {
+    pub fn set_value(&mut self, _id: InputCellId, _new_value: T) -> bool {
         unimplemented!()
     }
 
@@ -107,9 +107,9 @@ impl<T: Copy + PartialEq> Reactor<T> {
     //   set_value call.
     pub fn add_callback<F: FnMut(T)>(
         &mut self,
-        _id: ComputeCellID,
+        _id: ComputeCellId,
         _callback: F,
-    ) -> Option<CallbackID> {
+    ) -> Option<CallbackId> {
         unimplemented!()
     }
 
@@ -120,11 +120,11 @@ impl<T: Copy + PartialEq> Reactor<T> {
     // A removed callback should no longer be called.
     pub fn remove_callback(
         &mut self,
-        cell: ComputeCellID,
-        callback: CallbackID,
+        cell: ComputeCellId,
+        callback: CallbackId,
     ) -> Result<(), RemoveCallbackError> {
         unimplemented!(
-            "Remove the callback identified by the CallbackID {:?} from the cell {:?}",
+            "Remove the callback identified by the CallbackId {:?} from the cell {:?}",
             callback,
             cell,
         )

--- a/exercises/practice/react/tests/react.rs
+++ b/exercises/practice/react/tests/react.rs
@@ -4,7 +4,7 @@ use react::*;
 fn input_cells_have_a_value() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(10);
-    assert_eq!(reactor.value(CellID::Input(input)), Some(10));
+    assert_eq!(reactor.value(CellId::Input(input)), Some(10));
 }
 
 #[test]
@@ -13,7 +13,7 @@ fn an_input_cells_value_can_be_set() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(4);
     assert!(reactor.set_value(input, 20));
-    assert_eq!(reactor.value(CellID::Input(input)), Some(20));
+    assert_eq!(reactor.value(CellId::Input(input)), Some(20));
 }
 
 #[test]
@@ -30,9 +30,9 @@ fn compute_cells_calculate_initial_value() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let output = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] + 1)
+        .create_compute(&[CellId::Input(input)], |v| v[0] + 1)
         .unwrap();
-    assert_eq!(reactor.value(CellID::Compute(output)), Some(2));
+    assert_eq!(reactor.value(CellId::Compute(output)), Some(2));
 }
 
 #[test]
@@ -42,11 +42,11 @@ fn compute_cells_take_inputs_in_the_right_order() {
     let one = reactor.create_input(1);
     let two = reactor.create_input(2);
     let output = reactor
-        .create_compute(&[CellID::Input(one), CellID::Input(two)], |v| {
+        .create_compute(&[CellId::Input(one), CellId::Input(two)], |v| {
             v[0] + v[1] * 10
         })
         .unwrap();
-    assert_eq!(reactor.value(CellID::Compute(output)), Some(21));
+    assert_eq!(reactor.value(CellId::Compute(output)), Some(21));
 }
 
 #[test]
@@ -55,8 +55,8 @@ fn error_creating_compute_cell_if_input_doesnt_exist() {
     let mut dummy_reactor = Reactor::new();
     let input = dummy_reactor.create_input(1);
     assert_eq!(
-        Reactor::new().create_compute(&[CellID::Input(input)], |_| 0),
-        Err(CellID::Input(input))
+        Reactor::new().create_compute(&[CellId::Input(input)], |_| 0),
+        Err(CellId::Input(input))
     );
 }
 
@@ -69,11 +69,11 @@ fn do_not_break_cell_if_creating_compute_cell_with_valid_and_invalid_input() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     assert_eq!(
-        reactor.create_compute(&[CellID::Input(input), CellID::Input(dummy_cell)], |_| 0),
-        Err(CellID::Input(dummy_cell))
+        reactor.create_compute(&[CellId::Input(input), CellId::Input(dummy_cell)], |_| 0),
+        Err(CellId::Input(dummy_cell))
     );
     assert!(reactor.set_value(input, 5));
-    assert_eq!(reactor.value(CellID::Input(input)), Some(5));
+    assert_eq!(reactor.value(CellId::Input(input)), Some(5));
 }
 
 #[test]
@@ -82,11 +82,11 @@ fn compute_cells_update_value_when_dependencies_are_changed() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let output = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] + 1)
+        .create_compute(&[CellId::Input(input)], |v| v[0] + 1)
         .unwrap();
-    assert_eq!(reactor.value(CellID::Compute(output)), Some(2));
+    assert_eq!(reactor.value(CellId::Compute(output)), Some(2));
     assert!(reactor.set_value(input, 3));
-    assert_eq!(reactor.value(CellID::Compute(output)), Some(4));
+    assert_eq!(reactor.value(CellId::Compute(output)), Some(4));
 }
 
 #[test]
@@ -95,20 +95,20 @@ fn compute_cells_can_depend_on_other_compute_cells() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let times_two = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] * 2)
+        .create_compute(&[CellId::Input(input)], |v| v[0] * 2)
         .unwrap();
     let times_thirty = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] * 30)
+        .create_compute(&[CellId::Input(input)], |v| v[0] * 30)
         .unwrap();
     let output = reactor
         .create_compute(
-            &[CellID::Compute(times_two), CellID::Compute(times_thirty)],
+            &[CellId::Compute(times_two), CellId::Compute(times_thirty)],
             |v| v[0] + v[1],
         )
         .unwrap();
-    assert_eq!(reactor.value(CellID::Compute(output)), Some(32));
+    assert_eq!(reactor.value(CellId::Compute(output)), Some(32));
     assert!(reactor.set_value(input, 3));
-    assert_eq!(reactor.value(CellID::Compute(output)), Some(96));
+    assert_eq!(reactor.value(CellId::Compute(output)), Some(96));
 }
 
 /// A CallbackRecorder helps tests whether callbacks get called correctly.
@@ -168,7 +168,7 @@ fn compute_cells_fire_callbacks() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let output = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] + 1)
+        .create_compute(&[CellId::Input(input)], |v| v[0] + 1)
         .unwrap();
     assert!(reactor
         .add_callback(output, |v| cb.callback_called(v))
@@ -183,7 +183,7 @@ fn error_adding_callback_to_nonexistent_cell() {
     let mut dummy_reactor = Reactor::new();
     let input = dummy_reactor.create_input(1);
     let output = dummy_reactor
-        .create_compute(&[CellID::Input(input)], |_| 0)
+        .create_compute(&[CellId::Input(input)], |_| 0)
         .unwrap();
     assert_eq!(
         Reactor::new().add_callback(output, |_: u32| println!("hi")),
@@ -197,16 +197,16 @@ fn error_removing_callback_from_nonexisting_cell() {
     let mut dummy_reactor = Reactor::new();
     let dummy_input = dummy_reactor.create_input(1);
     let _ = dummy_reactor
-        .create_compute(&[CellID::Input(dummy_input)], |_| 0)
+        .create_compute(&[CellId::Input(dummy_input)], |_| 0)
         .unwrap();
     let dummy_output = dummy_reactor
-        .create_compute(&[CellID::Input(dummy_input)], |_| 0)
+        .create_compute(&[CellId::Input(dummy_input)], |_| 0)
         .unwrap();
 
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let output = reactor
-        .create_compute(&[CellID::Input(input)], |_| 0)
+        .create_compute(&[CellId::Input(input)], |_| 0)
         .unwrap();
     let callback = reactor.add_callback(output, |_| ()).unwrap();
     assert_eq!(
@@ -223,7 +223,7 @@ fn callbacks_only_fire_on_change() {
     let input = reactor.create_input(1);
     let output = reactor
         .create_compute(
-            &[CellID::Input(input)],
+            &[CellId::Input(input)],
             |v| if v[0] < 3 { 111 } else { 222 },
         )
         .unwrap();
@@ -244,7 +244,7 @@ fn callbacks_can_be_called_multiple_times() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let output = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] + 1)
+        .create_compute(&[CellId::Input(input)], |v| v[0] + 1)
         .unwrap();
     assert!(reactor
         .add_callback(output, |v| cb.callback_called(v))
@@ -264,10 +264,10 @@ fn callbacks_can_be_called_from_multiple_cells() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let plus_one = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] + 1)
+        .create_compute(&[CellId::Input(input)], |v| v[0] + 1)
         .unwrap();
     let minus_one = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] - 1)
+        .create_compute(&[CellId::Input(input)], |v| v[0] - 1)
         .unwrap();
     assert!(reactor
         .add_callback(plus_one, |v| cb1.callback_called(v))
@@ -291,7 +291,7 @@ fn callbacks_can_be_added_and_removed() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(11);
     let output = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] + 1)
+        .create_compute(&[CellId::Input(input)], |v| v[0] + 1)
         .unwrap();
 
     let callback = reactor
@@ -325,7 +325,7 @@ fn removing_a_callback_multiple_times_doesnt_interfere_with_other_callbacks() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let output = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] + 1)
+        .create_compute(&[CellId::Input(input)], |v| v[0] + 1)
         .unwrap();
     let callback = reactor
         .add_callback(output, |v| cb1.callback_called(v))
@@ -354,17 +354,17 @@ fn callbacks_should_only_be_called_once_even_if_multiple_dependencies_change() {
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let plus_one = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] + 1)
+        .create_compute(&[CellId::Input(input)], |v| v[0] + 1)
         .unwrap();
     let minus_one1 = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] - 1)
+        .create_compute(&[CellId::Input(input)], |v| v[0] - 1)
         .unwrap();
     let minus_one2 = reactor
-        .create_compute(&[CellID::Compute(minus_one1)], |v| v[0] - 1)
+        .create_compute(&[CellId::Compute(minus_one1)], |v| v[0] - 1)
         .unwrap();
     let output = reactor
         .create_compute(
-            &[CellID::Compute(plus_one), CellID::Compute(minus_one2)],
+            &[CellId::Compute(plus_one), CellId::Compute(minus_one2)],
             |v| v[0] * v[1],
         )
         .unwrap();
@@ -382,14 +382,14 @@ fn callbacks_should_not_be_called_if_dependencies_change_but_output_value_doesnt
     let mut reactor = Reactor::new();
     let input = reactor.create_input(1);
     let plus_one = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] + 1)
+        .create_compute(&[CellId::Input(input)], |v| v[0] + 1)
         .unwrap();
     let minus_one = reactor
-        .create_compute(&[CellID::Input(input)], |v| v[0] - 1)
+        .create_compute(&[CellId::Input(input)], |v| v[0] - 1)
         .unwrap();
     let always_two = reactor
         .create_compute(
-            &[CellID::Compute(plus_one), CellID::Compute(minus_one)],
+            &[CellId::Compute(plus_one), CellId::Compute(minus_one)],
             |v| v[0] - v[1],
         )
         .unwrap();
@@ -413,25 +413,25 @@ fn test_adder_with_boolean_values() {
     let carry_in = reactor.create_input(false);
 
     let a_xor_b = reactor
-        .create_compute(&[CellID::Input(a), CellID::Input(b)], |v| v[0] ^ v[1])
+        .create_compute(&[CellId::Input(a), CellId::Input(b)], |v| v[0] ^ v[1])
         .unwrap();
     let sum = reactor
-        .create_compute(&[CellID::Compute(a_xor_b), CellID::Input(carry_in)], |v| {
+        .create_compute(&[CellId::Compute(a_xor_b), CellId::Input(carry_in)], |v| {
             v[0] ^ v[1]
         })
         .unwrap();
 
     let a_xor_b_and_cin = reactor
-        .create_compute(&[CellID::Compute(a_xor_b), CellID::Input(carry_in)], |v| {
+        .create_compute(&[CellId::Compute(a_xor_b), CellId::Input(carry_in)], |v| {
             v[0] && v[1]
         })
         .unwrap();
     let a_and_b = reactor
-        .create_compute(&[CellID::Input(a), CellID::Input(b)], |v| v[0] && v[1])
+        .create_compute(&[CellId::Input(a), CellId::Input(b)], |v| v[0] && v[1])
         .unwrap();
     let carry_out = reactor
         .create_compute(
-            &[CellID::Compute(a_xor_b_and_cin), CellID::Compute(a_and_b)],
+            &[CellId::Compute(a_xor_b_and_cin), CellId::Compute(a_and_b)],
             |v| v[0] || v[1],
         )
         .unwrap();
@@ -452,9 +452,9 @@ fn test_adder_with_boolean_values() {
         assert!(reactor.set_value(b, bval));
         assert!(reactor.set_value(carry_in, cinval));
 
-        assert_eq!(reactor.value(CellID::Compute(sum)), Some(expected_sum));
+        assert_eq!(reactor.value(CellId::Compute(sum)), Some(expected_sum));
         assert_eq!(
-            reactor.value(CellID::Compute(carry_out)),
+            reactor.value(CellId::Compute(carry_out)),
             Some(expected_cout)
         );
     }

--- a/exercises/practice/simple-linked-list/example.rs
+++ b/exercises/practice/simple-linked-list/example.rs
@@ -69,7 +69,7 @@ impl<T> FromIterator<T> for SimpleLinkedList<T> {
 
 impl<T> From<SimpleLinkedList<T>> for Vec<T> {
     fn from(mut linked_list: SimpleLinkedList<T>) -> Vec<T> {
-        let mut vec: Vec<T> = vec![];
+        let mut vec: Vec<T> = Vec::with_capacity(linked_list.len());
         while let Some(data) = linked_list.pop() {
             vec.push(data);
         }

--- a/exercises/practice/simple-linked-list/example.rs
+++ b/exercises/practice/simple-linked-list/example.rs
@@ -67,10 +67,10 @@ impl<T> FromIterator<T> for SimpleLinkedList<T> {
     }
 }
 
-impl<T> Into<Vec<T>> for SimpleLinkedList<T> {
-    fn into(mut self) -> Vec<T> {
-        let mut vec = Vec::new();
-        while let Some(data) = self.pop() {
+impl<T> From<SimpleLinkedList<T>> for Vec<T> {
+    fn from(mut linked_list: SimpleLinkedList<T>) -> Vec<T> {
+        let mut vec: Vec<T> = vec![];
+        while let Some(data) = linked_list.pop() {
             vec.push(data);
         }
         vec.reverse();

--- a/exercises/practice/simple-linked-list/src/lib.rs
+++ b/exercises/practice/simple-linked-list/src/lib.rs
@@ -58,7 +58,6 @@ impl<T> FromIterator<T> for SimpleLinkedList<T> {
 // of IntoIterator is that implementing that interface is fairly complicated, and
 // demands more of the student than we expect at this point in the track.
 
-#[allow(clippy::from_over_into)]
 impl<T> Into<Vec<T>> for SimpleLinkedList<T> {
     fn into(self) -> Vec<T> {
         unimplemented!()

--- a/exercises/practice/simple-linked-list/src/lib.rs
+++ b/exercises/practice/simple-linked-list/src/lib.rs
@@ -58,8 +58,8 @@ impl<T> FromIterator<T> for SimpleLinkedList<T> {
 // of IntoIterator is that implementing that interface is fairly complicated, and
 // demands more of the student than we expect at this point in the track.
 
-impl<T> Into<Vec<T>> for SimpleLinkedList<T> {
-    fn into(self) -> Vec<T> {
+impl<T> From<SimpleLinkedList<T>> for Vec<T> {
+    fn from(mut _linked_list: SimpleLinkedList<T>) -> Vec<T> {
         unimplemented!()
     }
 }

--- a/exercises/practice/simple-linked-list/src/lib.rs
+++ b/exercises/practice/simple-linked-list/src/lib.rs
@@ -58,6 +58,7 @@ impl<T> FromIterator<T> for SimpleLinkedList<T> {
 // of IntoIterator is that implementing that interface is fairly complicated, and
 // demands more of the student than we expect at this point in the track.
 
+#[allow(clippy::from_over_into)]
 impl<T> Into<Vec<T>> for SimpleLinkedList<T> {
     fn into(self) -> Vec<T> {
         unimplemented!()


### PR DESCRIPTION
I batch applied the camel case abbreviation changes.
I was not sure about the simple-linked-list lint so exempted it.
- [exemption applied here](https://github.com/exercism/rust/compare/clippy-beta-fixes?expand=1#diff-82b44a277ea9de5d666b7f807136f46e26f46d7ed16a71c4ca3925a342a1e0bcR61)
- [clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into)
- [example failure](https://github.com/exercism/rust/runs/1919516153?check_suite_focus=true#step:7:268)

Since the clippy lint is new, it [fails](https://github.com/exercism/rust/runs/1920253485?check_suite_focus=true#step:7:10) for stable clippy runs. If I've taken the correct approach i'm happy to find a way to exempt this in the script executing clippy. 

Otherwise I'm open to refactoring the simple-linked-list exercise per the exercise or another solution to make all CI steps pass.