### PR TITLE
remove concepts added by #1322

### DIFF
--- a/config.json
+++ b/config.json
@@ -1520,46 +1520,6 @@
       "uuid": "febd2cf9-e058-48ef-bdc7-7583fb67e053",
       "slug": "structs",
       "name": "Structs"
-    },
-    {
-      "uuid": "536dcab5-b60e-4aaa-8ce7-88c86b90ca95",
-      "slug": "tuples",
-      "name": "Tuples"
-    },
-    {
-      "uuid": "6ff479bf-d1a7-4ed8-af69-0e06aea921d5",
-      "slug": "vec-macro",
-      "name": "vec! macro"
-    },
-    {
-      "uuid": "ffb6842a-631b-42f5-bfa2-cb1dc2497250",
-      "slug": "vec-stack",
-      "name": "Vector as a Stack"
-    },
-    {
-      "uuid": "e119467a-34f7-4841-9929-88d4317d904d",
-      "slug": "hashmap",
-      "name": "Hashmap"
-    },
-    {
-      "uuid": "7317fc9b-93b5-4712-aae3-e44d3b0fb451",
-      "slug": "string",
-      "name": "String"
-    },
-    {
-      "uuid": "5f133f11-050d-47e7-9b32-ba3258929eb8",
-      "slug": "match-basics",
-      "name": "Match Basics"
-    },
-    {
-      "uuid": "76f4ccd0-c5ab-456b-a874-c70eb34c57f8",
-      "slug": "mutability",
-      "name": "Mutability"
-    },
-    {
-      "uuid": "56c95d54-dacc-4a9f-b38f-7cca4fef6307",
-      "slug": "loops",
-      "name": "Loops"
     }
   ],
   "key_features": [


### PR DESCRIPTION
This is a temporary reversion. All of the concepts removed here should
be re-added in the future (with the same UUIDs) when suitable documentation is produced.
However, the intent is to fix the configlet lint errors and sync
failures so that the track is once again updateable.