### PR TITLE
[Robot Name] Check for collisions in Robot Name example implementation (Attempt 2)

### DIFF
--- a/exercises/practice/robot-name/.meta/Cargo-example.toml
+++ b/exercises/practice/robot-name/.meta/Cargo-example.toml
@@ -4,4 +4,5 @@ name = "robot-name"
 version = "0.0.0"
 
 [dependencies]
+lazy_static = "1.4.0"
 rand = "0.3.12"

--- a/exercises/practice/robot-name/.meta/example.rs
+++ b/exercises/practice/robot-name/.meta/example.rs
@@ -1,21 +1,32 @@
-extern crate rand;
+use lazy_static::lazy_static;
 use rand::{thread_rng, Rng};
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref NAMES: Mutex<HashSet<String>> = Mutex::new(HashSet::new());
+}
 
 pub struct Robot {
     name: String,
 }
 
 fn generate_name() -> String {
-    let mut s = String::with_capacity(5);
-    static LETTERS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    static NUMBERS: &[u8] = b"0123456789";
-    for _ in 0..2 {
-        s.push(*thread_rng().choose(LETTERS).unwrap() as char);
+    loop {
+        let mut s = String::with_capacity(5);
+        static LETTERS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        static NUMBERS: &[u8] = b"0123456789";
+        for _ in 0..2 {
+            s.push(*thread_rng().choose(LETTERS).unwrap() as char);
+        }
+        for _ in 0..3 {
+            s.push(*thread_rng().choose(NUMBERS).unwrap() as char);
+        }
+
+        if NAMES.lock().unwrap().insert(s.clone()) {
+            return s;
+        }
     }
-    for _ in 0..3 {
-        s.push(*thread_rng().choose(NUMBERS).unwrap() as char);
-    }
-    s
 }
 
 impl Robot {


### PR DESCRIPTION
Add collision check when returning robot names, to make the example implementation more in line with the instructions.

Fixes #1195