### PR TITLE
parallel-letter-frequency: Suppress nightly feature error

### DIFF
--- a/exercises/practice/parallel-letter-frequency/benches/benchmark.rs
+++ b/exercises/practice/parallel-letter-frequency/benches/benchmark.rs
@@ -1,3 +1,4 @@
+#![cfg(nightly)]
 #![feature(test)]
 extern crate parallel_letter_frequency;
 extern crate test;


### PR DESCRIPTION
Everything works fine from the command line, running the regular tests on the stable toolchain as well as the benchmarks on the nightly toolchain. But I got an error in vscode:

> `#![feature]` may not be used on the stable release channel

So this basically just makes that annoying error message go away.