### PR TITLE
fix test_reviving_dead_level9_player

### DIFF
--- a/exercises/concept/role-playing-game/tests/role-playing-game.rs
+++ b/exercises/concept/role-playing-game/tests/role-playing-game.rs
@@ -20,7 +20,7 @@ fn test_reviving_dead_player() {
 fn test_reviving_dead_level9_player() {
     let dead_player = Player {
         health: 0,
-        mana: Some(0),
+        mana: None,
         level: 9,
     };
     let revived_player = dead_player


### PR DESCRIPTION
the `dead_player` in `test_reviving_dead_level9_player` is an invalid state. A level 9 character should have `Player{mana: None,..}` not `Player{mana:Some(0),..}`.

The inspiration for this PR is that this clean solution without a `mana` field in the first arm of the match statement: 
```
impl Player {
    pub fn revive(&self) -> Option<Player> {
        match &self {
            &Self{health:0, level: 0..10, ..} => Some(Self{health: 100, ..*self}),
            &Self{health:0, level: 10.., ..} => Some(Self{health: 100, mana: Some(100), ..*self}),
            _ => None
        }
    }
}
```
must be modified to this solution with a `mana` field:
```
impl Player {
    pub fn revive(&self) -> Option<Player> {
        match &self {
            &Self{health:0, level: 0..10, ..} => Some(Self{health: 100, mana: None, ..*self}),
            &Self{health:0, level: 10.., ..} => Some(Self{health: 100, mana: Some(100), ..*self}),
            _ => None
        }
    }
}
```

If the `Player` in `test_reviving_dead_level9_player` was valid and internally consistent, the test would pass instead of fail