### PR TITLE
Improve instructions for RPN Calculator

### DIFF
--- a/exercises/concept/rpn-calculator/.docs/instructions.md
+++ b/exercises/concept/rpn-calculator/.docs/instructions.md
@@ -87,6 +87,9 @@ we can say the expression evaluated to 6.
 ## 3. Goal
 
 Your goal is to write a calculator to evaluate a list of inputs ordered by Reverse Polish notation.
+
+If there is more than one element in the stack at the end, return `None`.
+
 You are given the following enum and stubbed function as a starting point.
 
 ```rust
@@ -98,7 +101,7 @@ pub enum CalculatorInput {
     Divide,
     Value(i32),
 }
-  
+
 pub fn evaluate(inputs: &[CalculatorInput]) -> Option<i32> {
     unimplemented!(
 		"Given the inputs: {:?}, evaluate them as though they were a Reverse Polish notation expression",

--- a/exercises/concept/rpn-calculator/.docs/instructions.md
+++ b/exercises/concept/rpn-calculator/.docs/instructions.md
@@ -86,9 +86,11 @@ we can say the expression evaluated to 6.
 
 ## 3. Goal
 
-Your goal is to write a calculator to evaluate a list of inputs ordered by Reverse Polish notation.
+Your goal is to write a calculator to evaluate a list of inputs ordered by Reverse Polish notation and return the final element on the stack.
 
-If there is more than one element in the stack at the end, return `None`.
+If there is not exactly one element in the stack at the end, return `None`.
+
+If there is an operator with too few operands (such as the input `2 +`), return `None`.
 
 You are given the following enum and stubbed function as a starting point.
 


### PR DESCRIPTION
This PR improves the instructions for the RPN exercise, by specifying that your solution should return `None` if there is more than one item left in the stack. This was not mentioned elsewhere in the instructions, but [is included in unit tests](https://github.com/exercism/rust/blob/0c24b8ec71669467ce3a2c59d61b9c2519fbd46f/exercises/concept/rpn-calculator/tests/rpn-calculator.rs#L70-L75).

I could include an example which demonstrates this, but I feel as though this should be pretty clear after this change — and makes the instructions more concise by omitting a new example.