### PR TITLE
add detailed description of `Box`'s implementation to appropriate concept links

### DIFF
--- a/concepts/box/links.json
+++ b/concepts/box/links.json
@@ -1,1 +1,6 @@
-[]
+[
+    {
+        "url": "https://fasterthanli.me/articles/whats-in-the-box",
+        "description": "Detailed description of `Box`'s implementation and how it differs from Go / Javascript"
+    }
+]


### PR DESCRIPTION
A useful command to show non-empty `links.json` example:

```sh
fd links.json concepts --size +4b | xargs bat
```