### PR TITLE
test: add unit test for sum-of-multiples

### DIFF
--- a/exercises/practice/sum-of-multiples/tests/sum-of-multiples.rs
+++ b/exercises/practice/sum-of-multiples/tests/sum-of-multiples.rs
@@ -85,6 +85,12 @@ fn the_only_multiple_of_0_is_0() {
 
 #[test]
 #[ignore]
+fn a_limit_of_0_always_returns_0() {
+    assert_eq!(0, sum_of_multiples(0, &[]))
+}
+
+#[test]
+#[ignore]
 fn the_factor_0_does_not_affect_the_sum_of_multiples_of_other_factors() {
     assert_eq!(3, sum_of_multiples(4, &[3, 0]))
 }


### PR DESCRIPTION
I'm learning Rust, and was wondering why my code was working when I realized `reduce` is meant to return `None` when the iterable is empty.

I did `(0..limit).reduce()` in my answer, but there was no test that passed `0` as the limit, so the case that would cause this error never occurred.

Since 0 is a valid u32 integer, perhaps we should have a test that expects a limit of 0 to return 0 rather than be undefined and untested?

Before adding this test, my solution passed all tests but would throw an error on 0.