### PR TITLE
Remove concepts without documents

### DIFF
--- a/config.json
+++ b/config.json
@@ -35,7 +35,7 @@
   "exercises": {
     "concept": [
       {
-        "slug": "lucians-luscious-lasagna",        
+        "slug": "lucians-luscious-lasagna",
         "uuid": "29a2d3bd-eec8-454d-9dba-4b2d7d071925",
         "name": "Lucian's Luscious Lasagna",
         "difficulty": 1,
@@ -1453,54 +1453,14 @@
       "name": "String Slices"
     },
     {
-      "uuid": "53804676-e4f0-4faa-a8b8-68ff8314ccbe",
-      "slug": "anonymous-lifetime",
-      "name": "Anonymous lifetime"
-    },
-    {
-      "uuid": "1775c091-1edc-4a30-8582-0e014721887f",
-      "slug": "arc",
-      "name": "Arc"
-    },
-    {
-      "uuid": "17f9277e-5299-4e92-98f3-7d3534fbdd44",
-      "slug": "async",
-      "name": "Async"
-    },
-    {
       "uuid": "d29b735e-26fb-4eea-9f2d-0e738d2571ca",
       "slug": "booleans",
       "name": "Booleans"
     },
     {
-      "uuid": "289274e9-8b87-4373-9090-21e00c8b6d67",
-      "slug": "borrow-trait",
-      "name": "Borrow trait"
-    },
-    {
       "uuid": "908173dc-3e6a-4f15-be9f-f3aa4b880f24",
       "slug": "box",
       "name": "Box"
-    },
-    {
-      "uuid": "154344c0-2fc0-4607-9834-9a4e5d4eb66a",
-      "slug": "btreemap",
-      "name": "BTreeMap"
-    },
-    {
-      "uuid": "19f805e5-d3b2-4050-8b14-5efadcb94f65",
-      "slug": "casting",
-      "name": "Casting"
-    },
-    {
-      "uuid": "61922c2a-63cc-4fab-a924-5b0dbac7d452",
-      "slug": "cell-and-refcell",
-      "name": "Cell and Refcell"
-    },
-    {
-      "uuid": "7a42f420-2352-4912-a54c-fa5453190f27",
-      "slug": "channels",
-      "name": "Channels"
     },
     {
       "uuid": "5c61a070-0585-4e23-8620-46c7c73f2fe1",
@@ -1513,69 +1473,9 @@
       "name": "Collect"
     },
     {
-      "uuid": "4e5ca742-379c-49da-9f57-54a740f3e632",
-      "slug": "conditionals",
-      "name": "Conditionals"
-    },
-    {
-      "uuid": "44644a80-8b1f-4a52-a999-97a3f5f9db6b",
-      "slug": "const-and-static",
-      "name": "Const and Static"
-    },
-    {
-      "uuid": "992f5e5d-72a8-4f52-95e1-3bbe6c4f4689",
-      "slug": "count-and-sum",
-      "name": "Count and Sum"
-    },
-    {
-      "uuid": "f060e364-b6ea-4699-bb7a-e64807a8f0dd",
-      "slug": "deref-coercion",
-      "name": "Deref coercion"
-    },
-    {
-      "uuid": "9cdc0b7e-520b-4d08-854b-ca7063c2dc97",
-      "slug": "derive",
-      "name": "Derive"
-    },
-    {
-      "uuid": "053cdc50-ca0b-4267-97f7-2d5ca4436df0",
-      "slug": "designing-custom-traits",
-      "name": "Designing custom traits"
-    },
-    {
-      "uuid": "c554fa18-7aba-4e96-b4bb-fc9b547252d2",
-      "slug": "enums",
-      "name": "Enums"
-    },
-    {
-      "uuid": "56454976-5e1b-4560-bff4-51f996534a08",
-      "slug": "explicit-return",
-      "name": "Explicit return"
-    },
-    {
-      "uuid": "6ba4b428-3d56-4798-ada1-79675bd5be1d",
-      "slug": "external-crates",
-      "name": "External crates"
-    },
-    {
-      "uuid": "e54494dc-15af-4904-b554-c583f511dca3",
-      "slug": "external-traits-as-bounds",
-      "name": "External traits as bounds"
-    },
-    {
       "uuid": "3fe73200-fe19-4492-98ec-40bc17760cdd",
       "slug": "fold",
       "name": "Fold"
-    },
-    {
-      "uuid": "445f2f63-e5fb-4500-93b3-19afac753bfa",
-      "slug": "format-macro",
-      "name": "Format macro"
-    },
-    {
-      "uuid": "44d3d261-443d-4bbc-834e-5d35aca0cab8",
-      "slug": "from-into-iterator",
-      "name": "FromIterator, IntoIterator, and .collect()"
     },
     {
       "uuid": "cd77f4c9-3c07-4882-b828-ac99748415e5",
@@ -1583,214 +1483,9 @@
       "name": "Functions"
     },
     {
-      "uuid": "bd7d1ccb-feac-482d-86bd-3d611172bb3f",
-      "slug": "closures",
-      "name": "Closures"
-    },
-    {
-      "uuid": "99e5f5e4-c202-4ad2-917f-068ff56e1c03",
-      "slug": "higher-order-functions",
-      "name": "Higher order functions"
-    },
-    {
-      "uuid": "56648cbf-14ca-44e6-8848-ec1334478608",
-      "slug": "futures",
-      "name": "Futures"
-    },
-    {
-      "uuid": "34ccdfa9-2a08-43a3-9d36-21767fe11918",
-      "slug": "lifetimes",
-      "name": "Lifetimes"
-    },
-    {
-      "uuid": "fc7e0724-11de-4471-95d1-4cd76324bebe",
-      "slug": "generics",
-      "name": "Generics"
-    },
-    {
-      "uuid": "aab1a247-8c64-48fd-bf76-3384957aadd6",
-      "slug": "hashmap",
-      "name": "HashMap"
-    },
-    {
-      "uuid": "8eaa0431-2743-4ff0-a7ba-2b2ba496fb92",
-      "slug": "hashset",
-      "name": "HashSet"
-    },
-    {
-      "uuid": "dc958fc2-e1f6-4ff9-8f9c-9bde565d8ec9",
-      "slug": "if-while-let",
-      "name": "`if let` and `while let`"
-    },
-    {
-      "uuid": "f9db0ad6-b204-4e9f-a5f2-2aa407782ff9",
-      "slug": "impl-blocks",
-      "name": "Impl blocks"
-    },
-    {
-      "uuid": "1554bfb1-0a82-40ad-96f3-78ca7bb8117c",
-      "slug": "implementing-traits",
-      "name": "Implementing traits"
-    },
-    {
-      "uuid": "41e5ecf1-56cf-4f14-83a8-a6b041b133b3",
-      "slug": "iterator-usage",
-      "name": "Iterator usage"
-    },
-    {
-      "uuid": "b46be939-6e57-4686-a0e2-01dcd76fddb9",
-      "slug": "lazy-evaluation",
-      "name": "Lazy evaluation"
-    },
-    {
-      "uuid": "4486d871-5fa2-47af-892b-da910802482e",
-      "slug": "logical-operators",
-      "name": "Logical operators"
-    },
-    {
-      "uuid": "952406cb-dcb1-47df-8129-b996b32a6cc4",
-      "slug": "loops",
-      "name": "Loops"
-    },
-    {
-      "uuid": "f16a9f91-7fbd-406a-9642-5cb5f9f52590",
-      "slug": "macros-declarative",
-      "name": "Declarative Macros"
-    },
-    {
-      "uuid": "9e7b6f00-c30d-4a44-934f-e762203ebc2f",
-      "slug": "macros-procedural",
-      "name": "Procedural Macros"
-    },
-    {
-      "uuid": "b1f7f3d8-ee41-47e3-a94f-75080f5f649f",
-      "slug": "map-and-filter",
-      "name": "Map and filter"
-    },
-    {
-      "uuid": "29560443-55f8-4af4-9186-6bf11fcb066d",
-      "slug": "match-basics",
-      "name": "Match basics"
-    },
-    {
-      "uuid": "63bcae1b-11f8-4aea-8981-76c913e79ab2",
-      "slug": "match-destructuring",
-      "name": "Match destructuring"
-    },
-    {
-      "uuid": "0649f216-c720-4653-a33e-64b5513b9780",
-      "slug": "methods",
-      "name": "Methods"
-    },
-    {
-      "uuid": "c61e971c-15b0-4b80-a724-35a841b68720",
-      "slug": "move-semantics",
-      "name": "Move semantics"
-    },
-    {
-      "uuid": "38785236-be81-44ef-8625-c4054d5d3641",
-      "slug": "mutability",
-      "name": "Mutability"
-    },
-    {
-      "uuid": "fc6fe604-01b7-476c-86dc-125b441b1fb5",
-      "slug": "mutex",
-      "name": "Mutex"
-    },
-    {
-      "uuid": "ab78652d-bfc4-4741-b68c-5515a2e1f511",
-      "slug": "newtype-pattern",
-      "name": "Newtype pattern"
-    },
-    {
-      "uuid": "8fe3f7c1-15d2-434f-8cd3-16b6f410baa5",
-      "slug": "numeric-traits",
-      "name": "Numeric traits"
-    },
-    {
-      "uuid": "8e7fd01b-b4d6-4386-8259-7817374ce620",
-      "slug": "overflow-and-underflow",
-      "name": "Overflow and underflow"
-    },
-    {
-      "uuid": "7b456eec-5348-45e5-a442-bcdcc48fda61",
-      "slug": "ranges",
-      "name": "Ranges"
-    },
-    {
-      "uuid": "e06b4e87-58b2-4dd2-88cd-60f4178ebd54",
-      "slug": "rc",
-      "name": "Rc"
-    },
-    {
       "uuid": "3e01401e-1627-4423-aa8b-f9cf52c4adaa",
       "slug": "references",
       "name": "References"
-    },
-    {
-      "uuid": "5a1896c8-b479-4bc4-89e7-a74d34056bde",
-      "slug": "result",
-      "name": "Result"
-    },
-    {
-      "uuid": "5173a1e4-5909-4dd3-a348-1750c096f1de",
-      "slug": "rwlock",
-      "name": "RwLock"
-    },
-    {
-      "uuid": "4ce100e4-8ead-4d9e-b6e2-76cfd4c376f0",
-      "slug": "scopes-and-expressions",
-      "name": "Scopes and expressions"
-    },
-    {
-      "uuid": "d844d9b8-47e2-40e8-ab12-47a0a3565882",
-      "slug": "shadowing",
-      "name": "Shadowing"
-    },
-    {
-      "uuid": "7e826a22-45ed-4847-8de9-594bc57daa65",
-      "slug": "slices",
-      "name": "Slices"
-    },
-    {
-      "uuid": "ac37efdf-a1c5-4526-bd7a-fe1c4cba1656",
-      "slug": "static-lifetime",
-      "name": "Static lifetime"
-    },
-    {
-      "uuid": "07a32f06-1268-4f17-abbe-7b9c7fcc7995",
-      "slug": "std-thread",
-      "name": "std::thread"
-    },
-    {
-      "uuid": "477a5b7b-a475-4a24-9080-45779d67c9de",
-      "slug": "total-ordering",
-      "name": "Total ordering"
-    },
-    {
-      "uuid": "aadd1449-3ab8-425e-bce0-1ce00c9c9351",
-      "slug": "typedefs",
-      "name": "Typedefs"
-    },
-    {
-      "uuid": "ba077ed4-ba53-480d-8e31-92b445f7e921",
-      "slug": "unsafe",
-      "name": "Unsafe"
-    },
-    {
-      "uuid": "b7906dd5-e20b-49ac-ae69-6bad48bce6f2",
-      "slug": "use",
-      "name": "Use"
-    },
-    {
-      "uuid": "06f7ac1c-af67-461c-a9d9-05fa75e40966",
-      "slug": "variable-assignment",
-      "name": "Variable assignment"
-    },
-    {
-      "uuid": "2ce37dbc-f8d7-4bb6-aa02-4bf77813fd55",
-      "slug": "visibility",
-      "name": "Visibility"
     },
     {
       "uuid": "37e85710-3e1d-40f4-aed9-72f43e8a2fcd",
@@ -1813,34 +1508,14 @@
       "name": "Floating Point Numbers"
     },
     {
-      "uuid": "11d39059-0949-4bfe-a89c-0fd522c3baee",
-      "slug": "hashmaps",
-      "name": "Hashmaps"
-    },
-    {
       "uuid": "8e399de6-f143-45fb-bb8e-1ce1f15dcf01",
       "slug": "integers",
       "name": "Integers"
     },
     {
-      "uuid": "4cd3ad94-0a2a-4f44-a0dc-0c7402225499",
-      "slug": "intro-fn",
-      "name": "Introductory Functions"
-    },
-    {
-      "uuid": "9eb55d59-7953-46ab-a8cc-8525daddf1a9",
-      "slug": "intro-types",
-      "name": "Introductory Types"
-    },
-    {
       "uuid": "36bc26cf-dd54-4706-9abf-7a89e6a168e3",
       "slug": "option",
       "name": "Option"
-    },
-    {
-      "uuid": "8dc3c89e-afd4-4155-a79a-9699852ea21e",
-      "slug": "string-use",
-      "name": "String Use"
     },
     {
       "uuid": "febd2cf9-e058-48ef-bdc7-7583fb67e053",


### PR DESCRIPTION
The concept entries this PR removes from the config.json all did not have any documents. This causes syncing to fail, which previously did not happen because we hadn't yet made the blurb a required field (we do now). There were basically two options:

1. Remove the concept entries from the config.json that did not have any documents
2. Create empty placeholder documents for the concepts

I've opted for option nr. 1, as option nr. 2 would also mean that I'd have to set the `authors` property of the concept's `.meta/config.json` file to a non-empty array and I can't really do that.

Closes https://github.com/exercism/rust/issues/1299