### PR TITLE
low-power-embedded-game: change test order for clarity

### DIFF
--- a/exercises/concept/low-power-embedded-game/tests/low-power-embedded-game.rs
+++ b/exercises/concept/low-power-embedded-game/tests/low-power-embedded-game.rs
@@ -40,6 +40,15 @@ mod evens {
 
     #[test]
     #[ignore]
+    fn strs() {
+        let input = "You really must never be above joking.".split_whitespace();
+        let expected: Vec<_> = "You must be joking.".split_whitespace().collect();
+        let out: Vec<_> = evens(input).collect();
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    #[ignore]
     fn simple_i32() {
         let out: Vec<i32> = evens(0..).take(5).collect();
         assert_eq!(out, &[0, 2, 4, 6, 8]);
@@ -57,15 +66,6 @@ mod evens {
     fn offset_i32() {
         let out: Vec<i32> = evens(1..).take(5).collect();
         assert_eq!(out, &[1, 3, 5, 7, 9]);
-    }
-
-    #[test]
-    #[ignore]
-    fn strs() {
-        let input = "You really must never be above joking.".split_whitespace();
-        let expected: Vec<_> = "You must be joking.".split_whitespace().collect();
-        let out: Vec<_> = evens(input).collect();
-        assert_eq!(out, expected);
     }
 }
 


### PR DESCRIPTION
In this exercise, it's easy to think you must work with values instead of their position. The README only states it in the title:

> ## 2. Choose even-positioned items from an iterator

And the first tests are about sequences of numbers, so it makes sense. I wasn't the only one who made that mistake:

https://stackoverflow.com/a/71145392
https://stackoverflow.com/questions/69032551/in-rust-how-can-i-restrict-a-generic-t-to-allow-modulus

I propose to change the order of tests, so the test with strings is first. This should be easy, and it doesn't add more tests.

