### PR TITLE
gigasecond: Replace chrono dependency with time

### DIFF
--- a/exercises/practice/gigasecond/.meta/example.rs
+++ b/exercises/practice/gigasecond/.meta/example.rs
@@ -1,6 +1,5 @@
-extern crate chrono;
-use chrono::{DateTime, Duration, Utc};
+use time::{Duration, PrimitiveDateTime as DateTime};
 
-pub fn after(start: DateTime<Utc>) -> DateTime<Utc> {
+pub fn after(start: DateTime) -> DateTime {
     start + Duration::seconds(1_000_000_000)
 }

--- a/exercises/practice/gigasecond/Cargo.toml
+++ b/exercises/practice/gigasecond/Cargo.toml
@@ -4,4 +4,4 @@ name = "gigasecond"
 version = "2.0.0"
 
 [dependencies]
-chrono = "0.4"
+time = "0.3"

--- a/exercises/practice/gigasecond/src/lib.rs
+++ b/exercises/practice/gigasecond/src/lib.rs
@@ -1,6 +1,6 @@
-use chrono::{DateTime, Utc};
+use time::PrimitiveDateTime as DateTime;
 
-// Returns a Utc DateTime one billion seconds after start.
-pub fn after(start: DateTime<Utc>) -> DateTime<Utc> {
+// Returns a DateTime one billion seconds after start.
+pub fn after(start: DateTime) -> DateTime {
     unimplemented!("What time is a gigasecond later than {}", start);
 }

--- a/exercises/practice/gigasecond/tests/gigasecond.rs
+++ b/exercises/practice/gigasecond/tests/gigasecond.rs
@@ -1,55 +1,52 @@
-use chrono::{TimeZone, Utc};
+use time::PrimitiveDateTime as DateTime;
+
+/// Create a datetime from the given numeric point in time.
+///
+/// Panics if any field is invalid.
+fn dt(year: i32, month: u8, day: u8, hour: u8, minute: u8, second: u8) -> DateTime {
+    use time::{Date, Time};
+
+    DateTime::new(
+        Date::from_calendar_date(year, month.try_into().unwrap(), day).unwrap(),
+        Time::from_hms(hour, minute, second).unwrap(),
+    )
+}
 
 #[test]
 fn test_date() {
-    let start_date = Utc.ymd(2011, 4, 25).and_hms(0, 0, 0);
+    let start_date = dt(2011, 4, 25, 0, 0, 0);
 
-    assert_eq!(
-        gigasecond::after(start_date),
-        Utc.ymd(2043, 1, 1).and_hms(1, 46, 40)
-    );
+    assert_eq!(gigasecond::after(start_date), dt(2043, 1, 1, 1, 46, 40));
 }
 
 #[test]
 #[ignore]
 fn test_another_date() {
-    let start_date = Utc.ymd(1977, 6, 13).and_hms(0, 0, 0);
+    let start_date = dt(1977, 6, 13, 0, 0, 0);
 
-    assert_eq!(
-        gigasecond::after(start_date),
-        Utc.ymd(2009, 2, 19).and_hms(1, 46, 40)
-    );
+    assert_eq!(gigasecond::after(start_date), dt(2009, 2, 19, 1, 46, 40));
 }
 
 #[test]
 #[ignore]
 fn test_third_date() {
-    let start_date = Utc.ymd(1959, 7, 19).and_hms(0, 0, 0);
+    let start_date = dt(1959, 7, 19, 0, 0, 0);
 
-    assert_eq!(
-        gigasecond::after(start_date),
-        Utc.ymd(1991, 3, 27).and_hms(1, 46, 40)
-    );
+    assert_eq!(gigasecond::after(start_date), dt(1991, 3, 27, 1, 46, 40));
 }
 
 #[test]
 #[ignore]
 fn test_datetime() {
-    let start_date = Utc.ymd(2015, 1, 24).and_hms(22, 0, 0);
+    let start_date = dt(2015, 1, 24, 22, 0, 0);
 
-    assert_eq!(
-        gigasecond::after(start_date),
-        Utc.ymd(2046, 10, 2).and_hms(23, 46, 40)
-    );
+    assert_eq!(gigasecond::after(start_date), dt(2046, 10, 2, 23, 46, 40));
 }
 
 #[test]
 #[ignore]
 fn test_another_datetime() {
-    let start_date = Utc.ymd(2015, 1, 24).and_hms(23, 59, 59);
+    let start_date = dt(2015, 1, 24, 23, 59, 59);
 
-    assert_eq!(
-        gigasecond::after(start_date),
-        Utc.ymd(2046, 10, 3).and_hms(1, 46, 39)
-    );
+    assert_eq!(gigasecond::after(start_date), dt(2046, 10, 3, 1, 46, 39));
 }


### PR DESCRIPTION
Rationale: see https://passcod.name/technical/no-time-for-chrono.html

It is good for exercism to suggest crates which are reasonably current.