### PR TITLE
Add Final Electric Bill exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -129,6 +129,21 @@
         "status": "active"
       },
       {
+        "slug": "final-electric-bill",
+        "name": "Final Electric Bill",
+        "difficulty": 1,
+        "uuid": "8e063611-db3f-4991-adba-8f9565e98c71",
+        "concepts": [
+          "vec-stack"
+        ],
+        "prerequisites": [
+          "intro-fn",
+          "numbers",
+          "option"
+        ],
+        "status": "wip"
+      },
+      {
         "slug": "csv-builder",
         "name": "CSV builder",
         "difficulty": 1,

--- a/exercises/concept/final-electric-bill/.docs/hints.md
+++ b/exercises/concept/final-electric-bill/.docs/hints.md
@@ -1,0 +1,6 @@
+# Hints
+
+## General
+
+- Look at the documentation for `std::vec::Vec`'s [`push()`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.push) and ['pop()`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.pop) methods.
+- No `Vec` with fewer than 2 elements will be passed in.

--- a/exercises/concept/final-electric-bill/.docs/instructions.md
+++ b/exercises/concept/final-electric-bill/.docs/instructions.md
@@ -1,0 +1,34 @@
+# Instructions
+
+Your electric utility company needs to compile a summary of all bills sent to a customer who has closed their account. Unfortunately, your billing software provides the "last monthly bill" and the "final bill" separately, yet in reality, both were combined into a single bill.
+
+Given a list of bills, write a function that replaces the last two bills with a single bill equal to their sum.
+
+You'll start with the following stubbed function signature:
+
+```rust
+pub fn fix_billing_summary(Vec<i32>) -> Vec<i32> {
+	todo!()
+}
+```
+
+## Optional further practice
+
+There is a feature-gated test in this suite.
+Feature gates disable compilation entirely for certain sections of your program.
+They will be covered later.
+For now just know that there is a test which is only built and run when you use a special testing invocation:
+
+```sh
+cargo test --features generic
+```
+
+This test is meant to show how you can modify your function to accept more complicated bills.
+
+Hint: replace the function signature with:
+
+```rust
+pub fn fix_billing_summary<T: std::ops::Add>(Vec<T>) -> Vec<T> {
+	todo!()
+}
+```

--- a/exercises/concept/final-electric-bill/.docs/instructions.md
+++ b/exercises/concept/final-electric-bill/.docs/instructions.md
@@ -7,7 +7,7 @@ Given a list of bills, write a function that replaces the last two bills with a 
 You'll start with the following stubbed function signature:
 
 ```rust
-pub fn fix_billing_summary(Vec<i32>) -> Vec<i32> {
+pub fn fix_billing_summary(summary: Vec<i32>) -> Vec<i32> {
 	todo!()
 }
 ```
@@ -28,7 +28,7 @@ This test is meant to show how you can modify your function to accept more compl
 Hint: replace the function signature with:
 
 ```rust
-pub fn fix_billing_summary<T: std::ops::Add>(Vec<T>) -> Vec<T> {
+pub fn fix_billing_summary<T: std::ops::Add>(summary: Vec<T>) -> Vec<T> {
 	todo!()
 }
 ```

--- a/exercises/concept/final-electric-bill/.docs/introduction.md
+++ b/exercises/concept/final-electric-bill/.docs/introduction.md
@@ -1,0 +1,4 @@
+# Introduction
+
+Rust's vector implementation, `std::vec::Vec`, provides several methods, out of the box.
+Two of which are `push()` and `pop()`, which are used efficiently add and remove elements at the end of the `Vec`.

--- a/exercises/concept/final-electric-bill/.meta/config.json
+++ b/exercises/concept/final-electric-bill/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "blurb": "Use `push()` and `pop()` to fix electric bills.",
+  "authors": [
+    "cwhakes"
+  ],
+  "files": {
+    "solution": [
+      "src/lib.rs"
+    ],
+    "test": [
+      "tests/final-electric-bill.rs"
+    ],
+    "exemplar": [
+      ".meta/exemplar.rs"
+    ]
+  }
+}

--- a/exercises/concept/final-electric-bill/.meta/design.md
+++ b/exercises/concept/final-electric-bill/.meta/design.md
@@ -1,0 +1,27 @@
+# Design
+
+## Goal
+
+Introduce the `push()` and `pop()` methods of `Vec`.
+
+## Learning objectives
+
+- Know what `push()` and `pop()` do.
+- Know how to use the values returned by `pop()`.
+
+## Out of scope
+
+- Specific Error hadling
+- other ways to instantiate `Vec<T>`
+
+## Concepts
+
+The Concepts this exercise unlocks are:
+
+- `vec-index`: for O(1) access to elements in vectors
+
+## Prerequisites
+
+- intro-fn
+- numbers
+- option

--- a/exercises/concept/final-electric-bill/.meta/exemplar.rs
+++ b/exercises/concept/final-electric-bill/.meta/exemplar.rs
@@ -1,0 +1,10 @@
+pub fn fix_billing_summary(mut summary: Vec<i32>) -> Vec<i32> {
+    assert!(summary.len() >= 2);
+    
+    let last_monthly_bill = summary.pop().unwrap();
+    let final_bill = summary.pop().unwrap;
+    let total_bill = last_monthly_bill + final_bill;
+    summary.push(total_bill);
+
+    summary;
+}

--- a/exercises/concept/final-electric-bill/.meta/exemplar.rs
+++ b/exercises/concept/final-electric-bill/.meta/exemplar.rs
@@ -1,10 +1,7 @@
-pub fn fix_billing_summary<T: std::ops::Add<Output = T>>(mut summary: Vec<T>) -> Vec<T> {
-    assert!(summary.len() >= 2);
-
-    let last_monthly_bill = summary.pop().unwrap();
-    let final_bill = summary.pop().unwrap();
-    let total_bill = last_monthly_bill + final_bill;
-    summary.push(total_bill);
-
-    summary
+/// Combines the final two elements of the input vector, or `None` if fewer than two elements present.
+pub fn fix_billing_summary<T: std::ops::Add<Output = T>>(mut summary: Vec<T>) -> Option<Vec<T>> {
+    let final_bill = summary.pop()?;
+    let last_monthly_bill = summary.pop()?;
+    summary.push(last_monthly_bill + final_bill);
+    Some(summary)
 }

--- a/exercises/concept/final-electric-bill/.meta/exemplar.rs
+++ b/exercises/concept/final-electric-bill/.meta/exemplar.rs
@@ -2,7 +2,7 @@ pub fn fix_billing_summary<T: std::ops::Add<Output = T>>(mut summary: Vec<T>) ->
     assert!(summary.len() >= 2);
 
     let last_monthly_bill = summary.pop().unwrap();
-    let final_bill = summary.pop().unwrap;
+    let final_bill = summary.pop().unwrap();
     let total_bill = last_monthly_bill + final_bill;
     summary.push(total_bill);
 

--- a/exercises/concept/final-electric-bill/.meta/exemplar.rs
+++ b/exercises/concept/final-electric-bill/.meta/exemplar.rs
@@ -1,6 +1,6 @@
-pub fn fix_billing_summary<T: std::ops::Add>(summary: Vec<T>) -> Vec<T> {
+pub fn fix_billing_summary<T: std::ops::Add<Output = T>>(mut summary: Vec<T>) -> Vec<T> {
     assert!(summary.len() >= 2);
-    
+
     let last_monthly_bill = summary.pop().unwrap();
     let final_bill = summary.pop().unwrap;
     let total_bill = last_monthly_bill + final_bill;

--- a/exercises/concept/final-electric-bill/.meta/exemplar.rs
+++ b/exercises/concept/final-electric-bill/.meta/exemplar.rs
@@ -1,4 +1,4 @@
-pub fn fix_billing_summary(mut summary: Vec<i32>) -> Vec<i32> {
+pub fn fix_billing_summary<T: std::ops::Add>(summary: Vec<T>) -> Vec<T> {
     assert!(summary.len() >= 2);
     
     let last_monthly_bill = summary.pop().unwrap();
@@ -6,5 +6,5 @@ pub fn fix_billing_summary(mut summary: Vec<i32>) -> Vec<i32> {
     let total_bill = last_monthly_bill + final_bill;
     summary.push(total_bill);
 
-    summary;
+    summary
 }

--- a/exercises/concept/final-electric-bill/Cargo.toml
+++ b/exercises/concept/final-electric-bill/Cargo.toml
@@ -3,3 +3,5 @@ name = "final_electric_bill"
 version = "0.1.0"
 edition = "2018"
 
+[features]
+generic = []

--- a/exercises/concept/final-electric-bill/Cargo.toml
+++ b/exercises/concept/final-electric-bill/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "final_electric_bill"
+version = "0.1.0"
+edition = "2018"
+

--- a/exercises/concept/final-electric-bill/src/lib.rs
+++ b/exercises/concept/final-electric-bill/src/lib.rs
@@ -1,3 +1,6 @@
 pub fn fix_billing_summary(summary: Vec<i32>) -> Option<Vec<i32>> {
-    unimplemented!("Combine the final two elements of {:?}, or `None` if fewer than two elements present.", summary)
+    unimplemented!(
+        "Combine the final two elements of {:?}, or `None` if fewer than two elements present.",
+        summary
+    )
 }

--- a/exercises/concept/final-electric-bill/src/lib.rs
+++ b/exercises/concept/final-electric-bill/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn fix_billing_summary(summary: Vec<i32>) -> Vec<i32> {
+pub fn fix_billing_summary(_summary: Vec<i32>) -> Vec<i32> {
     unimplemented!()
 }

--- a/exercises/concept/final-electric-bill/src/lib.rs
+++ b/exercises/concept/final-electric-bill/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn fix_billing_summary(summary: Vec<i32>) -> Vec<i32> {
+    unimplemented!()
+}

--- a/exercises/concept/final-electric-bill/src/lib.rs
+++ b/exercises/concept/final-electric-bill/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn fix_billing_summary(_summary: Vec<i32>) -> Vec<i32> {
-    unimplemented!()
+pub fn fix_billing_summary(summary: Vec<i32>) -> Vec<i32> {
+    unimplemented!("Combine the final two elements of {}, or `None` if fewer than two elements present.", summary)
 }

--- a/exercises/concept/final-electric-bill/src/lib.rs
+++ b/exercises/concept/final-electric-bill/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn fix_billing_summary(summary: Vec<i32>) -> Vec<i32> {
-    unimplemented!("Combine the final two elements of {}, or `None` if fewer than two elements present.", summary)
+pub fn fix_billing_summary(summary: Vec<i32>) -> Option<Vec<i32>> {
+    unimplemented!("Combine the final two elements of {:?}, or `None` if fewer than two elements present.", summary)
 }

--- a/exercises/concept/final-electric-bill/tests/final-electric-bill.rs
+++ b/exercises/concept/final-electric-bill/tests/final-electric-bill.rs
@@ -1,0 +1,35 @@
+use final_electric_bill::*;
+
+#[test]
+fn test_small_bill() {
+    let summary = vec![100, 200];
+    let fixed_summary = fix_billing_summary(summary);
+    assert_eq!(fixed_summary, vec![300]);
+}
+
+#[test]
+#[ignore]
+fn test_large_bill() {
+    let summary = vec![100; 37];
+    let fixed_summary = fix_billing_summary(summary);
+    assert_eq!(fixed_summary.pop(), Some(200));
+}
+
+#[test]
+#[cfg(feature = "generic")]
+#[ignore]
+fn test_generic() {
+    #[derive(PartialEq)]
+    struct Bill(i64);
+
+    impl std::ops::Add for Bill {
+        fn add(self, rhs: Bill) -> Bill {
+            Bill(self.0 + rhs.0)
+        }
+    }
+
+    let bills: Vec<_> = vec![100, 200, 300].into_iter().map(Bill).collect();
+    let fixed_bills = fix_billing_summary(bills);
+
+    assert_eq!(bills.pop(), Some(Bill(500)));
+}

--- a/exercises/concept/final-electric-bill/tests/final-electric-bill.rs
+++ b/exercises/concept/final-electric-bill/tests/final-electric-bill.rs
@@ -11,7 +11,7 @@ fn test_small_bill() {
 #[ignore]
 fn test_large_bill() {
     let summary = vec![100; 37];
-    let fixed_summary = fix_billing_summary(summary);
+    let mut fixed_summary = fix_billing_summary(summary);
     assert_eq!(fixed_summary.pop(), Some(200));
 }
 
@@ -29,7 +29,7 @@ fn test_generic() {
     }
 
     let bills: Vec<_> = vec![100, 200, 300].into_iter().map(Bill).collect();
-    let fixed_bills = fix_billing_summary(bills);
+    let mut fixed_bills = fix_billing_summary(bills);
 
     assert_eq!(bills.pop(), Some(Bill(500)));
 }

--- a/exercises/concept/final-electric-bill/tests/final-electric-bill.rs
+++ b/exercises/concept/final-electric-bill/tests/final-electric-bill.rs
@@ -31,5 +31,5 @@ fn test_generic() {
     let bills: Vec<_> = vec![100, 200, 300].into_iter().map(Bill).collect();
     let mut fixed_bills = fix_billing_summary(bills);
 
-    assert_eq!(bills.pop(), Some(Bill(500)));
+    assert_eq!(bills, vec![100, 500].into_iter().map(Bill).collect());
 }

--- a/exercises/concept/final-electric-bill/tests/final-electric-bill.rs
+++ b/exercises/concept/final-electric-bill/tests/final-electric-bill.rs
@@ -1,17 +1,25 @@
 use final_electric_bill::*;
 
 #[test]
+fn test_too_small_bill() {
+    let summary = vec![100];
+    let fixed_summary = fix_billing_summary(summary);
+    assert_eq!(fixed_summary, None);
+}
+
+#[test]
+#[ignore]
 fn test_small_bill() {
     let summary = vec![100, 200];
     let fixed_summary = fix_billing_summary(summary);
-    assert_eq!(fixed_summary, vec![300]);
+    assert_eq!(fixed_summary, Some(vec![300]));
 }
 
 #[test]
 #[ignore]
 fn test_large_bill() {
     let summary = vec![100; 37];
-    let mut fixed_summary = fix_billing_summary(summary);
+    let mut fixed_summary = fix_billing_summary(summary).expect("Expected some bill");
     assert_eq!(fixed_summary.pop(), Some(200));
     assert_eq!(fixed_summary, vec![100; 35]);
 }
@@ -20,17 +28,20 @@ fn test_large_bill() {
 #[cfg(feature = "generic")]
 #[ignore]
 fn test_generic() {
-    #[derive(PartialEq)]
+    #[derive(Debug, PartialEq)]
     struct Bill(i64);
 
     impl std::ops::Add for Bill {
+        type Output = Self;
+
         fn add(self, rhs: Bill) -> Bill {
             Bill(self.0 + rhs.0)
         }
     }
 
     let bills: Vec<_> = vec![100, 200, 300].into_iter().map(Bill).collect();
-    let mut fixed_bills = fix_billing_summary(bills);
+    let fixed_bills = fix_billing_summary(bills).expect("Expected some bill");
+    let expected_bills: Vec<_> = vec![100, 500].into_iter().map(Bill).collect();
 
-    assert_eq!(bills, vec![100, 500].into_iter().map(Bill).collect());
+    assert_eq!(fixed_bills, expected_bills);
 }

--- a/exercises/concept/final-electric-bill/tests/final-electric-bill.rs
+++ b/exercises/concept/final-electric-bill/tests/final-electric-bill.rs
@@ -13,6 +13,7 @@ fn test_large_bill() {
     let summary = vec![100; 37];
     let mut fixed_summary = fix_billing_summary(summary);
     assert_eq!(fixed_summary.pop(), Some(200));
+    assert_eq!(fixed_summary, vec![100; 35]);
 }
 
 #[test]


### PR DESCRIPTION
This concept exercise teaches the `vec-stack` concept. It is very much a work-in-progress.

Issues:
- ~~I was unable to add the exercise to config.json, because util/exercise doesn't appear to work with the new format.~~
- The exercise is a lot less in-depth than a Reverse Polish Notation stack. I am under the impression this is a very early exercise, and I don't believe enough concepts have been covered to implement that.