### PR TITLE
forth: Remove `Option<_>` type requirement

### DIFF
--- a/exercises/practice/poker/.meta/example.rs
+++ b/exercises/practice/poker/.meta/example.rs
@@ -7,21 +7,24 @@ use counter::Counter;
 ///
 /// Note the type signature: this function should return _the same_ reference to
 /// the winning hand(s) as were passed in, not reconstructed strings which happen to be equal.
-pub fn winning_hands<'a>(hands: &[&'a str]) -> Option<Vec<&'a str>> {
+pub fn winning_hands<'a>(hands: &[&'a str]) -> Vec<&'a str> {
     let mut hands = hands
         .iter()
         .map(|source| Hand::try_from(*source))
         .collect::<Result<Vec<_>, _>>()
-        .ok()?;
+        .unwrap_or_default();
     hands.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Less));
-    hands.last().map(|last| {
-        hands
-            .iter()
-            .rev()
-            .take_while(|&item| item.partial_cmp(last) == Some(Ordering::Equal))
-            .map(|hand| hand.source)
-            .collect()
-    })
+    hands
+        .last()
+        .map(|last| {
+            hands
+                .iter()
+                .rev()
+                .take_while(|&item| item.partial_cmp(last) == Some(Ordering::Equal))
+                .map(|hand| hand.source)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy, Hash)]

--- a/exercises/practice/poker/src/lib.rs
+++ b/exercises/practice/poker/src/lib.rs
@@ -2,6 +2,6 @@
 ///
 /// Note the type signature: this function should return _the same_ reference to
 /// the winning hand(s) as were passed in, not reconstructed strings which happen to be equal.
-pub fn winning_hands<'a>(hands: &[&'a str]) -> Option<Vec<&'a str>> {
+pub fn winning_hands<'a>(hands: &[&'a str]) -> Vec<&'a str> {
     unimplemented!("Out of {:?}, which hand wins?", hands)
 }

--- a/exercises/practice/poker/tests/poker.rs
+++ b/exercises/practice/poker/tests/poker.rs
@@ -15,10 +15,7 @@ fn hs_from<'a>(input: &[&'a str]) -> HashSet<&'a str> {
 /// Note that the output can be in any order. Here, we use a HashSet to
 /// abstract away the order of outputs.
 fn test<'a, 'b>(input: &[&'a str], expected: &[&'b str]) {
-    assert_eq!(
-        hs_from(&winning_hands(input).expect("This test should produce Some value")),
-        hs_from(expected)
-    )
+    assert_eq!(hs_from(&winning_hands(input)), hs_from(expected))
 }
 
 #[test]
@@ -30,10 +27,7 @@ fn test_single_hand_always_wins() {
 #[ignore]
 fn test_duplicate_hands_always_tie() {
     let input = &["3S 4S 5D 6H JH", "3S 4S 5D 6H JH", "3S 4S 5D 6H JH"];
-    assert_eq!(
-        &winning_hands(input).expect("This test should produce Some value"),
-        input
-    )
+    assert_eq!(&winning_hands(input), input)
 }
 
 #[test]


### PR DESCRIPTION
Hi!

As discussed recently with @coriolinus, the `None` case can never really occur and was not tested either. Just an empty vector actually covers the desired semantics.

Cheers,
Paul.