### PR TITLE
Remove IRC channel that no longer exists

### DIFF
--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -3,7 +3,6 @@
 * [The Rust Programming Language](https://doc.rust-lang.org/book/) is a great resource for getting started with Rust as well as diving deeper into specific features of Rust.
 * [Rust by Example](https://doc.rust-lang.org/stable/rust-by-example/) shows you examples of the most common things you will be writing in Rust.
 * The [Rust API Documentation](http://doc.rust-lang.org/std/) can be used to discover new methods and how they work.
-* [#rust](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) on irc.mozilla.org is the official Rust IRC channel.  Other channels include (but not limited to): [#rust-gamedev](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev), [#rust-osdev](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev), and [#rust-webdev](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-webdev).
 * [Stack Overflow](http://stackoverflow.com/questions/tagged/rust) can be used to search for your problem and see if it has been answered already.  You can also ask and answer questions.
 * The [Rust User Forum](http://users.rust-lang.org) is for general discussion about Rust.
 * [/r/rust](http://www.reddit.com/r/rust/) is the official Rust subreddit.


### PR DESCRIPTION
As of March 2020, irc.mozilla.org has been [permanently decommissioned](https://wiki.mozilla.org/IRC).