### PR TITLE
Update luhn.rs

### DIFF
--- a/exercises/practice/luhn/tests/luhn.rs
+++ b/exercises/practice/luhn/tests/luhn.rs
@@ -125,3 +125,10 @@ fn test_using_ascii_value_for_nondoubled_nondigit_isnt_allowed() {
 fn test_valid_number_with_an_odd_number_of_spaces() {
     process_valid_case("234 567 891 234", true);
 }
+
+#[test]
+#[ignore]
+/// non-numeric, non-space char in the middle with a sum that's divisible by 10 isn't allowed
+fn test_invalid_char_in_middle_with_sum_divisible_by_10_isnt_allowed() {
+    process_valid_case("59%59", false);
+}


### PR DESCRIPTION
An example of the code this would catch that's currently slipping through:

```rust
//17 nanoseconds
// Check a Luhn checksum.
 pub fn is_valid(code: &str) -> bool {
     let mut sum = 0;
     let mut i = 0;
     for ch in code.chars().rev() {
         match ch.to_digit(10) {
             Some(digit) => {
                 sum += if i % 2 == 0 {
                     digit
                 } else if 4 < digit {
                     digit * 2 - 9
                 } else {
                     digit * 2
                 };
                 i+=1;
             },
             None => {
                 if ch != ' ' {
                     break
                 }
             },
         }
     }
     i > 1 && sum % 10 == 0
 }
```