### PR TITLE
Update Rust -> Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check out our [contributor documentation](docs/CONTRIBUTING.md).
 
 ## Exercise Tests
 
-At the most basic level, Exercism is all about the tests. You can read more about how we think about test suites in [the Exercism documentation](https://github.com/exercism/docs/blob/main/language-tracks/exercises/anatomy/test-suites.md).
+At the most basic level, Exercism is all about the tests. You can read more about how we think about test suites in [the Exercism documentation](https://github.com/exercism/legacy-docs/blob/main/language-tracks/exercises/anatomy/test-suites.md).
 
 Test files should use the following format:
 
@@ -38,7 +38,7 @@ If you plan to make significant or breaking changes, please open an issue so we 
 
 ## Submitting a Pull Request
 
-Pull requests should be focused on a single exercise, issue, or conceptually cohesive change. Please refer to Exercism's [pull request guidelines](https://github.com/exercism/docs/blob/main/contributing/pull-request-guidelines.md).
+Pull requests should be focused on a single exercise, issue, or conceptually cohesive change. Please refer to Exercism's [pull request guidelines](https://github.com/exercism/legacy-docs/blob/main/contributing/pull-request-guidelines.md).
 
 Please follow the coding standards for Rust.  [rustfmt](https://github.com/nrc/rustfmt) may help with this
 and can be installed with `cargo install rustfmt`.
@@ -60,13 +60,13 @@ Please note that the README of every exercise is formed using several templates,
 
 - The `.meta/hints.md` file in the exercise directory on this repository
 
-- The [Rust-specific instructions](https://github.com/exercism/rust/blob/main/config/exercise-readme-insert.md)
+- The [Rust-specific instructions](https://github.com/exercism/rust/blob/main/config/exercise_readme.go.tmpl)
 
 If you are modifying the section of the README that belongs to the template not from this repository, please consider [opening a PR](https://github.com/exercism/problem-specifications/pulls) on the `problem-specifications` repository first.
 
 ## Contributing a New Exercise
 
-Please see the documentation about [adding new exercises](https://github.com/exercism/docs/blob/main/you-can-help/make-up-new-exercises.md).
+Please see the documentation about [adding new exercises](https://github.com/exercism/legacy-docs/blob/main/you-can-help/make-up-new-exercises.md).
 
 Note that:
 
@@ -74,7 +74,7 @@ Note that:
 
 - Each exercise must stand on its own. Do not reference files outside the exercise directory. They will not be included when the user fetches the exercise.
 
-- Exercises must conform to the Exercism-wide standards described in [the documentation](https://github.com/exercism/docs/tree/main/language-tracks/exercises).
+- Exercises must conform to the Exercism-wide standards described in [the documentation](https://github.com/exercism/legacy-docs/tree/main/language-tracks/exercises).
 
 - Each exercise should have:
 
@@ -100,8 +100,8 @@ Note that:
 
 - If the test suite is appreciably sped up by running in release mode, and there is reason to be confident that the example implementation does not contain any overflow errors, consider adding a file `.meta/test-in-release-mode`. This should contain brief comments explaining the situation.
 
-- If your exercise implements macro-based testing (see [#392](https://github.com/exercism/rust/issues/392#issuecomment-343865993) and [`perfect-numbers.rs`](https://github.com/exercism/rust/blob/main/exercises/perfect-numbers/tests/perfect-numbers.rs)), you will likely run afoul of a CI check which counts the `#[ignore]` lines and compares the result to the number of `#[test]` lines. To fix this, add a file `.meta/ignore-count-ignores` to disable that check for your exercise.
+- If your exercise implements macro-based testing (see [#392](https://github.com/exercism/rust/issues/392#issuecomment-343865993) and [`perfect-numbers.rs`](https://github.com/exercism/rust/blob/main/exercises/practice/perfect-numbers/tests/perfect-numbers.rs)), you will likely run afoul of a CI check which counts the `#[ignore]` lines and compares the result to the number of `#[test]` lines. To fix this, add a file `.meta/ignore-count-ignores` to disable that check for your exercise.
 
-- `README.md` may be [regenerated](https://github.com/exercism/docs/blob/main/maintaining-a-track/regenerating-exercise-readmes.md) from Exercism data. The generator will use the `description.md` from the exercise directory in the [problem-specifications repository](https://github.com/exercism/problem-specifications/tree/main/exercises), then any hints in `.meta/hints.md`, then the [Rust-specific instructions](https://github.com/exercism/rust/blob/main/config/exercise-readme-insert.md). The `## Source` section comes from the `metadata.yml` in the same directory.  Convention is that the description of the source remains text and the link is both name and hyperlink of the markdown link.
+- `README.md` may be [regenerated](https://github.com/exercism/legacy-docs/blob/main/maintaining-a-track/regenerating-exercise-readmes.md) from Exercism data. The generator will use the `description.md` from the exercise directory in the [problem-specifications repository](https://github.com/exercism/problem-specifications/tree/main/exercises), then any hints in `.meta/hints.md`, then the [Rust-specific instructions](https://github.com/exercism/rust/blob/main/config/exercise_readme.go.tmpl). The `## Source` section comes from the `metadata.yml` in the same directory.  Convention is that the description of the source remains text and the link is both name and hyperlink of the markdown link.
 
 - Be sure to add the exercise to an appropriate place in the `config.json` file.  The position in the file determines the order exercises are sent.   Generate a unique UUID for the exercise.  Current difficulty levels in use are 1, 4, 7 and 10.


### PR DESCRIPTION
Updated links. Some are updated to links in the legacy docs. These might no longer be relevant, so need to replaced when relevant docs are rewritten. Rust specific instructions go to a tpl file, a normal file should be made, normal MD.