### PR TITLE
fix: 2nd assert example from Magazine Cutout exercise

### DIFF
--- a/exercises/concept/magazine-cutout/.docs/instructions.md
+++ b/exercises/concept/magazine-cutout/.docs/instructions.md
@@ -31,7 +31,7 @@ The following input will succeed:
 
 ```rust
 let magazine = "Astronomer Amy Mainzer spent hours chatting with Leonardo DiCaprio for Netflix's 'Don't Look Up'".split_whitespace().collect::<Vec<&str>>();
-let note = "Amy Mainzer chatting with Leonardo DiCaprio."
+let note = "Amy Mainzer chatting with Leonardo DiCaprio"
     .split_whitespace()
     .collect::<Vec<&str>>();
 assert!(can_construct_note(&magazine, &note));


### PR DESCRIPTION
`thread 'main' panicked at 'assertion failed: can_construct_note(&magazine, &note)` due to "." in the given example from Magazine Cutout exercise.