### PR TITLE
upgrade rstest version to one which works with the online test runner

### DIFF
--- a/exercises/practice/xorcism/Cargo.toml
+++ b/exercises/practice/xorcism/Cargo.toml
@@ -11,5 +11,5 @@ io = []
 
 [dev-dependencies]
 hexlit = "0.5.0"
-rstest = "0.6.4"
+rstest = "0.12.0"
 rstest_reuse = "0.1.0"


### PR DESCRIPTION
Closes https://github.com/exercism/rust/issues/1501.