### PR TITLE
Revert "Disable analyzer"

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "concept_exercises": true,
     "test_runner": true,
     "representer": true,
-    "analyzer": false
+    "analyzer": true
   },
   "blurb": "Rust is a compiled programming language designed for speed, concurrency, and memory safety. Rust programs can run almost anywhere, from low-power embedded devices to web servers.",
   "version": 3,


### PR DESCRIPTION
With https://github.com/exercism/rust-analyzer/pull/39 being merged, we can re-enable the analyzer again. Thanks @petertseng!

Reverts exercism/rust#1399