### PR TITLE
remove legacy metadata.yml files

### DIFF
--- a/exercises/practice/decimal/.meta/config.json
+++ b/exercises/practice/decimal/.meta/config.json
@@ -1,5 +1,6 @@
 {
   "blurb": "Implement a Decimal type",
+  "source": "Peter Goodspeed-Niklaus",
   "authors": [
     {
       "github_username": "coriolinus"

--- a/exercises/practice/decimal/.meta/metadata.yml
+++ b/exercises/practice/decimal/.meta/metadata.yml
@@ -1,3 +1,0 @@
----
-blurb: "Implement a Decimal type"
-source: "Peter Goodspeed-Niklaus"

--- a/exercises/practice/doubly-linked-list/.meta/metadata.yml
+++ b/exercises/practice/doubly-linked-list/.meta/metadata.yml
@@ -1,4 +1,0 @@
----
-blurb: "linked-list"
-source: ""
-source_url: ""

--- a/exercises/practice/fizzy/.meta/config.json
+++ b/exercises/practice/fizzy/.meta/config.json
@@ -1,5 +1,7 @@
 {
   "blurb": "Implement FizzBuzz using advanced generics",
+  "source": "Peter Goodspeed-Niklaus",
+  "source_url": "https://github.com/coriolinus/fizzy",
   "authors": [
     {
       "github_username": "coriolinus"

--- a/exercises/practice/fizzy/.meta/metadata.yml
+++ b/exercises/practice/fizzy/.meta/metadata.yml
@@ -1,4 +1,0 @@
----
-blurb: "Implement FizzBuzz using advanced generics"
-source: "Peter Goodspeed-Niklaus"
-source_url: "https://github.com/coriolinus/fizzy"

--- a/exercises/practice/luhn-from/.meta/config.json
+++ b/exercises/practice/luhn-from/.meta/config.json
@@ -1,5 +1,6 @@
 {
   "blurb": "Luhn: Using the From Trait",
+  "source": "The Rust track maintainers, based on the original Luhn exercise",
   "authors": [
     {
       "github_username": "IanWhitney"

--- a/exercises/practice/luhn-from/.meta/metadata.yml
+++ b/exercises/practice/luhn-from/.meta/metadata.yml
@@ -1,3 +1,0 @@
----
-blurb: "Luhn: Using the From Trait"
-source: "The Rust track maintainers, based on the original Luhn exercise"

--- a/exercises/practice/luhn-trait/.meta/config.json
+++ b/exercises/practice/luhn-trait/.meta/config.json
@@ -1,5 +1,6 @@
 {
   "blurb": "Luhn: Using a Custom Trait",
+  "source": "The Rust track maintainers, based on the original Luhn exercise",
   "authors": [
     {
       "github_username": "IanWhitney"

--- a/exercises/practice/luhn-trait/.meta/metadata.yml
+++ b/exercises/practice/luhn-trait/.meta/metadata.yml
@@ -1,3 +1,0 @@
----
-blurb: "Luhn: Using a Custom Trait"
-source: "The Rust track maintainers, based on the original Luhn exercise"

--- a/exercises/practice/macros/.meta/config.json
+++ b/exercises/practice/macros/.meta/config.json
@@ -1,5 +1,6 @@
 {
   "blurb": "Implement a macro using macros-by-example",
+  "source": "Peter Goodspeed-Niklaus",
   "authors": [
     {
       "github_username": "coriolinus"

--- a/exercises/practice/macros/.meta/metadata.yml
+++ b/exercises/practice/macros/.meta/metadata.yml
@@ -1,3 +1,0 @@
----
-blurb: "Implement a macro using macros-by-example"
-source: "Peter Goodspeed-Niklaus"

--- a/exercises/practice/xorcism/.meta/config.json
+++ b/exercises/practice/xorcism/.meta/config.json
@@ -1,5 +1,6 @@
 {
   "blurb": "Implement zero-copy streaming adaptors",
+  "source": "Peter Goodspeed-Niklaus",
   "authors": [
     {
       "github_username": "coriolinus"

--- a/exercises/practice/xorcism/.meta/metadata.yml
+++ b/exercises/practice/xorcism/.meta/metadata.yml
@@ -1,3 +1,0 @@
----
-blurb: "Implement zero-copy streaming adaptors"
-source: "Peter Goodspeed-Niklaus"


### PR DESCRIPTION
Combine v2 `metadata.yml` values into the v3 `config.json`.

Note I have not touched the `exercise` utility which still generates
`metadata.yml`.

Close #1166.