### PR TITLE
fix CI error

### DIFF
--- a/bin/format_exercises
+++ b/bin/format_exercises
@@ -16,15 +16,12 @@ format_exercises() {
         if [ -f "$allowed_file" ]; then
             exercise=$(basename "$exercise_dir")
             echo "$exercise's stub is allowed to not compile"
-            # we disable the below shellcheck lint
-            # because we want to exit this iteration
-            # shellcheck disable=SC2106
-            continue
-        fi
-        cargo fmt
-        file_name=".meta/$source_file_name.rs"
-        if [ -f "$file_name" ]; then
-            rustfmt "$file_name"
+        else
+            cargo fmt
+            file_name=".meta/$source_file_name.rs"
+            if [ -f "$file_name" ]; then
+                rustfmt "$file_name"
+            fi
         fi
     )
     done

--- a/bin/format_exercises
+++ b/bin/format_exercises
@@ -16,12 +16,14 @@ format_exercises() {
         if [ -f "$allowed_file" ]; then
             exercise=$(basename "$exercise_dir")
             echo "$exercise's stub is allowed to not compile"
-        else
-            cargo fmt
-            file_name=".meta/$source_file_name.rs"
-            if [ -f "$file_name" ]; then
-                rustfmt "$file_name"
-            fi
+            # exit the subshell successfully to continue
+            # to the next exercise directory
+            exit 0
+        fi
+        cargo fmt
+        file_name=".meta/$source_file_name.rs"
+        if [ -f "$file_name" ]; then
+            rustfmt "$file_name"
         fi
     )
     done


### PR DESCRIPTION
This happened because newer versions of Bash (5.x) rightly fail on using
`continue` incorrectly.

I rewrote that section to simply run `rustfmt` if the example is allowed
to compile. I am unsure why that is in a subshell.

As an aside, I tested this locally on macOS by running `brew install
bash`, then changing the shebang to use `/usr/local/bin/bash`.