### PR TITLE
resistor-color: changed color values from usize to u32

### DIFF
--- a/exercises/concept/resistor-color/src/lib.rs
+++ b/exercises/concept/resistor-color/src/lib.rs
@@ -12,11 +12,11 @@ pub enum ResistorColor {
     Yellow,
 }
 
-pub fn color_to_value(_color: ResistorColor) -> usize {
+pub fn color_to_value(_color: ResistorColor) -> u32 {
     unimplemented!("convert a color into a numerical representation")
 }
 
-pub fn value_to_color_string(value: usize) -> String {
+pub fn value_to_color_string(value: u32) -> String {
     unimplemented!(
         "convert the value {} into a string representation of color",
         value


### PR DESCRIPTION
To better convey the intent, the type for color values should be an int type (I chose ``u32`` here, but any ``u*`` would do) instead of ``usize``, as it's not an index or an address.

> The primary situation in which you’d use isize or usize is when indexing some sort of collection.

from [The Rust Programming Language](https://doc.rust-lang.org/book/ch03-02-data-types.html) book