### PR TITLE
fix new lints for scale-generator

### DIFF
--- a/exercises/practice/scale-generator/src/lib.rs
+++ b/exercises/practice/scale-generator/src/lib.rs
@@ -9,7 +9,7 @@
 // One common idiom is to define an Error enum which wraps all potential
 // errors. Another common idiom is to use a helper type such as failure::Error
 // which does more or less the same thing but automatically.
-pub type Error = ();
+pub struct Error;
 
 pub struct Scale;
 

--- a/exercises/practice/scale-generator/src/lib.rs
+++ b/exercises/practice/scale-generator/src/lib.rs
@@ -9,6 +9,7 @@
 // One common idiom is to define an Error enum which wraps all potential
 // errors. Another common idiom is to use a helper type such as failure::Error
 // which does more or less the same thing but automatically.
+#[derive(Debug)]
 pub struct Error;
 
 pub struct Scale;


### PR DESCRIPTION
With the new release of rust 1.51, the nightlies are now building rust 1.53. 1.53 includes a new clippy lint which complains about interfaces which return `Result<_, ()>`; they should return `Option<_>` instead. 

In `scale-generator`, this design is intentional; we'd typedef'd `Error` to () with a long comment above so that students could define their own error type. This change produces a new unit struct instead. 

After merging, this PR should cause the `main` branch to successfully pass CI again.