### PR TITLE
Set CSV Builder to WIP

### DIFF
--- a/config.json
+++ b/config.json
@@ -165,7 +165,6 @@
       {
         "slug": "csv-builder",
         "name": "CSV builder",
-        "status": "wip",
         "difficulty": 1,
         "uuid": "10c9f505-9aef-479f-b689-cb7959572482",
         "concepts": [
@@ -175,7 +174,7 @@
           "string",
           "string-slices"
         ],
-        "status": "active"
+        "status": "wip"
       }
     ],
     "practice": [


### PR DESCRIPTION
Hotfix for #1303 

The exercise config has 2 instances of status attribute with conflicting values. Thus the exercise was still active but could not be unlocked (due to reasons described in the issue).

This PR removes the duplicate status key and sets the exercise to WIP.