### PR TITLE
Revert the configlet fmt on resistor-color

### DIFF
--- a/exercises/concept/resistor-color/.meta/config.json
+++ b/exercises/concept/resistor-color/.meta/config.json
@@ -1,8 +1,10 @@
 {
+  "blurb": "Convert a resistor band's color to its numeric representation and back, using external crates",
   "authors": [
     "still-flow",
     "coriolinus"
   ],
+  "contributors": [],
   "files": {
     "solution": [
       "src/lib.rs",
@@ -15,7 +17,7 @@
       ".meta/exemplar.rs"
     ]
   },
-  "blurb": "Convert a resistor band's color to its numeric representation and back, using external crates",
   "source": "Maud de Vries, Erik Schierboom",
-  "source_url": "https://github.com/exercism/problem-specifications/issues/1458"
+  "source_url": "https://github.com/exercism/problem-specifications/issues/1458",
+  "test_runner": false
 }


### PR DESCRIPTION
The configlet fmt command removed custom key-value pairs.
This adds the unformatted file back for resistor-color, which
looks like it is the only one where this happened.

See https://forum.exercism.org/t/online-test-timeout-with-recommended-solution/1574