### PR TITLE
Remove IRC channel that no longer exists

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -4,5 +4,4 @@
 * [Rust by Example](https://doc.rust-lang.org/stable/rust-by-example/) shows you examples of the most common things you will be writing in Rust.
 * [Into_rust()](http://intorust.com/) "Screencasts for learning Rust."
 * [Rustlings](https://github.com/carols10cents/rustlings) "Small exercises to get you used to reading and writing Rust code."
-* [#rust-beginners](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners) "an IRC channel that loves answering questions at any depth"
 * The [Rust User Forum](http://users.rust-lang.org) answers questions of all levels


### PR DESCRIPTION
As of March 2020, irc.mozilla.org has been [permanently decommissioned](https://wiki.mozilla.org/IRC).