### PR TITLE
Anagram-exercise: Add missing word to comment in test

### DIFF
--- a/exercises/practice/anagram/tests/anagram.rs
+++ b/exercises/practice/anagram/tests/anagram.rs
@@ -114,8 +114,8 @@ fn test_unicode_anagrams() {
 #[test]
 #[ignore]
 fn test_misleading_unicode_anagrams() {
-    // Despite what a human might think these words different letters, the input uses Greek A and B
-    // while the list of potential anagrams uses Latin A and B.
+    // Despite what a human might think these words contain different letters, the input uses Greek
+    // A and B while the list of potential anagrams uses Latin A and B.
     let word = "ΑΒΓ";
 
     let inputs = ["ABΓ"];


### PR DESCRIPTION
The part "these words different letters" of a comment within a test case
seems to miss a word, add the word "contain".

Signed-off-by: Sebastian Fricke <sebastian.fricke@posteo.net>