### PR TITLE
fix: update dependencies for xorcism exercise

### DIFF
--- a/exercises/practice/xorcism/Cargo.toml
+++ b/exercises/practice/xorcism/Cargo.toml
@@ -10,6 +10,6 @@ edition = "2021"
 io = []
 
 [dev-dependencies]
-hexlit = "0.5.0"
-rstest = "0.12.0"
-rstest_reuse = "0.1.0"
+hexlit = "0.5.5"
+rstest = "0.15.0"
+rstest_reuse = "0.4.0"


### PR DESCRIPTION
The platform can't build the solution with `rstest_reuse==0.3.0`

Decided to update all libraries to actual versions