### PR TITLE
queen-attack: Add test case to catch an incomplete diagonal check

### DIFF
--- a/exercises/practice/queen-attack/tests/queen-attack.rs
+++ b/exercises/practice/queen-attack/tests/queen-attack.rs
@@ -85,3 +85,12 @@ fn queens_on_the_same_diagonal_can_attack_four() {
 
     assert!(white_queen.can_attack(&black_queen));
 }
+
+#[test]
+#[ignore]
+fn queens_that_can_not_attack_two() {
+    let white_queen = Queen::new(ChessPosition::new(4, 1).unwrap());
+    let black_queen = Queen::new(ChessPosition::new(2, 5).unwrap());
+
+    assert!(!white_queen.can_attack(&black_queen));
+}

--- a/exercises/practice/queen-attack/tests/queen-attack.rs
+++ b/exercises/practice/queen-attack/tests/queen-attack.rs
@@ -88,7 +88,7 @@ fn queens_on_the_same_diagonal_can_attack_four() {
 
 #[test]
 #[ignore]
-fn queens_that_can_not_attack_two() {
+fn queens_that_cannot_attack_with_equal_difference() {
     let white_queen = Queen::new(ChessPosition::new(4, 1).unwrap());
     let black_queen = Queen::new(ChessPosition::new(2, 5).unwrap());
 


### PR DESCRIPTION
This extra test catches an issue that existing tests do not:

Imagine the following code to check if two positions are on the same `\` diagonal, where `rank` and `file` are `u8` fields:

```rust
impl ChessPosition {
    fn incomplete_is_same_diagonal_1(&self, other: &ChessPosition) -> bool {
        self.rank.max(self.file) - self.file.min(self.rank)
            == other.rank.max(other.file) - other.file.min(other.rank)
    }
}
```

This might return `true` even though the positions are **not** on the same diagonal (neither `\` nor `/`), and that's what my new test case checks for.

History: I ended up with the above myself when solving the exercise, and noticed it was incorrect. But together with the check for `/` diagonals (`self.rank + self.file == other.rank + other.file`) it passed all the existing tests.

My initial version of the `\` diagonal-check was:
```rust
self.rank - self.file == other.rank - other.file
```

This obviously panics with an 'attempt to subtract with overflow' when `file` > `rank`, and to rectify this the incomplete diagonal check was born. I figured other people's code might evolve similarly, so this extra test case might help.

This is my first pull request on Github ever, so I appreciate constructive feedback on how to improve.