### PR TITLE
series: add test asking for way too many digits

### DIFF
--- a/exercises/practice/series/tests/series.rs
+++ b/exercises/practice/series/tests/series.rs
@@ -31,3 +31,10 @@ fn test_too_long() {
     let expected: Vec<String> = vec![];
     assert_eq!(series("92017", 6), expected);
 }
+
+#[test]
+#[ignore]
+fn test_way_too_long() {
+    let expected: Vec<String> = vec![];
+    assert_eq!(series("92017", 42), expected);
+}


### PR DESCRIPTION
series: add a test going well beyond the edge case of `len == digits.len() + 1`