### PR TITLE
tests: `cargo clean` before checking stubs compile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,6 +123,9 @@ jobs:
         run: ./_test/check_exercises.sh
         continue-on-error: ${{ matrix.rust == 'beta' && matrix.deny_warnings == '1' }}
 
+      - name: Cargo clean (to prevent previous compilation from unintentionally interfering with later ones)
+        run: ./_test/cargo_clean_all.sh
+
       - name: Ensure stubs compile
         env:
           DENYWARNINGS: ${{ matrix.deny_warnings }}

--- a/_test/cargo_clean_all.sh
+++ b/_test/cargo_clean_all.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+status=0
+repo="$(cd "$(dirname "$0")/.." && pwd)"
+
+for ex in "$repo"/exercises/*/*/; do
+  name=$(grep '^name =' "$ex/Cargo.toml" | cut -d\" -f2)
+  if [ -z "$name" ]; then
+    echo "don't know name of $ex"
+    status=1
+    continue
+  fi
+  cargo clean --manifest-path "$ex/Cargo.toml" --package "$name"
+done
+
+exit $status

--- a/exercises/practice/perfect-numbers/.meta/example.rs
+++ b/exercises/practice/perfect-numbers/.meta/example.rs
@@ -3,11 +3,11 @@ pub fn classify(num: u64) -> Option<Classification> {
         return None;
     }
     let sum: u64 = (1..num).filter(|i| num % i == 0).sum();
-    match sum.cmp(&num) {
-        std::cmp::Ordering::Equal => Some(Classification::Perfect),
-        std::cmp::Ordering::Less => Some(Classification::Deficient),
-        std::cmp::Ordering::Greater => Some(Classification::Abundant),
-    }
+    Some(match sum.cmp(&num) {
+        std::cmp::Ordering::Equal => Classification::Perfect,
+        std::cmp::Ordering::Less => Classification::Deficient,
+        std::cmp::Ordering::Greater => Classification::Abundant,
+    })
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
1.59.0-beta.6 (0426998f5 2022-02-02) runs into an internal compiler
error unless we do this.
(This has been reported to rustc in
https://github.com/rust-lang/rust/issues/93131)

It may be a good idea to keep this `clean` in the long term anyway, so
as to ensure that nothing from the "Check exercises" step unduly affects
the "Ensure stubs compile" step.