### PR TITLE
add a trailing whitespace lint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Check exercises for authors
         run: ./_test/check-exercises-for-authors.sh
 
+      - name: Ensure relevant files do not have trailing whitespace
+        run: ./bin/lint_trailing_spaces.sh
+
   configlet:
     name: configlet lint
     runs-on: ubuntu-latest
@@ -74,7 +77,7 @@ jobs:
 
   # stolen from https://raw.githubusercontent.com/exercism/github-actions/main/.github/workflows/shellcheck.yml
   shellcheck:
-    name: shellcheck internal tooling
+    name: shellcheck internal tooling lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/bin/lint_trailing_spaces.sh
+++ b/bin/lint_trailing_spaces.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Report any .toml files that have trailing white space
+# so user can fix them
+set -eo pipefail
+
+files=$(find . -name '*.toml' -exec grep -l '[[:space:]]$' {} \;)
+
+if [ -n "$files" ]; then
+	echo "These files have trailing whitespace:"
+	echo "$files"
+	echo "Our conventions disallow this so please remove the trailing whitespace."
+	exit 1
+fi

--- a/bin/lint_trailing_spaces.sh
+++ b/bin/lint_trailing_spaces.sh
@@ -4,11 +4,11 @@
 # so user can fix them
 set -eo pipefail
 
-files=$(find . -name '*.toml' -exec grep -l '[[:space:]]$' {} \;)
+files=$(find . \( -iname '*.toml' -o -iname '*.sh' -o -iname '*.rs' \) -exec grep -l '[[:space:]]$' {} \;)
 
 if [ -n "$files" ]; then
-	echo "These files have trailing whitespace:"
-	echo "$files"
-	echo "Our conventions disallow this so please remove the trailing whitespace."
-	exit 1
+    echo "These files have trailing whitespace:"
+    echo "$files"
+    echo "Our conventions disallow this so please remove the trailing whitespace."
+    exit 1
 fi

--- a/exercises/practice/spiral-matrix/tests/spiral-matrix.rs
+++ b/exercises/practice/spiral-matrix/tests/spiral-matrix.rs
@@ -24,8 +24,8 @@ fn size_two_spiral() {
 fn size_three_spiral() {
     #[rustfmt::skip]
     let expected: Vec<Vec<u32>> = vec![
-        vec![1, 2, 3], 
-        vec![8, 9, 4], 
+        vec![1, 2, 3],
+        vec![8, 9, 4],
         vec![7, 6, 5],
     ];
     assert_eq!(spiral_matrix(3), expected);

--- a/util/exercise/Cargo.toml
+++ b/util/exercise/Cargo.toml
@@ -20,10 +20,10 @@ version = "1.3.0"
 # To implement `Deserialize` on `IndexMap`.
 features = ["serde-1"]
 
-[dependencies.reqwest]    
+[dependencies.reqwest]
 version = "0.9.16"
-default-features = false    
-features = ["rustls-tls"]   
+default-features = false
+features = ["rustls-tls"]
 
 [dependencies.serde]
 version = "1.0.102"

--- a/util/exercise/src/main.rs
+++ b/util/exercise/src/main.rs
@@ -102,7 +102,7 @@ fn process_matches(matches: &ArgMatches<'_>) -> Result<()> {
         }
 
         ("", None) => {
-            println!("No subcommand was used.\nUse init_exercise --help to learn about the possible subcommands.");
+            println!("No subcommand was used.\nUse exercise --help to learn about the possible subcommands.");
         }
 
         _ => unreachable!(),

--- a/util/exercise/src/main.rs
+++ b/util/exercise/src/main.rs
@@ -102,7 +102,7 @@ fn process_matches(matches: &ArgMatches<'_>) -> Result<()> {
         }
 
         ("", None) => {
-            println!("No subcommand was used.\nUse exercise --help to learn about the possible subcommands.");
+            println!("No subcommand was used.\nUse init_exercise --help to learn about the possible subcommands.");
         }
 
         _ => unreachable!(),


### PR DESCRIPTION
I was curious about what [util/exercise](https://github.com/exercism/rust/tree/main/util/exercise) and noticed the `Cargo.toml` has trailing whitespace.
So I took the opportunity to add a lint in CI too.
[This](https://github.com/exercism/rust/runs/1973793069#step:8:4) is an example failure.