### PR TITLE
add more introduction details for magazine-cutout

### DIFF
--- a/exercises/concept/magazine-cutout/.docs/instructions.md
+++ b/exercises/concept/magazine-cutout/.docs/instructions.md
@@ -26,3 +26,15 @@ assert!(!can_construct_note(&magazine, &note));
 ```
 
 The function returns `false` since the magazine only contains one instance of `"two"` when the note requires two of them.
+
+And the following input will success 
+
+```rust
+let magazine = "The metro orchestra unveiled its new grand piano today. Its donor paraphrased Nathn Hale: \"I only regret that I have but one to give \"".split_whitespace().collect::<Vec<&str>>();
+let note = "give one grand today."
+    .split_whitespace()
+    .collect::<Vec<&str>>();
+assert!(can_construct_note(&magazine, &note));
+```
+
+The function returns `true` since the magazine contains all the words that the note requires.

--- a/exercises/concept/magazine-cutout/.docs/instructions.md
+++ b/exercises/concept/magazine-cutout/.docs/instructions.md
@@ -27,11 +27,11 @@ assert!(!can_construct_note(&magazine, &note));
 
 The function returns `false` since the magazine only contains one instance of `"two"` when the note requires two of them.
 
-And the following input will success 
+The following input will succeed: 
 
 ```rust
-let magazine = "The metro orchestra unveiled its new grand piano today. Its donor paraphrased Nathn Hale: \"I only regret that I have but one to give \"".split_whitespace().collect::<Vec<&str>>();
-let note = "give one grand today."
+let magazine = "Astronomer Amy Mainzer spent hours chatting with Leonardo DiCaprio for Netflix's 'Don't Look Up'".split_whitespace().collect::<Vec<&str>>();
+let note = "Amy Mainzer chatting with Leonardo DiCaprio."
     .split_whitespace()
     .collect::<Vec<&str>>();
 assert!(can_construct_note(&magazine, &note));

--- a/exercises/concept/magazine-cutout/tests/magazine-cutout.rs
+++ b/exercises/concept/magazine-cutout/tests/magazine-cutout.rs
@@ -1,7 +1,7 @@
 use magazine_cutout::*;
 
 #[test]
-fn test_example_works() {
+fn test_magzine_has_less_than_words_available_than_needed() {
     let magazine = "two times three is not four"
         .split_whitespace()
         .collect::<Vec<&str>>();

--- a/exercises/concept/magazine-cutout/tests/magazine-cutout.rs
+++ b/exercises/concept/magazine-cutout/tests/magazine-cutout.rs
@@ -1,7 +1,7 @@
 use magazine_cutout::*;
 
 #[test]
-fn test_magzine_has_less_than_words_available_than_needed() {
+fn test_magazine_has_fewer_words_available_than_needed() {
     let magazine = "two times three is not four"
         .split_whitespace()
         .collect::<Vec<&str>>();


### PR DESCRIPTION
add one success example in the introductions for magazine-cutout, that would make readers understand the meaning of the exercise easier.