### PR TITLE
address clippy lints found in new beta clippy 1.59

### DIFF
--- a/exercises/practice/decimal/.meta/example.rs
+++ b/exercises/practice/decimal/.meta/example.rs
@@ -71,8 +71,8 @@ impl Decimal {
         }
         match one.decimal_index.cmp(&two.decimal_index) {
             std::cmp::Ordering::Equal => {}
-            std::cmp::Ordering::Less => expand(&mut one, &two),
-            std::cmp::Ordering::Greater => expand(&mut two, &one),
+            std::cmp::Ordering::Less => expand(one, two),
+            std::cmp::Ordering::Greater => expand(two, one),
         }
         assert_eq!(one.decimal_index, two.decimal_index);
     }

--- a/exercises/practice/decimal/.meta/example.rs
+++ b/exercises/practice/decimal/.meta/example.rs
@@ -60,7 +60,7 @@ impl Decimal {
     /// Add precision to the less-precise value until precisions match
     ///
     /// Precision, in this case, is defined as the decimal index.
-    fn equalize_precision(mut one: &mut Decimal, mut two: &mut Decimal) {
+    fn equalize_precision(one: &mut Decimal, two: &mut Decimal) {
         fn expand(lower_precision: &mut Decimal, higher_precision: &Decimal) {
             let precision_difference =
                 (higher_precision.decimal_index - lower_precision.decimal_index) as usize;

--- a/exercises/practice/decimal/tests/decimal.rs
+++ b/exercises/practice/decimal/tests/decimal.rs
@@ -36,7 +36,7 @@ fn test_ne() {
 fn test_gt() {
     for slice_2 in BIGS.windows(2) {
         assert!(decimal(slice_2[1]) > decimal(slice_2[0]));
-        assert!(!(decimal(slice_2[0]) > decimal(slice_2[1])));
+        assert!(decimal(slice_2[0]) < decimal(slice_2[1]));
     }
 }
 
@@ -45,7 +45,7 @@ fn test_gt() {
 fn test_lt() {
     for slice_2 in BIGS.windows(2) {
         assert!(decimal(slice_2[0]) < decimal(slice_2[1]));
-        assert!(!(decimal(slice_2[1]) < decimal(slice_2[0])));
+        assert!(decimal(slice_2[1]) > decimal(slice_2[0]));
     }
 }
 

--- a/exercises/practice/decimal/tests/decimal.rs
+++ b/exercises/practice/decimal/tests/decimal.rs
@@ -36,7 +36,6 @@ fn test_ne() {
 fn test_gt() {
     for slice_2 in BIGS.windows(2) {
         assert!(decimal(slice_2[1]) > decimal(slice_2[0]));
-        assert!(decimal(slice_2[0]) < decimal(slice_2[1]));
     }
 }
 
@@ -45,7 +44,6 @@ fn test_gt() {
 fn test_lt() {
     for slice_2 in BIGS.windows(2) {
         assert!(decimal(slice_2[0]) < decimal(slice_2[1]));
-        assert!(decimal(slice_2[1]) > decimal(slice_2[0]));
     }
 }
 

--- a/exercises/practice/macros/tests/macros.rs
+++ b/exercises/practice/macros/tests/macros.rs
@@ -189,7 +189,7 @@ mod simple_trybuild {
             file_path.into_os_string()
         );
 
-        let test_name = file_name.replace(".", "-");
+        let test_name = file_name.replace('.', "-");
         let macros_dir = ["..", "..", "target", "tests", "macros"]
             .iter()
             .collect::<PathBuf>();


### PR DESCRIPTION
[Failing lints](https://github.com/exercism/rust/runs/4815983072?check_suite_focus=true).