### PR TITLE
xorcism: bump hexlit version

### DIFF
--- a/exercises/practice/xorcism/Cargo.toml
+++ b/exercises/practice/xorcism/Cargo.toml
@@ -10,6 +10,6 @@ edition = "2021"
 io = []
 
 [dev-dependencies]
-hexlit = "0.3.0"
+hexlit = "0.5.0"
 rstest = "0.6.4"
 rstest_reuse = "0.1.0"


### PR DESCRIPTION
Closes https://github.com/exercism/rust/issues/1422

The error message complains that the only supported hexlit package (offline) is v0.5.3. Per semver, as a version under 1.0, that's not compatible with v0.3.0. 

This should fix the issue, but I'm not sure how to test the PR against the site before merging. @ErikSchierboom ?