### PR TITLE
Diffie-hellmann: Add test that private key is a prime

### DIFF
--- a/exercises/practice/diffie-hellman/tests/diffie-hellman.rs
+++ b/exercises/practice/diffie-hellman/tests/diffie-hellman.rs
@@ -13,6 +13,15 @@ fn test_private_key_in_range_key() {
 }
 
 #[test]
+fn test_private_key_is_prime() {
+    let primes: Vec<u64> = vec![2, 3, 5, 7, 11, 13];
+    for _ in 0..10 {
+        let private_key: u64 = private_key(15);
+        assert!(primes.contains(&private_key));
+    }
+}
+
+#[test]
 #[ignore]
 fn test_public_key_correct() {
     let p: u64 = 23;


### PR DESCRIPTION
Adds a test that checks that the private key is actually a prime for a simple example. 

All other tests pass if you simply return any random number between 2 and p from the prviate key function. Eg the following code passes:
```
pub fn private_key(p: u64) -> u64 {
    rand::thread_rng().gen_range(3..p)
}

```