### PR TITLE
Add custom token to community contributions workflow

### DIFF
--- a/.github/workflows/pause-community-contributions.yml
+++ b/.github/workflows/pause-community-contributions.yml
@@ -10,7 +10,6 @@ on:
     paths-ignore:
       - 'exercises/*/*/.approaches/**'
       - 'exercises/*/*/.articles/**'
-  workflow_dispatch:
 
 permissions:
   issues: write
@@ -22,3 +21,5 @@ jobs:
     uses: exercism/github-actions/.github/workflows/community-contributions.yml@main
     with:
       forum_category: rust
+    secrets:
+      github_membership_token: ${{ secrets.COMMUNITY_CONTRIBUTIONS_WORKFLOW_TOKEN }}


### PR DESCRIPTION
The pause-community-contributions workflow makes a call to the
GitHub API to check if the person contributing is a member of
the organization.

However, this call currently fails if the contributor has set their
membership to 'private'.

This is because the default token provided for GitHub Actions only
has permissions for the repository, not for the organization. With
this token, we're not allowed to see private memberships.

We've created a custom, org-wide secret containing a personal token
that has permissions to read organization membership.

Unfortunately the secret cannot be accessed directly by the shared
workflow, it has to be passed in.

We updated the shared workflow to use the token, if it is provided,
and this PR updates the workflow in this repo to pass the secret.

Until this is merged, contributions from people with private membership
in the Exercism organization will be automatically closed.

Note that this PR also removes the workflow_dispatch which fails if
you try to use it.
