### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/src/lib.rs
+++ b/exercises/practice/hello-world/src/lib.rs
@@ -1,5 +1,3 @@
-// The &'static here means the return type has a static lifetime.
-// This is a Rust feature that you don't need to worry about now.
 pub fn hello() -> &'static str {
-    "Goodbye, World!"
+    "Goodbye, Mars!"
 }

--- a/exercises/practice/hello-world/src/lib.rs
+++ b/exercises/practice/hello-world/src/lib.rs
@@ -1,3 +1,4 @@
+// &'static is a "lifetime specifier", something you'll learn more about later
 pub fn hello() -> &'static str {
     "Goodbye, Mars!"
 }


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46
