### PR TITLE
resistor-color: Include Cargo.toml enabling completion via Web-UI

### DIFF
--- a/exercises/concept/resistor-color/.meta/config.json
+++ b/exercises/concept/resistor-color/.meta/config.json
@@ -7,7 +7,8 @@
   "contributors": [],
   "files": {
     "solution": [
-      "src/lib.rs"
+      "src/lib.rs",
+      "Cargo.toml"
     ],
     "test": [
       "tests/resistor-color.rs"


### PR DESCRIPTION
Just an idea. Don't make people download and setup rust to learn this Rust concept via Exercism.

* This is guesstimation, no idea how to locally verify this will work, but it seems like including the file should work.

I Have completed this solution and tested locally within docker:

```
docker run --rm -it -v $HOME/Exercism/rust/resistor-color:/resistor-color rustlang/rust:nightly-bullseye bash -c 'cd /resistor-color && cargo t'
```

This gave me some confidence to what was being asked.
Really there is likely more that could and should be done to make this exercise useful for learners.

* The docs for the crates used are abysmal, so may need support documentation or upstream contribution.
* Running this without filling your machine up with `rust` dependencies is non-trivial.
* For some reason Cargo.toml is missing from web editor (this solves)
* Marking tests to be ignored... I think it is to encourage taking things one-step at a time. If this is the case then the tests may also need to be added to the editor.