### PR TITLE
improve scripts' ability to ignore things which are not exercises

### DIFF
--- a/_test/check_exercises.sh
+++ b/_test/check_exercises.sh
@@ -42,7 +42,7 @@ fi
 
 return_code=0
 # An exercise worth testing is defined here as any top level directory with
-# a 'tests' directory
+# a 'tests' directory and a .meta/config.json. 
 for exercise in $files; do
    exercise="$exercise/$target_dir"
 

--- a/_test/check_exercises.sh
+++ b/_test/check_exercises.sh
@@ -42,7 +42,7 @@ fi
 
 return_code=0
 # An exercise worth testing is defined here as any top level directory with
-# a 'tests' directory and a .meta/config.json. 
+# a 'tests' directory and a .meta/config.json.
 for exercise in $files; do
    exercise="$exercise/$target_dir"
 

--- a/_test/check_exercises.sh
+++ b/_test/check_exercises.sh
@@ -50,8 +50,14 @@ for exercise in $files; do
    # and that the primary module is named the same as the directory
    directory=$(dirname "${exercise}")
 
+   # An exercise must have a .meta/config.json
+   metaconf="$directory/.meta/config.json"
+   if [ ! -f "$metaconf" ]; then
+      continue
+   fi
+
    release=""
-   if [ -z "$BENCHMARK" ] && jq --exit-status '.custom?."test-in-release-mode"?' "$directory"/.meta/config.json; then
+   if [ -z "$BENCHMARK" ] && jq --exit-status '.custom?."test-in-release-mode"?' "$metaconf"; then
       # release mode is enabled if not benchmarking and the appropriate key is neither `false` nor `null`.
       release="--release"
    fi

--- a/_test/count_ignores.sh
+++ b/_test/count_ignores.sh
@@ -4,7 +4,13 @@ repo=$(cd "$(dirname "$0")/.." && pwd)
 exitcode=0
 
 for e in "$repo"/exercises/*/*; do
-   if jq --exit-status '.custom?."ignore-count-ignores"?' "$e"/.meta/config.json; then
+   # An exercise must have a .meta/config.json
+   metaconf="$e/.meta/config.json"
+   if [ ! -f "$metaconf" ]; then
+      continue
+   fi
+
+   if jq --exit-status '.custom?."ignore-count-ignores"?' "$metaconf"; then
       continue
    fi
    if [ -d "$e/tests" ]; then

--- a/_test/ensure_stubs_compile.sh
+++ b/_test/ensure_stubs_compile.sh
@@ -29,6 +29,11 @@ for dir in $changed_exercises; do
 
     config_file="$dir/.meta/config.json"
 
+    # An exercise must have a .meta/config.json
+    if [ ! -f "$config_file" ]; then
+       continue
+    fi
+
     if jq --exit-status '.custom?."allowed-to-not-compile"?' "$config_file"; then
       echo "$exercise's stub is allowed to not compile"
       continue


### PR DESCRIPTION
Test scripts used to be able to assume that everything in the
`exercises/` directory was in fact an exercise, but with certain
mandatory reorganization in v3 that is no longer a safe assumption.

This change helps the scripts to identify things which are not exercises.

The lack of this PR is causing CI failures on #1479.