### PR TITLE
Relax precision for assembly-line tests

### DIFF
--- a/exercises/concept/assembly-line/tests/assembly-line.rs
+++ b/exercises/concept/assembly-line/tests/assembly-line.rs
@@ -1,6 +1,6 @@
 fn process_rate_per_hour(speed: u8, expected_rate: f64) {
     let actual_rate = assembly_line::production_rate_per_hour(speed);
-    let actual_rate = (actual_rate * 100.0).floor()/100.0;
+    let actual_rate = (actual_rate * 100.0).round()/100.0;
     assert!((actual_rate - expected_rate).abs() < f64::EPSILON);
 }
 

--- a/exercises/concept/assembly-line/tests/assembly-line.rs
+++ b/exercises/concept/assembly-line/tests/assembly-line.rs
@@ -1,6 +1,6 @@
 fn process_rate_per_hour(speed: u8, expected_rate: f64) {
     let actual_rate = assembly_line::production_rate_per_hour(speed);
-    let actual_rate = (actual_rate * 100.0).round()/100.0;
+    let actual_rate = (actual_rate * 100.0).round() / 100.0;
     assert!((actual_rate - expected_rate).abs() < f64::EPSILON);
 }
 

--- a/exercises/concept/assembly-line/tests/assembly-line.rs
+++ b/exercises/concept/assembly-line/tests/assembly-line.rs
@@ -1,5 +1,7 @@
 fn process_rate_per_hour(speed: u8, expected_rate: f64) {
-    assert!((assembly_line::production_rate_per_hour(speed) - expected_rate).abs() < f64::EPSILON);
+    let actual_rate = assembly_line::production_rate_per_hour(speed);
+    let actual_rate = (actual_rate * 100.0).floor()/100.0;
+    assert!((actual_rate - expected_rate).abs() < f64::EPSILON);
 }
 
 fn process_rate_per_minute(speed: u8, expected_rate: u32) {


### PR DESCRIPTION
Fixes #1320 
The test helper rounds the actual value down to the nearest hundredth of a unit. 