### PR TITLE
use f64 for production rate

### DIFF
--- a/exercises/concept/assembly-line/.meta/exemplar.rs
+++ b/exercises/concept/assembly-line/.meta/exemplar.rs
@@ -1,11 +1,11 @@
-const PRODUCTION_RATE_DEFAULT: u32 = 221;
+const PRODUCTION_RATE_DEFAULT: f64 = 221.;
 
 pub fn production_rate_per_hour(speed: u8) -> f64 {
-    match speed as u32 {
+    match speed {
         0 => 0.0,
-        s @ 1..=4 => (PRODUCTION_RATE_DEFAULT * s) as f64,
-        s @ 5..=8 => (PRODUCTION_RATE_DEFAULT * s) as f64 * 0.9,
-        s @ 9..=10 => (PRODUCTION_RATE_DEFAULT * s) as f64 * 0.77,
+        s @ 1..=4 => PRODUCTION_RATE_DEFAULT * s as f64,
+        s @ 5..=8 => PRODUCTION_RATE_DEFAULT * s as f64 * 0.9,
+        s @ 9..=10 => PRODUCTION_RATE_DEFAULT * s as f64 * 0.77,
         _ => panic!("Speed should be a value from 0 to 10"),
     }
 }


### PR DESCRIPTION
A rate can be a positive real number, it doesn't have to be a whole
number of cars. This eliminates a cast as well.