### PR TITLE
fix: add blurb to csv-builder

### DIFF
--- a/exercises/concept/csv-builder/.meta/config.json
+++ b/exercises/concept/csv-builder/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for csv-builder exercise",
+  "blurb": "Learn about strings and string slices while working on a CSV builder",
   "authors": [
     "gilescope",
     "coriolinus",


### PR DESCRIPTION
Fixes #1185 by adding a blurb to the CSV-build concept exercise.