### PR TITLE
diffie-hellman: `use rand::Rng`

### DIFF
--- a/exercises/practice/diffie-hellman/src/lib.rs
+++ b/exercises/practice/diffie-hellman/src/lib.rs
@@ -1,3 +1,5 @@
+use rand::Rng;
+
 pub fn private_key(p: u64) -> u64 {
     unimplemented!("Pick a private key greater than 1 and less than {}", p)
 }


### PR DESCRIPTION
Assuming [my previous PR](https://github.com/exercism/rust/pull/1429) is accepted, this will indicate to the user that the rand crate is ready and available in Cargo.toml