### PR TITLE
Fix configlet errors

### DIFF
--- a/config.json
+++ b/config.json
@@ -54,7 +54,6 @@
           "entry-api"
         ],
         "prerequisites": [
-          "hashmap",
           "functions",
           "option"
         ],
@@ -96,7 +95,6 @@
           "structs"
         ],
         "prerequisites": [
-          "strings",
           "floating-point-numbers",
           "integers"
         ],
@@ -156,10 +154,7 @@
           "functions",
           "integers",
           "option",
-          "enums",
-          "match-basics",
-          "loops",
-          "mutability"
+          "enums"
         ],
         "status": "active"
       },
@@ -1452,6 +1447,11 @@
       "uuid": "f7be1969-380e-4348-ac79-9b2834a526fd",
       "slug": "string-slices",
       "name": "String Slices"
+    },
+    {
+      "uuid": "1d635be5-fcfa-4a2d-b78d-60e8d1895e19",
+      "slug": "string-vs-str",
+      "name": "String vs str"
     },
     {
       "uuid": "d29b735e-26fb-4eea-9f2d-0e738d2571ca",


### PR DESCRIPTION
As per https://github.com/exercism/rust/issues/1357 and the failing configlet, the Rust track is currently in a broken state. We have exercises that are not unlockable appearing, which is causing repeated confusion and frustration for students.

This PR removes the missing prerequisites, making the track pass CI again. 

I have also added [an issue](https://github.com/exercism/rust/issues/1379) to track the changes here, which can then be readded on when extract Concept Exercises are added.

---

Closes https://github.com/exercism/rust/issues/1357