### PR TITLE
diffie-hellman: Add rand 0.8.4 to Cargo.toml

### DIFF
--- a/exercises/practice/diffie-hellman/Cargo.toml
+++ b/exercises/practice/diffie-hellman/Cargo.toml
@@ -4,6 +4,7 @@ name = "diffie-hellman"
 version = "0.1.0"
 
 [dependencies]
+rand = "0.8.4"
 
 [features]
 big-primes = []


### PR DESCRIPTION
Problem: If the expectation is for the user to generate a _random_ private key, then there is currently no way to do this in the browser version of this exercise, as the user does not have access to Cargo.toml.

Solution: Allow the use of rand by adding rand 0.8.4 to Cargo.toml dependencies

Caveat: I don't know if  [this post](https://github.com/exercism/rust/issues/1365) indicates that the rand crate _was_ in Cargo.toml at some point and was simply removed for some reason, or whether this is a complaint that all attempts to use rand::Rng were frustrated (because the rand crate was never in Cargo.toml).