### PR TITLE
Relax the precision for assembly-line tests further

### DIFF
--- a/exercises/concept/assembly-line/tests/assembly-line.rs
+++ b/exercises/concept/assembly-line/tests/assembly-line.rs
@@ -1,7 +1,7 @@
 fn process_rate_per_hour(speed: u8, expected_rate: f64) {
     let actual_rate = assembly_line::production_rate_per_hour(speed);
     let actual_rate = (actual_rate * 100.0).round() / 100.0;
-    assert!((actual_rate - expected_rate).abs() < f64::EPSILON);
+    assert!((actual_rate - expected_rate).abs() < 0.00001);
 }
 
 fn process_rate_per_minute(speed: u8, expected_rate: u32) {


### PR DESCRIPTION
I was surprised when I saw that the solution which was implemented like this:

```rust
pub fn production_rate_per_hour(speed: u8) -> f64 {
    if speed <= 4 {
        return 221.0 * speed as f64;
    }
    if speed <= 8 {
        return 0.9 * 221.0 * speed as f64;
    }
    return 0.77 * 221.0 * speed as f64;
}
```

... was incorrect because the results yielded:

```
9: 1531.5300000000002
10: 1701.7000000000003
```
The bug is subtle(missing paratheses or moving the fraction to the end) and the tests should take into account the expertise level for an average student trying to finish this exercise. I had to print the numbers out to see the mistake.

An alternative could be to add a hint about the order of the factors being important in some cases or rounding.

Also see https://github.com/exercism/rust/pull/1328 - the solution was suggested there as well, but dismissed with "they should just round" which is not mentioned in anywhere in the exercise.