### PR TITLE
Health Statistics Concept Exercise Fix

### DIFF
--- a/exercises/concept/health-statistics/.docs/hints.md
+++ b/exercises/concept/health-statistics/.docs/hints.md
@@ -26,7 +26,6 @@ fn foo() -> i32 {
 
 ## 3. Implement the setter methods
 
-- The `set_age()` and `set_weight()` methods are setters, responsible for updating the corresponding field on a struct instance with the input argument.
+- The `age_mut()` and `weight_mut()` methods are setters, responsible for mutating (updating) the corresponding field on a struct instance with the input argument.
 
 - As the signatures of these methods specify, the setter methods shouldn't return anything.
-

--- a/exercises/concept/health-statistics/.docs/instructions.md
+++ b/exercises/concept/health-statistics/.docs/instructions.md
@@ -28,10 +28,10 @@ bob.weight();
 // Returns: 155.2
 ```
 
-The `set_age` method should set the age of the `User`.
+The `age_mut` method should set the age of the `User`.
 
 ```rust
-bob.set_age(33);
+bob.age_mut(33);
 // Updates Bob's age to 33; happy birthday Bob!
 ```
 

--- a/exercises/concept/health-statistics/.meta/exemplar.rs
+++ b/exercises/concept/health-statistics/.meta/exemplar.rs
@@ -21,11 +21,11 @@ impl User {
         self.weight
     }
 
-    pub fn set_age(&mut self, new_age: u32) {
+    pub fn age_mut(&mut self, new_age: u32) {
         self.age = new_age;
     }
 
-    pub fn set_weight(&mut self, new_weight: f32) {
+    pub fn weight_mut(&mut self, new_weight: f32) {
         self.weight = new_weight;
     }
 }

--- a/exercises/concept/health-statistics/src/lib.rs
+++ b/exercises/concept/health-statistics/src/lib.rs
@@ -25,11 +25,11 @@ impl User {
         unimplemented!()
     }
 
-    pub fn set_age(&mut self, new_age: u32) {
+    pub fn age_mut(&mut self, new_age: u32) {
         unimplemented!()
     }
 
-    pub fn set_weight(&mut self, new_weight: f32) {
+    pub fn weight_mut(&mut self, new_weight: f32) {
         unimplemented!()
     }
 }

--- a/exercises/concept/health-statistics/tests/health-statistics.rs
+++ b/exercises/concept/health-statistics/tests/health-statistics.rs
@@ -5,6 +5,7 @@ const AGE: u32 = 89;
 const WEIGHT: f32 = 131.6;
 
 #[test]
+#[ignore]
 fn test_name() {
     let user = User::new(NAME.into(), AGE, WEIGHT);
     assert_eq!(user.name(), NAME);
@@ -29,7 +30,7 @@ fn test_weight() {
 fn test_set_age() {
     let new_age: u32 = 90;
     let mut user = User::new(NAME.into(), AGE, WEIGHT);
-    user.set_age(new_age);
+    user.age_mut(new_age);
     assert_eq!(user.age(), new_age);
 }
 
@@ -38,6 +39,6 @@ fn test_set_age() {
 fn test_set_weight() {
     let new_weight: f32 = 129.4;
     let mut user = User::new(NAME.into(), AGE, WEIGHT);
-    user.set_weight(new_weight);
+    user.weight_mut(new_weight);
     assert!((user.weight() - new_weight).abs() < f32::EPSILON);
 }

--- a/exercises/concept/health-statistics/tests/health-statistics.rs
+++ b/exercises/concept/health-statistics/tests/health-statistics.rs
@@ -5,7 +5,6 @@ const AGE: u32 = 89;
 const WEIGHT: f32 = 131.6;
 
 #[test]
-#[ignore]
 fn test_name() {
     let user = User::new(NAME.into(), AGE, WEIGHT);
     assert_eq!(user.name(), NAME);


### PR DESCRIPTION
In this branch:

+ Setter methods for age and weight are renamed to follow [Rust API guidelines](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter). They indicate mutability, which is idiomatic in Rust.

 + Added `#[ignore]` to `test_name` as it was missing (and failing).