### PR TITLE
add `#[must_use]` to several stub and example functions

### DIFF
--- a/exercises/practice/custom-set/.meta/example.rs
+++ b/exercises/practice/custom-set/.meta/example.rs
@@ -43,6 +43,7 @@ impl<T: Ord + Clone> CustomSet<T> {
         !self.collection.iter().any(|x| other.contains(x))
     }
 
+    #[must_use]
     pub fn intersection(&self, other: &Self) -> CustomSet<T> {
         CustomSet::new(
             &self
@@ -54,6 +55,7 @@ impl<T: Ord + Clone> CustomSet<T> {
         )
     }
 
+    #[must_use]
     pub fn union(&self, other: &Self) -> CustomSet<T> {
         CustomSet::new(
             &self
@@ -65,6 +67,7 @@ impl<T: Ord + Clone> CustomSet<T> {
         )
     }
 
+    #[must_use]
     pub fn difference(&self, other: &Self) -> CustomSet<T> {
         CustomSet::new(
             &self

--- a/exercises/practice/custom-set/src/lib.rs
+++ b/exercises/practice/custom-set/src/lib.rs
@@ -34,14 +34,17 @@ impl<T> CustomSet<T> {
         unimplemented!();
     }
 
+    #[must_use]
     pub fn intersection(&self, _other: &Self) -> Self {
         unimplemented!();
     }
 
+    #[must_use]
     pub fn difference(&self, _other: &Self) -> Self {
         unimplemented!();
     }
 
+    #[must_use]
     pub fn union(&self, _other: &Self) -> Self {
         unimplemented!();
     }

--- a/exercises/practice/fizzy/.meta/example.rs
+++ b/exercises/practice/fizzy/.meta/example.rs
@@ -31,6 +31,7 @@ where
         Fizzy(Vec::new())
     }
 
+    #[must_use]
     pub fn add_matcher(mut self, matcher: Matcher<T>) -> Self {
         let Fizzy(ref mut matchers) = self;
         matchers.push(matcher);

--- a/exercises/practice/fizzy/src/lib.rs
+++ b/exercises/practice/fizzy/src/lib.rs
@@ -28,6 +28,7 @@ impl<T> Fizzy<T> {
     }
 
     // feel free to change the signature to `mut self` if you like
+    #[must_use]
     pub fn add_matcher(self, _matcher: Matcher<T>) -> Self {
         unimplemented!()
     }

--- a/exercises/practice/robot-simulator/.meta/example.rs
+++ b/exercises/practice/robot-simulator/.meta/example.rs
@@ -65,18 +65,22 @@ impl Robot {
         }
     }
 
+    #[must_use]
     pub fn turn_right(&self) -> Self {
         Self::build(self.position, self.direction.next_clockwise())
     }
 
+    #[must_use]
     pub fn turn_left(&self) -> Self {
         Self::build(self.position, self.direction.previous_clockwise())
     }
 
+    #[must_use]
     pub fn advance(&self) -> Self {
         Self::build(self.position.advance(&self.direction), self.direction)
     }
 
+    #[must_use]
     pub fn instructions(&self, instructions: &str) -> Self {
         instructions
             .chars()
@@ -93,6 +97,7 @@ impl Robot {
         &self.direction
     }
 
+    #[must_use]
     fn execute(self, command: char) -> Self {
         match command {
             'R' => self.turn_right(),

--- a/exercises/practice/robot-simulator/src/lib.rs
+++ b/exercises/practice/robot-simulator/src/lib.rs
@@ -16,18 +16,22 @@ impl Robot {
         unimplemented!("Create a robot at (x, y) ({}, {}) facing {:?}", x, y, d,)
     }
 
+    #[must_use]
     pub fn turn_right(self) -> Self {
         unimplemented!()
     }
 
+    #[must_use]
     pub fn turn_left(self) -> Self {
         unimplemented!()
     }
 
+    #[must_use]
     pub fn advance(self) -> Self {
         unimplemented!()
     }
 
+    #[must_use]
     pub fn instructions(self, instructions: &str) -> Self {
         unimplemented!(
             "Follow the given sequence of instructions: {}",

--- a/exercises/practice/simple-linked-list/.meta/example.rs
+++ b/exercises/practice/simple-linked-list/.meta/example.rs
@@ -47,6 +47,7 @@ impl<T> SimpleLinkedList<T> {
         self.head.as_ref().map(|node| &node.data)
     }
 
+    #[must_use]
     pub fn rev(self) -> SimpleLinkedList<T> {
         let mut rev_list = SimpleLinkedList::new();
         let mut vec: Vec<_> = self.into();

--- a/exercises/practice/simple-linked-list/src/lib.rs
+++ b/exercises/practice/simple-linked-list/src/lib.rs
@@ -36,6 +36,7 @@ impl<T> SimpleLinkedList<T> {
         unimplemented!()
     }
 
+    #[must_use]
     pub fn rev(self) -> SimpleLinkedList<T> {
         unimplemented!()
     }


### PR DESCRIPTION
This fixes the new lint: https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use