### PR TITLE
grep: use `lines()` instead of `split('\n')`

### DIFF
--- a/exercises/practice/grep/.meta/example.rs
+++ b/exercises/practice/grep/.meta/example.rs
@@ -41,7 +41,7 @@ fn get_file_lines(file_name: &str) -> Result<Vec<String>, FileAccessError> {
     }
 
     if let Ok(content) = fs::read_to_string(file_path) {
-        Ok(content.split('\n').map(|line| line.to_string()).collect())
+        Ok(content.lines().map(|line| line.to_string()).collect())
     } else {
         Err(FileAccessError::FileReadError {
             file_name: String::from(file_name),
@@ -80,7 +80,6 @@ pub fn grep(pattern: &str, flags: &Flags, files: &[&str]) -> Result<Vec<String>,
                         inner_line.contains(&inner_pattern)
                     }
                 })
-                .filter(|(_, line)| !line.is_empty())
                 .map(|(line_number, line)| {
                     let mut result = line.to_owned();
 


### PR DESCRIPTION
lines are terminated by newlines, not separated by newlines. using
`split('\n')` is incorrect because it interprets the trailing newline
(which is required by the POSIX standard) to separate the last actual
line in the file with a nonexistent empty line. `lines()` is the correct
way to split by lines.

Thus, the workaround of removing the empty line is also removed from the
example.

This was brought up in https://github.com/exercism/rust/issues/1530.