### PR TITLE
Add test to exercise luhn

### DIFF
--- a/exercises/practice/luhn/tests/luhn.rs
+++ b/exercises/practice/luhn/tests/luhn.rs
@@ -132,3 +132,10 @@ fn test_valid_number_with_an_odd_number_of_spaces() {
 fn test_invalid_char_in_middle_with_sum_divisible_by_10_isnt_allowed() {
     process_valid_case("59%59", false);
 }
+
+#[test]
+#[ignore]
+/// unicode numeric characters are not allowed in a otherwise valid number
+fn test_valid_strings_with_numeric_unicode_characters_become_invalid() {
+    process_valid_case("1249①", false);
+}


### PR DESCRIPTION
I was doing the exercise luhn and noticed that some incorrect code I wrote was passing the tests.
I was using `some_char.is_numeric()` to test whether the char is allowed. Later I used `some_char.to_digit(10).unwrap()` on allowed characters. This program passes all tests but panics, when the received string contains a numeric Unicode character such as `①`.
Where I used `some_char.is_numeric()` I should have used `some_char.is_digit(10)` to test if the Input string contains any disallowed characters. 

I hope that adding this test will prevent other  people from making the same mistake in their code.