### PR TITLE
Add a test to magazine-cutout

### DIFF
--- a/exercises/concept/magazine-cutout/tests/magazine-cutout.rs
+++ b/exercises/concept/magazine-cutout/tests/magazine-cutout.rs
@@ -62,3 +62,15 @@ fn test_magzine_has_more_than_words_available_than_needed() {
     let note = "enough is enough".split_whitespace().collect::<Vec<&str>>();
     assert!(can_construct_note(&magazine, &note));
 }
+
+#[test]
+#[ignore]
+fn test_magazine_has_one_good_word_many_times_but_still_cant_construct() {
+    let magazine = "A A A"
+        .split_whitespace()
+        .collect::<Vec<&str>>();
+    let note = "A nice day"
+        .split_whitespace()
+        .collect::<Vec<&str>>();
+    assert!(!can_construct_note(&magazine, &note));
+}

--- a/exercises/concept/magazine-cutout/tests/magazine-cutout.rs
+++ b/exercises/concept/magazine-cutout/tests/magazine-cutout.rs
@@ -66,11 +66,7 @@ fn test_magzine_has_more_than_words_available_than_needed() {
 #[test]
 #[ignore]
 fn test_magazine_has_one_good_word_many_times_but_still_cant_construct() {
-    let magazine = "A A A"
-        .split_whitespace()
-        .collect::<Vec<&str>>();
-    let note = "A nice day"
-        .split_whitespace()
-        .collect::<Vec<&str>>();
+    let magazine = "A A A".split_whitespace().collect::<Vec<&str>>();
+    let note = "A nice day".split_whitespace().collect::<Vec<&str>>();
     assert!(!can_construct_note(&magazine, &note));
 }


### PR DESCRIPTION
The addition of this test (in PR) makes _those_ (see below) wrong solutions fail, when they currently pass but shouldn't.

```rs
pub fn can_construct_note(magazine: &[&str], note: &[&str]) -> bool {
    magazine.iter().fold(0, |acc, &word| acc + note.contains(&word) as usize) >= note.len()
}
```