### PR TITLE
Update Resister Colour Order

### DIFF
--- a/exercises/concept/resistor-color/src/lib.rs
+++ b/exercises/concept/resistor-color/src/lib.rs
@@ -1,15 +1,15 @@
 #[derive(Debug, PartialEq)]
 pub enum ResistorColor {
     Black,
-    Blue,
     Brown,
-    Green,
-    Grey,
-    Orange,
     Red,
-    Violet,
-    White,
+    Orange,
     Yellow,
+    Green,
+    Blue,
+    Violet,
+    Grey,
+    White,
 }
 
 pub fn color_to_value(_color: ResistorColor) -> usize {


### PR DESCRIPTION
Passing the Final Test for the colors() function requires you to reorganize the enum.

Either, update the test to not care about the order, only that all the color strings are there, or update the order of the enum so people don't have to update it manually themselves while working on this problem.