### PR TITLE
resistor-color: Add explanation for disabled tests

### DIFF
--- a/exercises/concept/resistor-color/.docs/instructions.md
+++ b/exercises/concept/resistor-color/.docs/instructions.md
@@ -36,6 +36,8 @@ They're both already included in this exercise's `Cargo.toml`.
 Be sure to check the crates' documentation to learn how to use them.
 You can look into the default implementation of the Debug trait for Enums to complete task number two.
 
+Note that because of these external crates, online tests are disabled. They use procedural macros, which can increase compile time significantly. Long compile times may trigger the two second timeout, making the tests fail. That's why they are disabled for this exercise. It's recommended you test your code locally. Once the tests pass, you can mark the exercise as completed manually.
+
 Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
 
 More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article](https://en.wikipedia.org/wiki/Electronic_color_code)


### PR DESCRIPTION
Issue that lead to the tests being disabled:
https://github.com/exercism/exercism/issues/6353

---

Hi there!

I've been doing a bit of mentoring for Rust lately and I've had three people ask about why the tests for resistor-color aren't running online. I suspect many others are confused, but don't ask via mentoring.

I thought it might be a good idea to include a note in the description.