### PR TITLE
Add test with alternative numberings of books

### DIFF
--- a/exercises/practice/book-store/tests/book-store.rs
+++ b/exercises/practice/book-store/tests/book-store.rs
@@ -85,6 +85,20 @@ fn test_two_groups_of_four_is_cheaper_than_group_of_five_plus_group_of_three() {
 
 #[test]
 #[ignore]
+/// Two groups of four is cheaper than group of five plus group of three
+/// with an alternative ordering of the books
+fn test_two_groups_of_four_alternative_ordering() {
+    process_total_case(
+        (
+            vec![1, 2, 3, 3, 4, 4, 5, 5],
+            vec![vec![1, 3, 4, 5], vec![2, 3, 4, 5]],
+        ),
+        5_120,
+    );
+}
+
+#[test]
+#[ignore]
 /// Group of four plus group of two is cheaper than two groups of three
 fn test_group_of_four_plus_group_of_two_is_cheaper_than_two_groups_of_three() {
     process_total_case(


### PR DESCRIPTION
Test the case "Two groups of four is cheaper than group of five plus group of three" with an alternative ordering of the books. The reason for adding this test is to test whether a "greedy" algorithm is used which not always lead to the correct result.