### PR TITLE
hello-world: Show how to run the tests in the instructions

### DIFF
--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,0 +1,1 @@
+In the Rust track, tests are run using the command `cargo test`.


### PR DESCRIPTION
Hi, this is an update to the Hello World exercise of the Rust track. The track never introduces how to run tests to the user. It is described in the HELP file but I believe that file is meant for you to check when you get lost solving the exercise? It should continue to contain the more detailed information on how to run tests IMO but the basic command I believe should be a part of the README.