### PR TITLE
Alphametics: Added Cargo.toml to config.json

### DIFF
--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -17,6 +17,7 @@
     "nfiles",
     "nikamirrr",
     "omer-g",
+    "PaulT89",
     "petertseng",
     "rofrol",
     "stringparser",
@@ -25,7 +26,8 @@
   ],
   "files": {
     "solution": [
-      "src/lib.rs"
+      "src/lib.rs",
+      "Cargo.toml"
     ],
     "test": [
       "tests/alphametics.rs"


### PR DESCRIPTION
I'm a bit iffy about this.  One the one hand, the `example.rs` and `Cargo-example.toml` files seem to indicate that the way to solve Alphametics is to use external crates, and this proposed change will (in theory) allow the user to complete the exercise on the Exercism website.  However, this is all in service of a brute-force solution, and I can't help but wonder if the Exercism website will simply time-out before the tests complete.  I remember the Python Alphametics exercise was CLI-only for this reason, and suppose that would be the alternative if this doesn't work.

I propose the following sequence of events:

1. Cargo.toml is added to the config.json file
2. I attempt to complete Alphametics in the browser
3. If it keeps timing out, no matter what I do, I'll come back and create a new PR that changes this to a CLI-only exercise.


