### PR TITLE
poker: add test for flush with pair

### DIFF
--- a/exercises/practice/poker/tests/poker.rs
+++ b/exercises/practice/poker/tests/poker.rs
@@ -222,3 +222,8 @@ fn test_straight_flush_ranks() {
     // both hands have straight flush, tie goes to highest-ranked card
     test(&["4H 6H 7H 8H 5H", "5S 7S 8S 9S 6S"], &["5S 7S 8S 9S 6S"])
 }
+
+fn test_flush_discriminants() {
+    // both hands have straight flush, tie goes to highest-ranked card
+    test(&["AH KH QH 2H 2H", "7H 6H 5H 4H 3H"], &["AH KH QH 2H 2H"])
+}


### PR DESCRIPTION
We made a bug that none of the existing tests caught. So, here's one that does.

By the way, we study Rust in the format of mob programming regularly. If anyone is interested, [learn more here](https://mobusoperandi.zulipchat.com/). It's free.

Co-authored-by: Shahar Dawn Or <mightyiampresence@gmail.com>
Co-authored-by: Preet Dua <615318+prabhpreet@users.noreply.github.com>
Co-authored-by: Roland Fredenhagen <dev@modprog.de>
