### PR TITLE
Added two PartialEq-related tests

### DIFF
--- a/exercises/practice/decimal/tests/decimal.rs
+++ b/exercises/practice/decimal/tests/decimal.rs
@@ -41,10 +41,26 @@ fn test_gt() {
 
 #[test]
 #[ignore]
+fn test_gt_2() {
+    assert!(decimal("3.14") > decimal("3.13"));
+    assert!(decimal("3.14") > decimal("3.131"));
+    assert!(decimal("3.14") > decimal("3.1"));
+}
+
+#[test]
+#[ignore]
 fn test_lt() {
     for slice_2 in BIGS.windows(2) {
         assert!(decimal(slice_2[0]) < decimal(slice_2[1]));
     }
+}
+
+#[test]
+#[ignore]
+fn test_lt_2() {
+    assert!(decimal("3.13") < decimal("3.14"));
+    assert!(decimal("3.131") < decimal("3.14"));
+    assert!(decimal("3.1") < decimal("3.14"));
 }
 
 #[test]


### PR DESCRIPTION
In a silly implementation I accidentally wrote, I was able to pass all the PartialEq-related tests, even though my implementation didn't actually behave.

My implementation was like a floating point implementation, but with the data in a BigInt, but the floating point was incorrectly used in the PartialEq implementation. These tests test for that kind of mistake, where the number of digits in the decimal expansion determine the behavior of the PartialEq implementation.