### PR TITLE
magazine-cutout: fix small grammatical error in the introduction

### DIFF
--- a/exercises/concept/magazine-cutout/.docs/introduction.md
+++ b/exercises/concept/magazine-cutout/.docs/introduction.md
@@ -1,3 +1,4 @@
 # Introduction
 
-Rust's entry API provides a view into a single entry in map, which may be either a `HashMap` or a `BTreeMap`. The entry may be either occupied and vacant, and the API provides methods to modify the contents of the entry.
+Rust's entry API provides a view into a single entry in map, which may be either a `HashMap` or a `BTreeMap`.
+The entry may be either occupied and vacant, and the API provides methods to modify the contents of the entry.

--- a/exercises/concept/magazine-cutout/.docs/introduction.md
+++ b/exercises/concept/magazine-cutout/.docs/introduction.md
@@ -1,4 +1,4 @@
 # Introduction
 
 Rust's entry API provides a view into a single entry in map, which may be either a `HashMap` or a `BTreeMap`.
-The entry may be either occupied and vacant, and the API provides methods to modify the contents of the entry.
+The entry may be either occupied or vacant, and the API provides methods to modify the contents of the entry.


### PR DESCRIPTION
This is minor, but "either A and B" is wrong in English, it implies "either (A and B) or (C)". What the sentence wants is "either (A) or (B)", so this fixes it.

There's no associated issue yet, I assume something this tiny doesn't need it. But let me know if I should open one first nonetheless.

(First-time contributor to Exercism)