### PR TITLE
Remove the solution from the stub file of deprecated two-fer

### DIFF
--- a/exercises/practice/two-fer/src/lib.rs
+++ b/exercises/practice/two-fer/src/lib.rs
@@ -1,6 +1,3 @@
 pub fn twofer(name: &str) -> String {
-    match name {
-        "" => "One for you, one for me.".to_string(),
-        _ => format!("One for {}, one for me.", name),
-    }
+    "".to_string()
 }

--- a/exercises/practice/two-fer/src/lib.rs
+++ b/exercises/practice/two-fer/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn twofer(name: &str) -> String {
-    "".to_string()
+    unimplemented!("how many for {}", name)
 }


### PR DESCRIPTION
Fixes https://github.com/exercism/rust/issues/1266

We currently have students (22 to be precise) who have an in progress TwoFer. Although it is deprecated it should still work as an exercise for those students. This aims to fix the fact that the solution is provided in the stub by providing a minimal compiling solution.

As I've never written Rust and don't have it installed, I'm entirely guessing at the syntax from a quick Google. If CI passes then I think this is fine. If not, I'll try and iterate until it does compile, but obviously if someone with Rust skills wants to just fix it, that's fine too 🙂 