### PR TITLE
Update short-fibonacci.rs

### DIFF
--- a/exercises/concept/short-fibonacci/tests/short-fibonacci.rs
+++ b/exercises/concept/short-fibonacci/tests/short-fibonacci.rs
@@ -18,6 +18,8 @@ fn test_buffer() {
 fn test_fibonacci() {
     let fibb = fibonacci();
     assert_eq!(fibb.len(), 5);
+    assert_eq!(fibb[0], 1);
+    assert_eq!(fibb[1], 1);
     for window in fibb.windows(3) {
         assert_eq!(window[0] + window[1], window[2]);
     }


### PR DESCRIPTION
the test was not checking the first two element,
this incorrectly make `[0, 0, 0, 0, 0]` valid and also `[1, 2, 3, 5, 8]`.