### PR TITLE
fix Clippy 1.63 Beta lints

### DIFF
--- a/exercises/concept/resistor-color/src/lib.rs
+++ b/exercises/concept/resistor-color/src/lib.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ResistorColor {
     Black,
     Blue,

--- a/exercises/concept/semi-structured-logs/src/lib.rs
+++ b/exercises/concept/semi-structured-logs/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(unused)]
 
 /// various log levels
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum LogLevel {
     Info,
     Warning,

--- a/exercises/practice/all-your-base/src/lib.rs
+++ b/exercises/practice/all-your-base/src/lib.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     InvalidInputBase,
     InvalidOutputBase,

--- a/exercises/practice/allergies/src/lib.rs
+++ b/exercises/practice/allergies/src/lib.rs
@@ -1,6 +1,6 @@
 pub struct Allergies;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Allergen {
     Eggs,
     Peanuts,

--- a/exercises/practice/bowling/src/lib.rs
+++ b/exercises/practice/bowling/src/lib.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     NotEnoughPinsLeft,
     GameComplete,

--- a/exercises/practice/circular-buffer/src/lib.rs
+++ b/exercises/practice/circular-buffer/src/lib.rs
@@ -8,7 +8,7 @@ pub struct CircularBuffer<T> {
     field: PhantomData<T>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     EmptyBuffer,
     FullBuffer,

--- a/exercises/practice/custom-set/src/lib.rs
+++ b/exercises/practice/custom-set/src/lib.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CustomSet<T> {
     // This field is here to make the template compile and not to
     // complain about unused type parameter 'T'. Once you start

--- a/exercises/practice/forth/src/lib.rs
+++ b/exercises/practice/forth/src/lib.rs
@@ -3,7 +3,7 @@ pub type Result = std::result::Result<(), Error>;
 
 pub struct Forth;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     DivisionByZero,
     StackUnderflow,

--- a/exercises/practice/largest-series-product/src/lib.rs
+++ b/exercises/practice/largest-series-product/src/lib.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     SpanTooLong,
     InvalidDigit(char),

--- a/exercises/practice/ocr-numbers/src/lib.rs
+++ b/exercises/practice/ocr-numbers/src/lib.rs
@@ -1,7 +1,7 @@
 // The code below is a stub. Just enough to satisfy the compiler.
 // In order to pass the tests you can add-to or change any of this code.
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     InvalidRowCount(usize),
     InvalidColumnCount(usize),

--- a/exercises/practice/react/src/lib.rs
+++ b/exercises/practice/react/src/lib.rs
@@ -1,5 +1,5 @@
 /// `InputCellId` is a unique identifier for an input cell.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct InputCellId();
 /// `ComputeCellId` is a unique identifier for a compute cell.
 /// Values of type `InputCellId` and `ComputeCellId` should not be mutually assignable,
@@ -15,18 +15,18 @@ pub struct InputCellId();
 /// let input = r.create_input(111);
 /// let compute: react::InputCellId = r.create_compute(&[react::CellId::Input(input)], |_| 222).unwrap();
 /// ```
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ComputeCellId();
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CallbackId();
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CellId {
     Input(InputCellId),
     Compute(ComputeCellId),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum RemoveCallbackError {
     NonexistentCell,
     NonexistentCallback,

--- a/exercises/practice/rna-transcription/src/lib.rs
+++ b/exercises/practice/rna-transcription/src/lib.rs
@@ -1,7 +1,7 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Dna;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Rna;
 
 impl Dna {

--- a/exercises/practice/robot-simulator/src/lib.rs
+++ b/exercises/practice/robot-simulator/src/lib.rs
@@ -1,7 +1,7 @@
 // The code below is a stub. Just enough to satisfy the compiler.
 // In order to pass the tests you can add-to or change any of this code.
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum Direction {
     North,
     East,

--- a/exercises/practice/sublist/src/lib.rs
+++ b/exercises/practice/sublist/src/lib.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Comparison {
     Equal,
     Sublist,

--- a/exercises/practice/variable-length-quantity/src/lib.rs
+++ b/exercises/practice/variable-length-quantity/src/lib.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     IncompleteNumber,
     Overflow,


### PR DESCRIPTION
Looks like the upcoming version of Clippy adds a lint for instances
where you derive PartialEq, but not Eq, and don't explain why. This
PR fixes those instances.