### PR TITLE
grains: adds instructions for the panic message

### DIFF
--- a/exercises/practice/grains/.docs/instructions.md
+++ b/exercises/practice/grains/.docs/instructions.md
@@ -12,8 +12,9 @@ of grains doubling on each successive square.
 There are 64 squares on a chessboard (where square 1 has one grain, square 2 has two grains, and so on).
 
 Write code that shows:
-- how many grains were on a given square, and
-- the total number of grains on the chessboard
+- how many grains were on a given square,
+- the total number of grains on the chessboard, and
+- panics with a message of "Square must be between 1 and 64" if the value is not valid
 
 ## For bonus points
 


### PR DESCRIPTION
The original instructions for this exercise omit the panic message that is required for two of the tests to pass. 