### PR TITLE
armstrong-numbers: add larger testcases

### DIFF
--- a/exercises/practice/armstrong-numbers/tests/armstrong-numbers.rs
+++ b/exercises/practice/armstrong-numbers/tests/armstrong-numbers.rs
@@ -52,3 +52,27 @@ fn test_seven_digit_armstrong_number() {
 fn test_seven_digit_non_armstrong_number() {
     assert!(!is_armstrong_number(9_926_316))
 }
+
+#[test]
+#[ignore]
+fn test_nine_digit_armstrong_number() {
+    assert!(is_armstrong_number(912_985_153));
+}
+
+#[test]
+#[ignore]
+fn test_nine_digit_non_armstrong_number() {
+    assert!(!is_armstrong_number(999_999_999));
+}
+
+#[test]
+#[ignore]
+fn test_ten_digit_non_armstrong_number() {
+    assert!(!is_armstrong_number(3_999_999_999));
+}
+
+#[test]
+#[ignore]
+fn test_ten_digit_fake_armstrong_number() {
+    assert!(!is_armstrong_number(4_106_098_957));
+}


### PR DESCRIPTION
Add some extra Armstrong number tests for larger numbers. In particular, the ten-digit solutions can cause naive solutions to overflow; it might be reasonable to gate them behind a feature flag or bonus exercise.

The test case 4106098957 is particularly interesting: if the addition is done using `wrapping_add`, this number will appear as an Armstrong number, even though it really isn't. This is because the sum is equal to exactly 2^32 + 4106098957. This might be a worthwhile testcase to add to other languages too to check for overflow bugs. (Rust should panic in debug mode, but this will also catch folks who try to use wrapping_add to get around the panic).