### PR TITLE
Rust, RPN Calculator, Added test for missing operands

### DIFF
--- a/exercises/concept/rpn-calculator/tests/rpn-calculator.rs
+++ b/exercises/concept/rpn-calculator/tests/rpn-calculator.rs
@@ -76,7 +76,14 @@ fn test_too_many_operands_returns_none() {
 
 #[test]
 #[ignore]
-fn test_missing_operands_returns_none() {
+fn test_zero_operands_returns_none() {
+    let input = calculator_input("+");
+    assert_eq!(evaluate(&input), None);
+}
+
+#[test]
+#[ignore]
+fn test_intermediate_error_returns_none() {
     let input = calculator_input("+ 2 2 *");
     assert_eq!(evaluate(&input), None);
 }

--- a/exercises/concept/rpn-calculator/tests/rpn-calculator.rs
+++ b/exercises/concept/rpn-calculator/tests/rpn-calculator.rs
@@ -73,3 +73,10 @@ fn test_too_many_operands_returns_none() {
     let input = calculator_input("2 2");
     assert_eq!(evaluate(&input), None);
 }
+
+#[test]
+#[ignore]
+fn test_missing_operands_returns_none() {
+    let input = calculator_input("+ 2 2 *");
+    assert_eq!(evaluate(&input), None);
+}


### PR DESCRIPTION
Now, RPN input like "+ 2 2 *" is not tested.
There are solutions (using fold) that produce "4" for the above example, while it should be "None" due to incorrect input.
Adding one more test case will catch this kind of errors.