### PR TITLE
enable a few more markdown lints

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -26,6 +26,14 @@ MD013: false
 # MD014/commands-show-output - Dollar signs used before commands without showing output
 MD014: false
 
+# MD033/no-inline-html - Inline HTML
+MD033:
+  # Allowed elements
+  allowed_elements: []
+
+# MD034/no-bare-urls - Bare URL used
+MD034: true
+
 # MD039/no-space-in-links - Spaces inside link text
 MD039: true
 
@@ -34,3 +42,7 @@ MD040: true
 # MD042/no-empty-links - No empty links
 MD042: true
 
+# MD048/code-fence-style - Code fence style
+MD048:
+  # Code fence syle
+  style: "consistent"

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -45,4 +45,4 @@ MD042: true
 # MD048/code-fence-style - Code fence style
 MD048:
   # Code fence syle
-  style: "consistent"
+  style: "backtick"

--- a/concepts/option/about.md
+++ b/concepts/option/about.md
@@ -15,7 +15,7 @@ There are several common idioms for using the value which might be present in an
 
 - `if let Some(t) = optional { ... }`.
 
-    The `if let` idiom extracts the value from an Option<T> and binds it to the variable `t`. This lets you use it directly in that block scope.
+    The `if let` idiom extracts the value from an `Option<T>` and binds it to the variable `t`. This lets you use it directly in that block scope.
 
 - `match optional { Some(t) => {...}, None => {...}}`
 


### PR DESCRIPTION
I took the liberty of enabling a few more markdown lints.
I could not find how to lint one sentence per line, which would be nice
to have.
Otherwise I:
- disabled inline HTML since I don't see the reason we should allow
this. Funny enough, the lint caught an example using `Option<T>` without
code ticks.
- no bare URLs
- consistent code fence style