### PR TITLE
Add icons for key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -1850,26 +1850,32 @@
   ],
   "key_features": [
     {
+      "icon": "fast",
       "title": "Performance",
       "content": "Rust is blazingly fast and memory-efficient; it has no runtime or garbage collector."
     },
     {
+      "icon": "stable",
       "title": "Reliability",
       "content": "Rust’s rich type system and ownership model guarantee memory-safety and thread-safety."
     },
     {
+      "icon": "productive",
       "title": "Productivity",
       "content": "Rust has great documentation, a friendly compiler with useful error messages, and top-notch tooling."
     },
     {
+      "icon": "tooling",
       "title": "Cargo",
       "content": "Rust's package manager and build tool is best-in-class."
     },
     {
+      "icon": "cross-platform",
       "title": "Write Once, Run Anywhere",
       "content": "Rust compiles by default to a single static executable, and cross-compilation is easy."
     },
     {
+      "icon": "fun",
       "title": "❤︎",
       "content": "Stack Overflow's most-loved language every year since 2016."
     }


### PR DESCRIPTION
`configlet lint` now insists that the `icon` key is present for each key feature.

The list of available icons can be seen [here](https://github.com/exercism/docs/issues/189).

Feel free to change the icons to whatever is preferred.

---

This PR proposes:

![`fast`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/fast.svg) Performance
Rust is blazingly fast and memory-efficient; it has no runtime or garbage collector.

![`stable`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/stable.svg) Reliability
Rust’s rich type system and ownership model guarantee memory-safety and thread-safety.

![`productive`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/productive.svg) Productivity
Rust has great documentation, a friendly compiler with useful error messages, and top-notch tooling.

![`tooling`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/tooling.svg) Cargo
Rust's package manager and build tool is best-in-class.

![`cross-platform`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/cross-platform.svg) Write Once, Run Anywhere
Rust compiles by default to a single static executable, and cross-compilation is easy.

![`fun`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/fun.svg) ❤︎
Stack Overflow's most-loved language every year since 2016.