### PR TITLE
Update documentation links with correct versions

### DIFF
--- a/exercises/concept/resistor-color/.docs/hints.md
+++ b/exercises/concept/resistor-color/.docs/hints.md
@@ -2,9 +2,9 @@
 
 ## General
 
-- Use the `enum-iterator` crate to be able to iterate over enums. Check out [docs](https://docs.rs/enum-iterator/1.1.1/enum_iterator/) to find out how.
+- Use the `enum-iterator` crate to be able to iterate over enums. Check out [docs](https://docs.rs/enum-iterator/1.2.0/enum_iterator/) to find out how.
 
-- Use the `int-enum` crate to be able to convert from int to enum. See the [docs](https://docs.rs/int-enum/0.4.0/int_enum/) for details.
+- Use the `int-enum` crate to be able to convert from int to enum. See the [docs](https://docs.rs/int-enum/0.5.0/int_enum/) for details.
 
 - The `Debug` trait is there because you'll likely need it.
 


### PR DESCRIPTION
In `Cargo.toml` the specified versions of `int-enum` and `enum-iterator` are `0.5.0` and `1.2.0`, but the documentations links were pointed to older versions. This patch fixes that.