### PR TITLE
explore simple spell check

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -46,6 +46,12 @@ MD040: true
 # MD042/no-empty-links - No empty links
 MD042: true
 
+# low-hanging fruit to validate proper names
+# deprecate if a better solution via
+# https://github.com/exercism/docs/issues/29 is found
+MD044:
+  names: ["Rust", "UTF-8"]
+
 # MD048/code-fence-style - Code fence style
 MD048:
   # Code fence syle

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -5,7 +5,7 @@ In Rust, there are are many specific types of numbers but they generally fall un
 Initializing an integer:
 
 ```rust
-let x = 5; // rust defaults to an i32
+let x = 5; // Rust defaults to an i32
 ```
 
 Initializing a large positive integer:

--- a/concepts/string-vs-str/about.md
+++ b/concepts/string-vs-str/about.md
@@ -14,7 +14,7 @@ The proper pronunciation of `&str` is "ref string".
 `&str` is a read only view of a well-formed UTF-8 sequence.
 Because it's a reference, it is `Copy` and can be shared.
 
-`String` and `&str` in rust can not be indexed into like you might in other languages.
+`String` and `&str` in Rust can not be indexed into like you might in other languages.
 For example this will not work:
 
 ```rust,invalid

--- a/exercises/practice/hello-world/GETTING_STARTED.md
+++ b/exercises/practice/hello-world/GETTING_STARTED.md
@@ -5,14 +5,14 @@ an exact match.
 
 The following steps assume that you are in the same directory as the exercise.
 
-You must have rust installed.
+You must have Rust installed.
 Follow the [Installation chapter in the Rust book](https://doc.rust-lang.org/book/ch01-01-installation.html).
 The [Rust language section](http://exercism.io/languages/rust)
 section from exercism is also useful.
 
 ## Step 1
 
-Run the test suite. It can be run with `cargo`, which is installed with rust.
+Run the test suite. It can be run with `cargo`, which is installed with Rust.
 
 ```sh
 $ cargo test


### PR DESCRIPTION
markdownlint bundles a proper noun spellchecker which might be useful:
https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md044