### PR TITLE
resistor-color: Use int-enum 0.5.0 for compatilibity with rust-analyzer, and enum-iterator 1.2.0 for routine update

### DIFF
--- a/exercises/concept/resistor-color/.docs/instructions.md
+++ b/exercises/concept/resistor-color/.docs/instructions.md
@@ -32,7 +32,7 @@ The goal of this exercise is to create a way:
 - to list the different band colors
 
 For task number one, you will need the external crate [`int-enum`](https://docs.rs/int-enum/0.4.0/int_enum/) and for task number three, you'll need [`enum-iterator`](https://docs.rs/enum-iterator/1.1.1/enum_iterator/).
-They're both already included in this exercise's `Cargo.toml`. 
+They're both already included in this exercise's `Cargo.toml`.
 Be sure to check the crates' documentation to learn how to use them.
 You can look into the default implementation of the Debug trait for Enums to complete task number two.
 

--- a/exercises/concept/resistor-color/.docs/instructions.md
+++ b/exercises/concept/resistor-color/.docs/instructions.md
@@ -31,7 +31,7 @@ The goal of this exercise is to create a way:
 - to convert the numerical value into a string representing color
 - to list the different band colors
 
-For task number one, you will need the external crate [`int-enum`](https://docs.rs/int-enum/0.4.0/int_enum/) and for task number three, you'll need [`enum-iterator`](https://docs.rs/enum-iterator/1.1.1/enum_iterator/).
+For task number one, you will need the external crate [`int-enum`](https://docs.rs/int-enum/0.5.0/int_enum/) and for task number three, you'll need [`enum-iterator`](https://docs.rs/enum-iterator/1.1.1/enum_iterator/).
 They're both already included in this exercise's `Cargo.toml`.
 Be sure to check the crates' documentation to learn how to use them.
 You can look into the default implementation of the Debug trait for Enums to complete task number two.

--- a/exercises/concept/resistor-color/.docs/instructions.md
+++ b/exercises/concept/resistor-color/.docs/instructions.md
@@ -31,7 +31,7 @@ The goal of this exercise is to create a way:
 - to convert the numerical value into a string representing color
 - to list the different band colors
 
-For task number one, you will need the external crate [`int-enum`](https://docs.rs/int-enum/0.5.0/int_enum/) and for task number three, you'll need [`enum-iterator`](https://docs.rs/enum-iterator/1.1.1/enum_iterator/).
+For task number one, you will need the external crate [`int-enum`](https://docs.rs/int-enum/0.5.0/int_enum/) and for task number three, you'll need [`enum-iterator`](https://docs.rs/enum-iterator/1.2.0/enum_iterator/).
 They're both already included in this exercise's `Cargo.toml`.
 Be sure to check the crates' documentation to learn how to use them.
 You can look into the default implementation of the Debug trait for Enums to complete task number two.

--- a/exercises/concept/resistor-color/.docs/introduction.md
+++ b/exercises/concept/resistor-color/.docs/introduction.md
@@ -6,4 +6,4 @@ You will often see external packages being referred to as "crates" in Rust. A cr
 
 Most of the time, adding an external dependency is as simple as adding a line to your `Cargo.toml` file.
 
-In this exercise, [`enum-iterator`](https://docs.rs/enum-iterator/1.1.1/enum_iterator/) and [`int-enum`](https://docs.rs/int-enum/0.4.0/int_enum/) dependencies were added for you.
+In this exercise, [`enum-iterator`](https://docs.rs/enum-iterator/1.1.1/enum_iterator/) and [`int-enum`](https://docs.rs/int-enum/0.5.0/int_enum/) dependencies were added for you.

--- a/exercises/concept/resistor-color/.docs/introduction.md
+++ b/exercises/concept/resistor-color/.docs/introduction.md
@@ -6,4 +6,4 @@ You will often see external packages being referred to as "crates" in Rust. A cr
 
 Most of the time, adding an external dependency is as simple as adding a line to your `Cargo.toml` file.
 
-In this exercise, [`enum-iterator`](https://docs.rs/enum-iterator/1.1.1/enum_iterator/) and [`int-enum`](https://docs.rs/int-enum/0.5.0/int_enum/) dependencies were added for you.
+In this exercise, [`enum-iterator`](https://docs.rs/enum-iterator/1.2.0/enum_iterator/) and [`int-enum`](https://docs.rs/int-enum/0.5.0/int_enum/) dependencies were added for you.

--- a/exercises/concept/resistor-color/Cargo.toml
+++ b/exercises/concept/resistor-color/Cargo.toml
@@ -4,5 +4,5 @@ name = "resistor-color"
 version = "1.0.0"
 
 [dependencies]
-int-enum = "0.4.0"
+int-enum = "0.5.0"
 enum-iterator = "1.1.1"

--- a/exercises/concept/resistor-color/Cargo.toml
+++ b/exercises/concept/resistor-color/Cargo.toml
@@ -5,4 +5,4 @@ version = "1.0.0"
 
 [dependencies]
 int-enum = "0.5.0"
-enum-iterator = "1.1.1"
+enum-iterator = "1.2.0"


### PR DESCRIPTION
int-enum crate was updated - https://github.com/Juici/int-enum-rs/issues/4
to be compatible with the latest rust-analyzer - https://github.com/rust-lang/rust-analyzer/issues/13347