### PR TITLE
isogram: approaches: fix slug

### DIFF
--- a/exercises/practice/isogram/.approaches/config.json
+++ b/exercises/practice/isogram/.approaches/config.json
@@ -12,7 +12,7 @@
     },
     {
       "uuid": "ee6b5efb-7780-45f3-ae85-9a6ba4142e57",
-      "slug": "bitfied",
+      "slug": "bitfield",
       "title": "Bit field using a for loop",
       "blurb": "Use a bit field with a for loop to keep track of used letters.",
       "authors": ["bobahop"]


### PR DESCRIPTION
Commit e76c930fc907 added approaches for the isogram exercise, but there was a typo in a `slug` value. [There is](https://github.com/exercism/rust/tree/b71ba70dc621b32de8970946317094319f9a1738/exercises/practice/isogram/.approaches) indeed a `bitfield` subdirectory.

In this situation, it is likely that an upcoming version of configlet will produce an error like:

```console
$ configlet lint
[...]
A 'slug' value is 'bitfied', but there is no sibling directory with that name:
./exercises/practice/isogram/.approaches/config.json
```

---

Ping @bobahop / @ErikSchierboom 