### PR TITLE
rectangles: Add test for three disjoint rectangles

### DIFF
--- a/exercises/practice/rectangles/tests/rectangles.rs
+++ b/exercises/practice/rectangles/tests/rectangles.rs
@@ -149,3 +149,17 @@ fn test_large_input_with_many_rectangles() {
     ];
     assert_eq!(60, count(lines))
 }
+
+#[test]
+#[ignore]
+fn test_three_rectangles_no_shared_parts() {
+    #[rustfmt::skip]
+    let lines = &[
+        "  +-+  ",
+        "  | |  ",
+        "+-+-+-+",
+        "| | | |",
+        "+-+ +-+",
+    ];
+    assert_eq!(3, count(lines))
+}


### PR DESCRIPTION
Some solutions to this exercise will look for the top corners of the rectangles, making sure they are connected by a horizontal line, then go on to walk down the left and right side to find corners at the same row, in which case a rectangle is detected. These solutions sometimes fail to check that the bottom two corners are connected by a horizontal line. This test case will catch that.