### PR TITLE
role-playing-game: Add test that forces handing of integer overflow.

### DIFF
--- a/exercises/concept/role-playing-game/tests/role-playing-game.rs
+++ b/exercises/concept/role-playing-game/tests/role-playing-game.rs
@@ -85,3 +85,20 @@ fn test_cast_spell_with_no_mana_pool() {
     assert_eq!(underleveled_player.mana, clone.mana);
     assert_eq!(underleveled_player.level, clone.level);
 }
+
+#[test]
+#[ignore]
+fn test_cast_large_spell_with_no_mana_pool() {
+    const MANA_COST: u32 = 30;
+
+    let mut underleveled_player = Player {
+        health: 20,
+        mana: None,
+        level: 6,
+    };
+
+    assert_eq!(underleveled_player.cast_spell(MANA_COST), 0);
+    assert_eq!(underleveled_player.health, 0);
+    assert_eq!(underleveled_player.mana, None);
+    assert_eq!(underleveled_player.level, 6);
+}


### PR DESCRIPTION
The exemplar for this test suggests the use of `u32.saturating_sub`. However, there are no test cases that capture a use-case for it.

This patch adds in a single test that covers that case. Not sure if there was any specific reason for not adding this case in the first place. 