### PR TITLE
update semi-structured-logs to v3 spec

### DIFF
--- a/exercises/concept/semi-structured-logs/.docs/hints.md
+++ b/exercises/concept/semi-structured-logs/.docs/hints.md
@@ -2,10 +2,10 @@
 
 ## General
 
-- [cheats.rs - Basic Types][cheats-types]
 - [Rust By Example - Enums][rbe-enums]
+- [cheats.rs - Basic Types][cheats-types]
 
-## using match
+## 1. Emit semi-structured messages
 
 - `match` comes in handy when working with enums. In this case, see how you might use it when figuring how what kind of log message to generate.
 

--- a/exercises/concept/semi-structured-logs/.docs/instructions.md
+++ b/exercises/concept/semi-structured-logs/.docs/instructions.md
@@ -2,6 +2,8 @@
 
 In this exercise you'll be generating semi-structured log messages.
 
+## 1. Emit semi-structured messages
+
 You'll start with some stubbed functions and the following enum:
 
 ```rust
@@ -32,10 +34,15 @@ info("Timezone changed")
 
 Have fun!
 
-## further practice
+## 2. Optional further practice
 
-There is a feature-gated test in this suite. Feature gates disable compilation entirely for certain sections of your program. They will be covered later. For now just know that there is a test which is only built and run when you use a special testing invocation:
+There is a feature-gated test in this suite.
+Feature gates disable compilation entirely for certain sections of your program.
+They will be covered later.
+For now just know that there is a test which is only built and run when you use a special testing invocation:
 
-    cargo test --features add-a-variant
+```sh
+cargo test --features add-a-variant
+```
 
 This test is meant to show you how to add a variant to your enum.


### PR DESCRIPTION
Close #1192.

I updated the heading structure per [the specification](https://github.com/exercism/docs/blob/main/building/tracks/concept-exercises.md).
I also broke out the sentences into separate lines as I recently learned
Markdown will only render newlines when you have an empty newline between.