### PR TITLE
Add test to Magazine Cutout to reject invalid solutions

### DIFF
--- a/exercises/concept/magazine-cutout/tests/magazine-cutout.rs
+++ b/exercises/concept/magazine-cutout/tests/magazine-cutout.rs
@@ -52,3 +52,13 @@ fn test_case_sensitivity() {
         .collect::<Vec<&str>>();
     assert!(!can_construct_note(&magazine, &note));
 }
+
+#[test]
+#[ignore]
+fn test_magzine_has_more_than_words_available_than_needed() {
+    let magazine = "Enough is enough when enough is enough"
+        .split_whitespace()
+        .collect::<Vec<&str>>();
+    let note = "enough is enough".split_whitespace().collect::<Vec<&str>>();
+    assert!(can_construct_note(&magazine, &note));
+}


### PR DESCRIPTION
Reject solutions that can't construct note when magazine has more than enough.
Several are already published.