### PR TITLE
Add test case to rust/anagram to prevent ascii-sum-solutions

### DIFF
--- a/exercises/practice/anagram/tests/anagram.rs
+++ b/exercises/practice/anagram/tests/anagram.rs
@@ -172,3 +172,15 @@ fn test_same_bytes_different_chars() {
 
     process_anagram_case(word, &inputs, &outputs);
 }
+
+#[test]
+#[ignore]
+fn test_different_words_but_same_ascii_sum() {
+    let word = "bc";
+
+    let inputs = ["ad"];
+
+    let outputs = vec![];
+
+    process_anagram_case(word, &inputs, &outputs);
+}


### PR DESCRIPTION
Prevent solutions that use the sum of the ascii values of each char
to find anagrams.