### PR TITLE
Capitalize ASCII

### DIFF
--- a/concepts/match-basics/about.md
+++ b/concepts/match-basics/about.md
@@ -69,7 +69,7 @@ fn ascii_type(ch: u8) -> &'static str {
         0..=31 => "non-printable control code",
         32..=126 => "printable character",
         127 => "DEL",
-        _ => "extended ascii; region-specific",
+        _ => "extended ASCII; region-specific",
     }
 }
 ```

--- a/concepts/string-vs-str/about.md
+++ b/concepts/string-vs-str/about.md
@@ -30,7 +30,7 @@ This derives from the following properties:
 - Rust's standard library authors therefore chose not to implement the `Index` trait for strings: while it takes a constant time to index into a byte array, it might take quite a long time to index into a string. This violates the principle of least surprise.
 
 ```rust
-let example = "I'm not entirely ascii! ❤";
+let example = "I'm not entirely ASCII! ❤";
 
 let n_chars = example.chars().count();
 let final_byte = example.as_bytes()[example.len()-1];

--- a/docs/archived/exercise-concepts/parallel-letter-frequency.md
+++ b/docs/archived/exercise-concepts/parallel-letter-frequency.md
@@ -13,7 +13,7 @@ This exercise boasts a wide variety of possible solutions in combination with th
 - **Strings**
   - `&str` type
 - **Unicode**
-  - Unicode methods vs ascii methods
+  - Unicode methods vs ASCII methods
 - **Slices**
 - **Tuples**
 - **Destructuring**
@@ -52,7 +52,7 @@ This exercise boasts a wide variety of possible solutions in combination with th
 ## General
 
 - Strings: specifically the `str` is always a factor here
-- Unicode: performance/feature concessions of ascii vs unicode methods. Benchmarking is skewed when benchmark uses unicode methods and the solution uses ascii methods.
+- Unicode: performance/feature concessions of ASCII vs unicode methods. Benchmarking is skewed when benchmark uses unicode methods and the solution uses ASCII methods.
 - Iterators: iterating over input or chunks of it.
 - Collections: Iterating over a `HashMap` and using `Entry`. Commonly handles are collected into `Vec`.
 - References

--- a/exercises/practice/luhn/tests/luhn.rs
+++ b/exercises/practice/luhn/tests/luhn.rs
@@ -89,8 +89,8 @@ fn test_input_digit_9_is_correctly_converted_to_output_digit_9() {
 
 #[test]
 #[ignore]
-/// using ascii value for doubled non-digit isn't allowed
-/// Convert non-digits to their ascii values and then offset them by 48 sometimes accidentally declare an invalid string to be valid.
+/// using ASCII value for doubled non-digit isn't allowed
+/// Convert non-digits to their ASCII values and then offset them by 48 sometimes accidentally declare an invalid string to be valid.
 /// This test is designed to avoid that solution.
 fn test_using_ascii_value_for_doubled_nondigit_isnt_allowed() {
     process_valid_case(":9", false);
@@ -112,8 +112,8 @@ fn test_valid_strings_with_symbols_included_become_invalid() {
 
 #[test]
 #[ignore]
-/// using ascii value for non-doubled non-digit isn't allowed
-/// Convert non-digits to their ascii values and then offset them by 48 sometimes accidentally declare an invalid string to be valid.
+/// using ASCII value for non-doubled non-digit isn't allowed
+/// Convert non-digits to their ASCII values and then offset them by 48 sometimes accidentally declare an invalid string to be valid.
 /// This test is designed to avoid that solution.
 fn test_using_ascii_value_for_nondoubled_nondigit_isnt_allowed() {
     process_valid_case("055b 444 285", false);

--- a/exercises/practice/minesweeper/.docs/instructions.md
+++ b/exercises/practice/minesweeper/.docs/instructions.md
@@ -38,11 +38,11 @@ And your code will transform it into this:
 
 ## Performance Hint
 
-All the inputs and outputs are in Ascii. Rust `String`s and `&str` are utf8,
+All the inputs and outputs are in ASCII. Rust `String`s and `&str` are utf8,
 so while one might expect "Hello".chars() to be simple, it actually has to
 check each char to see if it's 1, 2, 3 or 4 `u8`s long. If we know a `&str`
-is ascii then we can call `.as_bytes()` and refer to the underlying data via a `&[u8]` slice.
-Iterating over a u8 slice of ascii is much quicker as there are no codepoints
-involved - every ascii char is one u8 long.
+is ASCII then we can call `.as_bytes()` and refer to the underlying data via a `&[u8]` slice.
+Iterating over a u8 slice of ASCII is much quicker as there are no codepoints
+involved - every ASCII char is one u8 long.
 
 Can you complete the challenge without cloning the input?


### PR DESCRIPTION
ASCII is an abbreviation and stands for American Standard Code for Information Interchange (ref: https://en.wikipedia.org/wiki/ASCII). I think it should be capitalized in all instances in this doc.