### PR TITLE
clock: make all expected values on the right

### DIFF
--- a/exercises/practice/clock/tests/clock.rs
+++ b/exercises/practice/clock/tests/clock.rs
@@ -282,67 +282,67 @@ fn test_compare_clocks_with_hour_overflow() {
 #[test]
 #[ignore]
 fn test_compare_clocks_with_hour_overflow_by_several_days() {
-    assert_eq!(Clock::new(3, 11), Clock::new(99, 11));
+    assert_eq!(Clock::new(99, 11), Clock::new(3, 11));
 }
 
 #[test]
 #[ignore]
 fn test_compare_clocks_with_negative_hour() {
-    assert_eq!(Clock::new(22, 40), Clock::new(-2, 40));
+    assert_eq!(Clock::new(-2, 40), Clock::new(22, 40));
 }
 
 #[test]
 #[ignore]
 fn test_compare_clocks_with_negative_hour_that_wraps() {
-    assert_eq!(Clock::new(17, 3), Clock::new(-31, 3));
+    assert_eq!(Clock::new(-31, 3), Clock::new(17, 3));
 }
 
 #[test]
 #[ignore]
 fn test_compare_clocks_with_negative_hour_that_wraps_multiple_times() {
-    assert_eq!(Clock::new(13, 49), Clock::new(-83, 49));
+    assert_eq!(Clock::new(-83, 49), Clock::new(13, 49));
 }
 
 #[test]
 #[ignore]
 fn test_compare_clocks_with_minutes_overflow() {
-    assert_eq!(Clock::new(0, 1), Clock::new(0, 1441));
+    assert_eq!(Clock::new(0, 1441), Clock::new(0, 1));
 }
 
 #[test]
 #[ignore]
 fn test_compare_clocks_with_minutes_overflow_by_several_days() {
-    assert_eq!(Clock::new(2, 2), Clock::new(2, 4322));
+    assert_eq!(Clock::new(2, 4322), Clock::new(2, 2));
 }
 
 #[test]
 #[ignore]
 fn test_compare_clocks_with_negative_minute() {
-    assert_eq!(Clock::new(2, 40), Clock::new(3, -20))
+    assert_eq!(Clock::new(3, -20), Clock::new(2, 40))
 }
 
 #[test]
 #[ignore]
 fn test_compare_clocks_with_negative_minute_that_wraps() {
-    assert_eq!(Clock::new(4, 10), Clock::new(5, -1490))
+    assert_eq!(Clock::new(5, -1490), Clock::new(4, 10))
 }
 
 #[test]
 #[ignore]
 fn test_compare_clocks_with_negative_minute_that_wraps_multiple() {
-    assert_eq!(Clock::new(6, 15), Clock::new(6, -4305))
+    assert_eq!(Clock::new(6, -4305), Clock::new(6, 15))
 }
 
 #[test]
 #[ignore]
 fn test_compare_clocks_with_negative_hours_and_minutes() {
-    assert_eq!(Clock::new(7, 32), Clock::new(-12, -268))
+    assert_eq!(Clock::new(-12, -268), Clock::new(7, 32))
 }
 
 #[test]
 #[ignore]
 fn test_compare_clocks_with_negative_hours_and_minutes_that_wrap() {
-    assert_eq!(Clock::new(18, 7), Clock::new(-54, -11_513))
+    assert_eq!(Clock::new(-54, -11_513), Clock::new(18, 7))
 }
 
 #[test]


### PR DESCRIPTION
Thanks for all the hard work, I really enjoy using excercism v3 in the browser. This PR stems from a little friction I encountered, feel free to close it as you see fit.

While trying to solve this exercise, I got confused when I ran the tests and sometimes the expected value was on the left side of the comparison and sometimes on the right.
In some cases it is obvious `assertion failed: '(left == right)' left: "12:03", right: "-10:03"`, but others were not `assertion failed: '(left == right)' left: "12:03", right: "11:03"` .. which required me to go back and forth between the test implementation, output of tests and my implementation.

My proposal is to keep all expected values on one side, since the tests started with them being on the right hand side, I sticked with that.