### PR TITLE
Add lasagna exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -35,6 +35,17 @@
   "exercises": {
     "concept": [
       {
+        "slug": "lucians-luscious-lasagna",        
+        "uuid": "29a2d3bd-eec8-454d-9dba-4b2d7d071925",
+        "name": "Lucian's Luscious Lasagna",
+        "difficulty": 1,
+        "concepts": [
+          "intro-fn"
+        ],
+        "prerequisites": [],
+        "status": "active"
+      },
+      {
         "slug": "magazine-cutout",
         "uuid": "091c141b-6b68-43ad-b009-a27cd6741906",
         "name": "Magazine Cutout",

--- a/exercises/concept/lucians-luscious-lasagna/.docs/hints.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/hints.md
@@ -1,0 +1,32 @@
+# Hints
+
+## General
+
+-   An integer value can be defined as one or more consecutive digits.
+
+## 1. Define the expected oven time in minutes
+
+-   You need to define a [function][functions] without any parameters.
+
+## 2. Calculate the remaining oven time in minutes
+
+-   You need to define a [function][functions] with a single parameter.
+-   You can use and refer to the previously defined binding by its name.
+-   The last expression in a function is [automatically returned][return-values] from the function; you don't have to explicitly indicate which value to return.
+-   You can use the [mathematical operator for subtraction][operators] to subtract values.
+
+## 3. Calculate the preparation time in minutes
+
+-   You need to define a [function][functions] with a single parameter.
+-   You can use the [mathematical operator for multiplicaton][operators] to multiply values.
+
+## 4. Calculate the elapsed time in minutes
+
+-   You need to define a [function][functions] with two parameters.
+-   You can [call][calling] one of the other functions you've defined previously.
+-   You can use the [mathematical operator for addition][operators] to add values.
+
+[functions]: TODO
+[return-values]: TODO
+[operators]: TODO
+[calling]: TODO

--- a/exercises/concept/lucians-luscious-lasagna/.docs/hints.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/hints.md
@@ -23,10 +23,9 @@
 ## 4. Calculate the elapsed time in minutes
 
 -   You need to define a [function][functions] with two parameters.
--   You can [call][calling] one of the other functions you've defined previously.
+-   You can [call][functions] one of the other functions you've defined previously.
 -   You can use the [mathematical operator for addition][operators] to add values.
 
 [functions]: https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
 [return-values]: https://doc.rust-lang.org/book/ch03-03-how-functions-work.html#functions-with-return-values
 [operators]: https://doc.rust-lang.org/book/appendix-02-operators.html
-[calling]: https://doc.rust-lang.org/book/ch03-03-how-functions-work.html#functions

--- a/exercises/concept/lucians-luscious-lasagna/.docs/hints.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/hints.md
@@ -2,7 +2,7 @@
 
 ## General
 
--   An integer value can be defined as one or more consecutive digits.
+-   An integer literal can be defined as one or more consecutive digits.
 
 ## 1. Define the expected oven time in minutes
 
@@ -11,7 +11,7 @@
 ## 2. Calculate the remaining oven time in minutes
 
 -   You need to define a [function][functions] with a single parameter.
--   You can use and refer to the previously defined binding by its name.
+-   You can use and refer to the previously defined item by its name.
 -   The last expression in a function is [automatically returned][return-values] from the function; you don't have to explicitly indicate which value to return.
 -   You can use the [mathematical operator for subtraction][operators] to subtract values.
 
@@ -26,7 +26,7 @@
 -   You can [call][calling] one of the other functions you've defined previously.
 -   You can use the [mathematical operator for addition][operators] to add values.
 
-[functions]: TODO
-[return-values]: TODO
-[operators]: TODO
-[calling]: TODO
+[functions]: https://doc.rust-lang.org/book/ch03-03-how-functions-work.html
+[return-values]: https://doc.rust-lang.org/book/ch03-03-how-functions-work.html#functions-with-return-values
+[operators]: https://doc.rust-lang.org/book/appendix-02-operators.html
+[calling]: https://doc.rust-lang.org/book/ch03-03-how-functions-work.html#functions

--- a/exercises/concept/lucians-luscious-lasagna/.docs/instructions.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/instructions.md
@@ -9,7 +9,7 @@ You have four tasks, all related to the time spent cooking the lasagna.
 Define the `expected_minutes_in_oven` binding to check how many minutes the lasagna should be in the oven. According to the cooking book, the expected oven time in minutes is 40:
 
 ```rust
-lucians_luscious_lasagna::expected_minutes_in_oven()
+expected_minutes_in_oven()
 // Returns: 40
 ```
 
@@ -18,7 +18,7 @@ lucians_luscious_lasagna::expected_minutes_in_oven()
 Define the `remaining_minutes_in_oven` function that takes the actual minutes the lasagna has been in the oven as a parameter and returns how many minutes the lasagna still has to remain in the oven, based on the expected time oven time in minutes from the previous task.
 
 ```rust
-lucians_luscious_lasagna::remaining_minutes_in_oven(30)
+remaining_minutes_in_oven(30)
 // Returns: 10
 ```
 
@@ -27,7 +27,7 @@ lucians_luscious_lasagna::remaining_minutes_in_oven(30)
 Define the `preparation_time_in_minutes` function that takes the number of layers you added to the lasagna as a parameter and returns how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
 
 ```rust
-lucians_luscious_lasagna::preparation_time_in_minutes(2)
+preparation_time_in_minutes(2)
 // Returns: 4
 ```
 
@@ -36,6 +36,6 @@ lucians_luscious_lasagna::preparation_time_in_minutes(2)
 Define the `elapsed_time_in_minutes` function that takes two parameters: the first parameter is the number of layers you added to the lasagna, and the second parameter is the number of minutes the lasagna has been in the oven. The function should return how many minutes you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
 
 ```rust
-lucians_luscious_lasagna::elapsed_time_in_minutes(3, 20)
+elapsed_time_in_minutes(3, 20)
 // Returns: 26
 ```

--- a/exercises/concept/lucians-luscious-lasagna/.docs/instructions.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/instructions.md
@@ -1,0 +1,41 @@
+# Instructions
+
+In this exercise you're going to write some code to help you cook a brilliant lasagna from your favorite cooking book.
+
+You have four tasks, all related to the time spent cooking the lasagna.
+
+## 1. Define the expected oven time in minutes
+
+Define the `expected_minutes_in_oven` binding to check how many minutes the lasagna should be in the oven. According to the cooking book, the expected oven time in minutes is 40:
+
+```rust
+lucians_luscious_lasagna::expected_minutes_in_oven()
+// Returns: 40
+```
+
+## 2. Calculate the remaining oven time in minutes
+
+Define the `remaining_minutes_in_oven` function that takes the actual minutes the lasagna has been in the oven as a parameter and returns how many minutes the lasagna still has to remain in the oven, based on the expected time oven time in minutes from the previous task.
+
+```rust
+lucians_luscious_lasagna::remaining_minutes_in_oven(30)
+// Returns: 10
+```
+
+## 3. Calculate the preparation time in minutes
+
+Define the `preparation_time_in_minutes` function that takes the number of layers you added to the lasagna as a parameter and returns how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
+
+```rust
+lucians_luscious_lasagna::preparation_time_in_minutes(2)
+// Returns: 4
+```
+
+## 4. Calculate the elapsed time in minutes
+
+Define the `elapsed_time_in_minutes` function that takes two parameters: the first parameter is the number of layers you added to the lasagna, and the second parameter is the number of minutes the lasagna has been in the oven. The function should return how many minutes you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
+
+```rust
+lucians_luscious_lasagna::elapsed_time_in_minutes(3, 20)
+// Returns: 26
+```

--- a/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
@@ -1,72 +1,104 @@
 # Introduction
 
-TODO: rewrite for Rust
+In Rust, assigning a value to a name is referred to as a _binding_. Bindings are immutable unless declared with the `mut` keyword. As Rust is a statically-typed language, each binding has a type known at compile-time.
 
-In F#, assigning a value to a name is referred to as a _binding_. Bindings are immutable, which makes them similar to constants in other languages. As F# is a statically-typed language, each binding has a type at compile-time.
+Bindings are most commonly defined using the `let` keyword. Specifying a binding's type is optional for most bindings, as Rust's _type inference_ can usually infer the type based on their value. A binding looks like this:
 
-Bindings are defined using the `let` keyword. Specifying a binding's type is optional for most bindings, as F#'s _type inference_ can usually infer the type based on their value. A binding looks like this:
-
-```fsharp
+```rust
 // Automatically inferred type
-let fingers = 10
+let fingers = 10;
 ```
 
-Functions are also regular bindings, but with one or more parameters. A function automatically returns its last expression. Type inference also works for most functions, by analyzing what values the function is called with and what value the function returns.
+Functions are _items_. Where bindings typically refer to a particular value, items refer to a unit of code organization, typically a function or a module, which is available throughout the lifetime of the program. A function automatically returns the result of its last expression. A function may have 0 or more parameters, which are bindings with a lifetime of the function call.
 
-```fsharp
-// Automatically inferred types for parameters and return type
-let add x y = x + y
+Type inference is theoretically possible for functions, but is disabled as an intentional language design choice. While this means that you need to spend a little more time when writing code to specify precisely what a function's input and output types are, you save the time when you're reading the code, because all the input and output types are explicitly defined.
+
+```rust
+fn add(x: i32, y: i32) -> i32 {
+  x + y
+}
 ```
 
-Invoking a function is done by specifying its name and passing arguments for each of the function's parameters.
+Invoking a function is done by specifying its name followed by parentheses. If the function requires parameters, an argument must be specified for each within the parentheses.
 
-```fsharp
-let five = add 2 3
+```rust
+let five = add(2, 3);
 ```
 
 If a binding's type cannot be inferred, the compiler will report an error. To fix this, add an explicit type annotation to the binding.
 
-```fsharp
+```rust
 // Explicit type annotation
-let fingers: int = 10
-
-// Explicit type annotation (also for parameters)
-let add (x: int) (y: int): int = x + y
+let fingers: i32 = 10;
 ```
 
-Bindings in F# can only be used _after_ they have been defined. Using a binding before it has been defined results in a compile error.
+Items in Rust can be used before or after they are defined, because they have a static lifetime. Bindings, on the other hand, can only be used _after_ they have been defined. Using a binding before it has been defined results in a compile error.
 
-```fsharp
-// Compile error as the add binding has not yet been defined
-// let seven = add 3 + 4
+```rust
+fn main() {
+    // `fn add` hasn't yet been defined, but that's perfectly ok
+    dbg!(add(3, 4));
+}
 
-let add x y = x + y
+fn add(x: i32, y: i32) -> i32 {
+  x + y
+}
 ```
 
-F# uses significant whitespace to define scope. This means that scope is defined by indenting the code with spaces, relative to the line declaring the binding. The default convention is to use four spaces for indentation:
-
-```fsharp
-let toes =
-    let left = 5
-    let right = 5
-    left + right
-
-let multiplyPlusTwo x y =
-    let product = x * y
-    product + 2
-
-// Trying to access the left, right or product bindings
-// here would result in a compile error
+```rust
+// this won't compile; `a` is used before its binding is defined
+let b = a;
+let a = x + y
 ```
 
-F# bindings (which include functions) are usually organized in modules. A module groups related functionality and is defined using the `module` keyword. The module definition must precede its bindings:
+Rust uses curly braces (`{}`) to define a scope. A binding defined within a scope can't escape from it. This means that scope is defined by indenting the code with spaces, relative to the line declaring the binding.
 
-```fsharp
-module Calculator
+```rust
+let a = 1;
+dbg!(a); // 1
+{
+    // Here, we re-bind `a` to a new value, which is still immutable.
+    // This technique is called _shadowing_. The new binding is constrained to
+    // this anonymous scope. Outside this scope, the previous binding still
+    // applies.
+    let a = 2;
+    let b = 3;
+    dbg!(a, b); // 2, 3
+}
+// can't use `b` anymore because it is out of scope
+// dbg!(b);
 
-let pi = 3.14
-
-let add x y = x + y
+// The shadowed `a` in the inner scope above has fallen out of scope,
+// leaving us with our original binding.
+dbg!(a); // 1
 ```
 
-F# supports two types of comments. Single line comments are preceded by `//` and multiline comments are inserted between `(*` and `*)`.
+Rust items are often organized in modules. Each crate is implicitly a module, but it can define inner sub-modules of arbitrary depth. A module groups related functionality and is defined using the `mod` keyword.
+
+```rust
+mod calc_i32 {
+    fn add(a: i32, b: i32) -> i32 { a + b }
+    fn sub(a: i32, b: i32) -> i32 { a - b }
+    fn mul(a: i32, b: i32) -> i32 { a * b }
+    fn div(a: i32, b: i32) -> i32 { a / b }
+}
+```
+
+Rust supports two types of comments. The keyword `//` indicates a single-line comment; everything following the keyword until the end of the line is ignored. The keywords `/*` and `*/` indicate a multi-line comment; everything within those two keywords is ignored. It is idiomatic and good practice to prefer single-line comments.
+
+Rust also supports doc-comments, which show up in the generated documentation produced by `cargo doc`. Outer doc comments are formed with the keyword `///`, which acts identically to the `//` keyword. They apply to the item which follows them, such as a function:
+
+```rust
+/// The `add` function produces the sum of its arguments.
+fn add(x: i32, y: i32) -> i32 { x + y }
+```
+
+Inner doc comments are formed with the keyword `//!`, which acts identically to the `//` keyword. They apply to the item enclosing them, such as a module:
+
+```rust
+mod my_cool_module {
+    //! This module is the bee's knees.
+}
+```
+
+Doc comments can be of arbitrary length and contain markdown, which is rendered into the generated documentation.

--- a/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
@@ -1,0 +1,72 @@
+# Introduction
+
+TODO: rewrite for Rust
+
+In F#, assigning a value to a name is referred to as a _binding_. Bindings are immutable, which makes them similar to constants in other languages. As F# is a statically-typed language, each binding has a type at compile-time.
+
+Bindings are defined using the `let` keyword. Specifying a binding's type is optional for most bindings, as F#'s _type inference_ can usually infer the type based on their value. A binding looks like this:
+
+```fsharp
+// Automatically inferred type
+let fingers = 10
+```
+
+Functions are also regular bindings, but with one or more parameters. A function automatically returns its last expression. Type inference also works for most functions, by analyzing what values the function is called with and what value the function returns.
+
+```fsharp
+// Automatically inferred types for parameters and return type
+let add x y = x + y
+```
+
+Invoking a function is done by specifying its name and passing arguments for each of the function's parameters.
+
+```fsharp
+let five = add 2 3
+```
+
+If a binding's type cannot be inferred, the compiler will report an error. To fix this, add an explicit type annotation to the binding.
+
+```fsharp
+// Explicit type annotation
+let fingers: int = 10
+
+// Explicit type annotation (also for parameters)
+let add (x: int) (y: int): int = x + y
+```
+
+Bindings in F# can only be used _after_ they have been defined. Using a binding before it has been defined results in a compile error.
+
+```fsharp
+// Compile error as the add binding has not yet been defined
+// let seven = add 3 + 4
+
+let add x y = x + y
+```
+
+F# uses significant whitespace to define scope. This means that scope is defined by indenting the code with spaces, relative to the line declaring the binding. The default convention is to use four spaces for indentation:
+
+```fsharp
+let toes =
+    let left = 5
+    let right = 5
+    left + right
+
+let multiplyPlusTwo x y =
+    let product = x * y
+    product + 2
+
+// Trying to access the left, right or product bindings
+// here would result in a compile error
+```
+
+F# bindings (which include functions) are usually organized in modules. A module groups related functionality and is defined using the `module` keyword. The module definition must precede its bindings:
+
+```fsharp
+module Calculator
+
+let pi = 3.14
+
+let add x y = x + y
+```
+
+F# supports two types of comments. Single line comments are preceded by `//` and multiline comments are inserted between `(*` and `*)`.

--- a/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -2,6 +2,7 @@
   "blurb": "Learn about the basics of Rust by following a lasagna recipe.",
   "icon": "lasagna",
   "authors": [
+    "coriolinus",
     "ErikSchierboom"
   ],
   "files": {

--- a/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -1,0 +1,18 @@
+{
+  "blurb": "Learn about the basics of Rust by following a lasagna recipe.",
+  "icon": "lasagna",
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "files": {
+    "solution": [
+      "src/lib.rs"
+    ],
+    "test": [
+      "tests/lucians-luscious-lasagna.rs"
+    ],
+    "exemplar": [
+      ".meta/exemplar.rs"
+    ]
+  }
+}

--- a/exercises/concept/lucians-luscious-lasagna/.meta/design.md
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/design.md
@@ -1,0 +1,36 @@
+# Design
+
+## Learning objectives
+
+-   Know how to define a function
+-   Know how to return a value from a function
+
+## Out of scope
+
+-   TODO
+
+## Concepts
+
+-   Functions
+
+## Prerequisites
+
+None
+
+## Resources to refer to
+
+### Hints
+
+TODO
+
+### After
+
+TODO
+
+## Representer
+
+This exercise does not require any specific representation logic to be added to the representer.
+
+## Analyzer
+
+This exercise does not require any specific logic to be added to the analyzer.

--- a/exercises/concept/lucians-luscious-lasagna/.meta/design.md
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/design.md
@@ -7,7 +7,7 @@
 
 ## Out of scope
 
--   TODO
+-   Know how to work with `const` values
 
 ## Concepts
 
@@ -21,11 +21,11 @@ None
 
 ### Hints
 
-TODO
+-   [Functions][https://doc.rust-lang.org/book/ch03-03-how-functions-work.html]
+-   [Return values][https://doc.rust-lang.org/book/ch03-03-how-functions-work.html#functions-with-return-values]
+-   [Operators][https://doc.rust-lang.org/book/appendix-02-operators.html]
 
 ### After
-
-TODO
 
 ## Representer
 

--- a/exercises/concept/lucians-luscious-lasagna/.meta/exemplar.rs
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/exemplar.rs
@@ -1,0 +1,15 @@
+pub fn expected_minutes_in_oven() -> u32 {
+    40
+}
+
+pub fn remaining_minutes_in_oven(actual_minutes_in_oven: u32) -> u32 {
+    expected_minutes_in_oven() - actual_minutes_in_oven
+}
+
+pub fn preparation_time_in_minutes(number_of_layers: u32) -> u32 {
+    number_of_layers * 2
+}
+
+pub fn elapsed_time_in_minutes(number_of_layers: u32, actual_minutes_in_oven: u32) -> u32 {
+    preparation_time_in_minutes(number_of_layers) + actual_minutes_in_oven
+}

--- a/exercises/concept/lucians-luscious-lasagna/.meta/exemplar.rs
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/exemplar.rs
@@ -1,15 +1,15 @@
-pub fn expected_minutes_in_oven() -> u32 {
+pub fn expected_minutes_in_oven() -> i32 {
     40
 }
 
-pub fn remaining_minutes_in_oven(actual_minutes_in_oven: u32) -> u32 {
+pub fn remaining_minutes_in_oven(actual_minutes_in_oven: i32) -> i32 {
     expected_minutes_in_oven() - actual_minutes_in_oven
 }
 
-pub fn preparation_time_in_minutes(number_of_layers: u32) -> u32 {
+pub fn preparation_time_in_minutes(number_of_layers: i32) -> i32 {
     number_of_layers * 2
 }
 
-pub fn elapsed_time_in_minutes(number_of_layers: u32, actual_minutes_in_oven: u32) -> u32 {
+pub fn elapsed_time_in_minutes(number_of_layers: i32, actual_minutes_in_oven: i32) -> i32 {
     preparation_time_in_minutes(number_of_layers) + actual_minutes_in_oven
 }

--- a/exercises/concept/lucians-luscious-lasagna/Cargo.toml
+++ b/exercises/concept/lucians-luscious-lasagna/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "lucians-luscious-lasagna"
+version = "0.1.0"
+edition = "2018"

--- a/exercises/concept/lucians-luscious-lasagna/src/lib.rs
+++ b/exercises/concept/lucians-luscious-lasagna/src/lib.rs
@@ -2,25 +2,25 @@
 // to enable stricter warnings.
 #![allow(unused)]
 
-pub fn expected_minutes_in_oven() -> u32 {
+pub fn expected_minutes_in_oven() -> i32 {
     unimplemented!("return expected minutes in the oven")
 }
 
-pub fn remaining_minutes_in_oven(actual_minutes_in_oven: u32) -> u32 {
+pub fn remaining_minutes_in_oven(actual_minutes_in_oven: i32) -> i32 {
     unimplemented!(
         "calculate remaining minutes in oven given actual minutes in oven: {}",
         actual_minutes_in_oven
     )
 }
 
-pub fn preparation_time_in_minutes(number_of_layers: u32) -> u32 {
+pub fn preparation_time_in_minutes(number_of_layers: i32) -> i32 {
     unimplemented!(
         "calculate preparation time in minutes for number of layers: {}",
         number_of_layers
     )
 }
 
-pub fn elapsed_time_in_minutes(number_of_layers: u32, actual_minutes_in_oven: u32) -> u32 {
+pub fn elapsed_time_in_minutes(number_of_layers: i32, actual_minutes_in_oven: i32) -> i32 {
     unimplemented!(
         "calculate elapsed time in minutes for number of layers {} and actual minutes in oven {}",
         number_of_layers,

--- a/exercises/concept/lucians-luscious-lasagna/src/lib.rs
+++ b/exercises/concept/lucians-luscious-lasagna/src/lib.rs
@@ -7,13 +7,23 @@ pub fn expected_minutes_in_oven() -> u32 {
 }
 
 pub fn remaining_minutes_in_oven(actual_minutes_in_oven: u32) -> u32 {
-    unimplemented!("calculate remaining minutes in oven given actual minutes in oven: {}", actual_minutes_in_oven)
+    unimplemented!(
+        "calculate remaining minutes in oven given actual minutes in oven: {}",
+        actual_minutes_in_oven
+    )
 }
 
 pub fn preparation_time_in_minutes(number_of_layers: u32) -> u32 {
-    unimplemented!("calculate preparation time in minutes for number of layers: {}", number_of_layers)
+    unimplemented!(
+        "calculate preparation time in minutes for number of layers: {}",
+        number_of_layers
+    )
 }
 
 pub fn elapsed_time_in_minutes(number_of_layers: u32, actual_minutes_in_oven: u32) -> u32 {
-    unimplemented!("calculate elapsed time in minutes for number of layers {} and actual minutes in oven {}", number_of_layers, actual_minutes_in_oven)
+    unimplemented!(
+        "calculate elapsed time in minutes for number of layers {} and actual minutes in oven {}",
+        number_of_layers,
+        actual_minutes_in_oven
+    )
 }

--- a/exercises/concept/lucians-luscious-lasagna/src/lib.rs
+++ b/exercises/concept/lucians-luscious-lasagna/src/lib.rs
@@ -1,0 +1,19 @@
+// This stub file contains items which aren't used yet; feel free to remove this module attribute
+// to enable stricter warnings.
+#![allow(unused)]
+
+pub fn expected_minutes_in_oven() -> u32 {
+    unimplemented!("return expected minutes in the oven")
+}
+
+pub fn remaining_minutes_in_oven(actual_minutes_in_oven: u32) -> u32 {
+    unimplemented!("calculate remaining minutes in oven given actual minutes in oven: {}", actual_minutes_in_oven)
+}
+
+pub fn preparation_time_in_minutes(number_of_layers: u32) -> u32 {
+    unimplemented!("calculate preparation time in minutes for number of layers: {}", number_of_layers)
+}
+
+pub fn elapsed_time_in_minutes(number_of_layers: u32, actual_minutes_in_oven: u32) -> u32 {
+    unimplemented!("calculate elapsed time in minutes for number of layers {} and actual minutes in oven {}", number_of_layers, actual_minutes_in_oven)
+}

--- a/exercises/concept/lucians-luscious-lasagna/tests/lucians-luscious-lasagna.rs
+++ b/exercises/concept/lucians-luscious-lasagna/tests/lucians-luscious-lasagna.rs
@@ -1,34 +1,41 @@
+use lucians_luscious_lasagna::{
+    expected_minutes_in_oven,
+    remaining_minutes_in_oven,
+    preparation_time_in_minutes,
+    elapsed_time_in_minutes,
+};
+
 #[test]
-fn expected_minutes_in_oven() {
-    assert_eq!(40, lucians_luscious_lasagna::expected_minutes_in_oven());
+fn expected_minutes_in_oven_is_correct() {
+    assert_eq!(40, expected_minutes_in_oven());
 }
 
 #[ignore]
 #[test]
-fn remaining_minutes_in_oven() {
-    assert_eq!(15, lucians_luscious_lasagna::remaining_minutes_in_oven(25));
+fn remaining_minutes_in_oven_after_fifteen_minutes() {
+    assert_eq!(15, remaining_minutes_in_oven(25));
 }
 
 #[ignore]
 #[test]
 fn preparation_time_in_minutes_for_one_layer() {
-    assert_eq!(2, lucians_luscious_lasagna::preparation_time_in_minutes(1));
+    assert_eq!(2, preparation_time_in_minutes(1));
 }
 
 #[ignore]
 #[test]
 fn preparation_time_in_minutes_for_multiple_layers() {
-    assert_eq!(8, lucians_luscious_lasagna::preparation_time_in_minutes(4));
+    assert_eq!(8, preparation_time_in_minutes(4));
 }
 
 #[ignore]
 #[test]
 fn elapsed_time_in_minutes_for_one_layer() {
-    assert_eq!(32, lucians_luscious_lasagna::elapsed_time_in_minutes(1, 30));
+    assert_eq!(32, elapsed_time_in_minutes(1, 30));
 }
 
 #[ignore]
 #[test]
 fn elapsed_time_in_minutes_for_multiple_layers() {
-    assert_eq!(16, lucians_luscious_lasagna::elapsed_time_in_minutes(4, 8));
+    assert_eq!(16, elapsed_time_in_minutes(4, 8));
 }

--- a/exercises/concept/lucians-luscious-lasagna/tests/lucians-luscious-lasagna.rs
+++ b/exercises/concept/lucians-luscious-lasagna/tests/lucians-luscious-lasagna.rs
@@ -1,0 +1,34 @@
+#[test]
+fn expected_minutes_in_oven() {
+    assert_eq!(40, lucians_luscious_lasagna::expected_minutes_in_oven());
+}
+
+#[ignore]
+#[test]
+fn remaining_minutes_in_oven() {
+    assert_eq!(15, lucians_luscious_lasagna::remaining_minutes_in_oven(25));
+}
+
+#[ignore]
+#[test]
+fn preparation_time_in_minutes_for_one_layer() {
+    assert_eq!(2, lucians_luscious_lasagna::preparation_time_in_minutes(1));
+}
+
+#[ignore]
+#[test]
+fn preparation_time_in_minutes_for_multiple_layers() {
+    assert_eq!(8, lucians_luscious_lasagna::preparation_time_in_minutes(4));
+}
+
+#[ignore]
+#[test]
+fn elapsed_time_in_minutes_for_one_layer() {
+    assert_eq!(32, lucians_luscious_lasagna::elapsed_time_in_minutes(1, 30));
+}
+
+#[ignore]
+#[test]
+fn elapsed_time_in_minutes_for_multiple_layers() {
+    assert_eq!(16, lucians_luscious_lasagna::elapsed_time_in_minutes(4, 8));
+}

--- a/exercises/concept/lucians-luscious-lasagna/tests/lucians-luscious-lasagna.rs
+++ b/exercises/concept/lucians-luscious-lasagna/tests/lucians-luscious-lasagna.rs
@@ -1,8 +1,6 @@
 use lucians_luscious_lasagna::{
-    expected_minutes_in_oven,
+    elapsed_time_in_minutes, expected_minutes_in_oven, preparation_time_in_minutes,
     remaining_minutes_in_oven,
-    preparation_time_in_minutes,
-    elapsed_time_in_minutes,
 };
 
 #[test]


### PR DESCRIPTION
While checking the status of the various tracks, I found that Rust has some nice Concept Exercises, but did not have a proper initial Concept Exercises, which is usually named `basics` in other tracks. This PR attempts to add the skeleton of such an exercise, which would allow us to enable the other Concept Exercises for Rust (by setting `.status.concept_exercises` to `true` in the `config.json` file).

I've based this exercise on similar implementations that we've used in other tracks and at https://github.com/exercism/rust/issues/1059.
The big kicker: I don't know any Rust :) This implementation will thus probably have mistakes in it, that I hope someone can fix for me. Speaking of help, knowing no Rust at all, the `introduction.md` documentation also needs to be rewritten by someone experienced in Rust. I've copied the F# introduction as a placeholder, to show you what the introduction could look like.

I was also unsure whether this exercise should teach students about `const`, which I think would be the natural way to define the expected minutes in oven value. For now, I've just made it a simple function without any parameters, but this could be changed. Whether we should depends on how complex the `const` explanation would be. Note that it is perfectly fine for the earlier concept exercises to _not_ be fully idiomatic, as that is usually not even possible without knowing some of the more advanced concepts.

I hope someone would be willing to help get this exercise merged, which would mean we'd be able to enable Concept Exercises for Rust and make Rust a great v3 track!
