### PR TITLE
alphametics: add test case for too short sum

### DIFF
--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -18,6 +18,7 @@
     "nikamirrr",
     "omer-g",
     "petertseng",
+    "pkwiek",
     "rofrol",
     "stringparser",
     "xakon",

--- a/exercises/practice/alphametics/tests/alphametics.rs
+++ b/exercises/practice/alphametics/tests/alphametics.rs
@@ -27,6 +27,13 @@ fn test_leading_zero_solution_is_invalid() {
 
 #[test]
 #[ignore]
+fn test_sum_must_be_wide_enough() {
+    let answer = alphametics::solve("ABC + DEF == GH");
+    assert_eq!(answer, None);
+}
+
+#[test]
+#[ignore]
 fn puzzle_with_two_digits_final_carry() {
     assert_alphametic_solution_eq(
         "A + A + A + A + A + A + A + A + A + A + A + B == BCC",


### PR DESCRIPTION
It was possible to pass tests without minding width of sum word. A test
with too short sum word exists, however the equation itself is invalid
due to leading zero, causing a lucky coincidence for some solutions.
This patch adds a test which is invalid only due to sum word length.