### PR TITLE
fix rpg test case with insufficient mana

### DIFF
--- a/exercises/concept/role-playing-game/.docs/instructions.md
+++ b/exercises/concept/role-playing-game/.docs/instructions.md
@@ -39,7 +39,7 @@ The `cast_spell` method takes a mutable reference to the Player as well as a `ma
   ```rust
   let not_a_wizard_yet = Player { health: 79, mana: None, level: 9 };
   assert_eq!(not_a_wizard_yet.cast_spell(5), 0)
-  assert_eq!(not_a_wizard_yet.health, 70);
+  assert_eq!(not_a_wizard_yet.health, 74);
   assert_eq!(not_a_wizard_yet.mana, None);
   ```
 


### PR DESCRIPTION
The instructions for this exercise when casting a spell with insufficient mana say this:

```
 If the player does not have access to a mana pool, attempting to cast the spell must decrease their health by the mana cost of the spell. The damage returned must be 0.
 ```
 
The correct behavior is outlined in this test:

```rust
#[test]
fn test_cast_spell_with_no_mana_pool() {
    const MANA_COST: u32 = 10;

    let mut underleveled_player = Player {
        health: 87,
        mana: None,
        level: 6,
    };

    let clone = Player {
        ..underleveled_player
    };

    assert_eq!(underleveled_player.cast_spell(MANA_COST), 0);
    assert_eq!(underleveled_player.health, clone.health - MANA_COST);
    assert_eq!(underleveled_player.mana, clone.mana);
    assert_eq!(underleveled_player.level, clone.level);
}
```

That being said, the docs seem to indicate that you're supposed to subtract the health from the level here: (79 - 9 == 70). I believe this should be (health - mana cost), or (79 - 5 == 74).

  ```rust
  let not_a_wizard_yet = Player { health: 79, mana: None, level: 9 };
  assert_eq!(not_a_wizard_yet.cast_spell(5), 0)
  assert_eq!(not_a_wizard_yet.health, 70);
  assert_eq!(not_a_wizard_yet.mana, None);
  ```


