### PR TITLE
🤖 Add labels append file

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -1,0 +1,64 @@
+- name: "Hacktoberfest"
+  description: ""
+  color: "cc8744"
+
+- name: "New Problem"
+  description: ""
+  color: "006b75"
+
+- name: "PR addressing"
+  description: "A PR exists addressing this issue"
+  color: "fff7a0"
+
+- name: "Track Anatomy"
+  description: ""
+  color: "405ba5"
+
+- name: "dependencies"
+  description: "Pull requests that update a dependency file"
+  color: "0366d6"
+
+- name: "good first issue"
+  description: "An improvement or bug fix that favors new contributors"
+  color: "009248"
+
+- name: "help wanted"
+  description: "We need your help to improve the track! By taking on this task."
+  color: "4CB642"
+
+- name: "invalid"
+  description: "Hacktoberfest says if we apply this label to a PR, the PR doesn't count for Hacktoberfest!"
+  color: "e6e6e6"
+
+- name: "question"
+  description: ""
+  color: "cc317c"
+
+- name: "sync/readme"
+  description: "Keep a README in sync with exercism/problem-specifications"
+  color: "c5def5"
+
+- name: "sync/tests"
+  description: "Keep a test suite/version in sync with exercism/problem-specifications"
+  color: "c5def5"
+
+- name: "track meta"
+  description: "Issues about the track as opposed to about exercises"
+  color: "ada6fc"
+
+- name: "track meta/exercise crate"
+  description: "Issues dealing with the exercise crate"
+  color: "ff99af"
+
+- name: "track policy"
+  description: "Official pronouncements about What We Do Here"
+  color: "2333bc"
+
+- name: "v3"
+  description: "Temporary label to group v3 issues. Many were transferred from @exercism/v3."
+  color: "33A5AB"
+
+- name: "v3-migration 🤖"
+  description: "Preparing for Exercism v3"
+  color: "E99695"
+


### PR DESCRIPTION
This PR adds a `.appends/.github/labels.yml` file, which contains all the labels that are currently used in this repo. The `.github/labels.yml` file will contain the full list of labels that this repo can use, which will be a combination of the `.appends/.github/labels.yml` file and a centrally-managed `labels.yml` file.

We'll automatically sync any changes, which allows us to guarantee that all the track repositories will have a pre-determined set of labels, augmented with any custom labels defined in the `.appends/.github/labels.yml` file. This syncing will be done by another (automatically-synced) workflow, which we will add in a later PR.

## Tracking

https://github.com/exercism/v3-launch/issues/41