### PR TITLE
Partial Fix for configlet lint failure

### DIFF
--- a/concepts/planned
+++ b/concepts/planned
@@ -61,4 +61,5 @@ typedefs
 unsafe
 use
 variable-assignment
+vec-stack
 visibility

--- a/config.json
+++ b/config.json
@@ -54,9 +54,8 @@
           "entry-api"
         ],
         "prerequisites": [
-          "hashmaps",
+          "hashmap",
           "functions",
-          "intro-types",
           "option"
         ],
         "status": "active"
@@ -95,7 +94,7 @@
           "structs"
         ],
         "prerequisites": [
-          "string-use",
+          "string",
           "floating-point-numbers",
           "integers"
         ],
@@ -139,7 +138,7 @@
         ],
         "prerequisites": [
           "functions",
-          "numbers"
+          "integers"
         ],
         "status": "active"
       },
@@ -153,7 +152,7 @@
         ],
         "prerequisites": [
           "functions",
-          "numbers",
+          "integers",
           "option",
           "enums",
           "match-basics",
@@ -1521,6 +1520,46 @@
       "uuid": "febd2cf9-e058-48ef-bdc7-7583fb67e053",
       "slug": "structs",
       "name": "Structs"
+    },
+    {
+      "uuid": "536dcab5-b60e-4aaa-8ce7-88c86b90ca95",
+      "slug": "tuples",
+      "name": "Tuples"
+    },
+    {
+      "uuid": "6ff479bf-d1a7-4ed8-af69-0e06aea921d5",
+      "slug": "vec-macro",
+      "name": "vec! macro"
+    },
+    {
+      "uuid": "ffb6842a-631b-42f5-bfa2-cb1dc2497250",
+      "slug": "vec-stack",
+      "name": "Vector as a Stack"
+    },
+    {
+      "uuid": "e119467a-34f7-4841-9929-88d4317d904d",
+      "slug": "hashmap",
+      "name": "Hashmap"
+    },
+    {
+      "uuid": "7317fc9b-93b5-4712-aae3-e44d3b0fb451",
+      "slug": "string",
+      "name": "String"
+    },
+    {
+      "uuid": "5f133f11-050d-47e7-9b32-ba3258929eb8",
+      "slug": "match-basics",
+      "name": "Match Basics"
+    },
+    {
+      "uuid": "76f4ccd0-c5ab-456b-a874-c70eb34c57f8",
+      "slug": "mutability",
+      "name": "Mutability"
+    },
+    {
+      "uuid": "56c95d54-dacc-4a9f-b38f-7cca4fef6307",
+      "slug": "loops",
+      "name": "Loops"
     }
   ],
   "key_features": [


### PR DESCRIPTION
Partial fix for #1318 
This fixes all failures due to missing entry in concepts array.

Other than adding missing entries to concepts array, following changes were made to some exercise entries:

1. replace `hashmaps` with `hashmap`
2. replace `numbers` with `integers`
3. replace `string-use` with `string`
4. remove `intro-types`
