### PR TITLE
[integer] update introduction.md

### DIFF
--- a/concepts/integers/introduction.md
+++ b/concepts/integers/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Integers are numbers with no digits behind the decimal separator (whole numbers).
+Integers are whole numbers with no decimal separator.
 
 Integer types can either store only positive numbers (unsigned) or store either positive and negative numbers (signed).
 


### PR DESCRIPTION
Because `let my_int: i32 = 2.;` will still error even if there is nothing to the right of the decimal separator.