### PR TITLE
clippy: fix new warnings

### DIFF
--- a/exercises/practice/affine-cipher/tests/affine-cipher.rs
+++ b/exercises/practice/affine-cipher/tests/affine-cipher.rs
@@ -62,13 +62,9 @@ fn encode_with_a_not_coprime_to_m() {
     const EXPECTED_ERROR: AffineCipherError = AffineCipherError::NotCoprime(6);
     match encode("This is a test.", 6, 17) {
         Err(EXPECTED_ERROR) => (),
-        Err(err) => panic!(
-            "Incorrect error: expected: {:?}, actual: {:?}.",
-            EXPECTED_ERROR, err
-        ),
+        Err(err) => panic!("Incorrect error: expected: {EXPECTED_ERROR:?}, actual: {err:?}."),
         Ok(r) => panic!(
-            "Cannot encode/decode when a is coprime to m: expected: {:?}, actual: {:?}.",
-            EXPECTED_ERROR, r
+            "Cannot encode/decode when a is coprime to m: expected: {EXPECTED_ERROR:?}, actual: {r:?}.",
         ),
     }
 }
@@ -134,13 +130,9 @@ fn decode_with_a_not_coprime_to_m() {
     const EXPECTED_ERROR: AffineCipherError = AffineCipherError::NotCoprime(13);
     match decode("Test", 13, 11) {
         Err(EXPECTED_ERROR) => (),
-        Err(e) => panic!(
-            "Incorrect error: expected: {:?}, actual: {:?}.",
-            EXPECTED_ERROR, e
-        ),
+        Err(e) => panic!("Incorrect error: expected: {EXPECTED_ERROR:?}, actual: {e:?}."),
         Ok(r) => panic!(
-            "Cannot encode/decode when a is coprime to m: expected: {:?}, actual: {:?}.",
-            EXPECTED_ERROR, r
+            "Cannot encode/decode when a is coprime to m: expected: {EXPECTED_ERROR:?}, actual: {r:?}.",
         ),
     }
 }

--- a/exercises/practice/allergies/tests/allergies.rs
+++ b/exercises/practice/allergies/tests/allergies.rs
@@ -3,17 +3,13 @@ use allergies::*;
 fn compare_allergy_vectors(expected: &[Allergen], actual: &[Allergen]) {
     for element in expected {
         if !actual.contains(element) {
-            panic!(
-                "Allergen missing\n  {:?} should be in {:?}",
-                element, actual
-            );
+            panic!("Allergen missing\n  {element:?} should be in {actual:?}");
         }
     }
 
     if actual.len() != expected.len() {
         panic!(
-            "Allergy vectors are of different lengths\n  expected {:?}\n  got {:?}",
-            expected, actual
+            "Allergy vectors are of different lengths\n  expected {expected:?}\n  got {actual:?}",
         );
     }
 }

--- a/exercises/practice/circular-buffer/src/lib.rs
+++ b/exercises/practice/circular-buffer/src/lib.rs
@@ -16,7 +16,7 @@ impl<T> CircularBuffer<T> {
             "Construct a new CircularBuffer with the capacity to hold {}.",
             match capacity {
                 1 => "1 element".to_string(),
-                _ => format!("{} elements", capacity),
+                _ => format!("{capacity} elements"),
             }
         );
     }

--- a/exercises/practice/dominoes/tests/dominoes.rs
+++ b/exercises/practice/dominoes/tests/dominoes.rs
@@ -67,16 +67,15 @@ fn check(input: &[Domino]) -> CheckResult {
 fn assert_correct(input: &[Domino]) {
     match check(input) {
         Correct => (),
-        GotInvalid => panic!("Unexpectedly got invalid on input {:?}", input),
-        ChainingFailure(output) => panic!(
-            "Chaining failure for input {:?}, output {:?}",
-            input, output
-        ),
+        GotInvalid => panic!("Unexpectedly got invalid on input {input:?}"),
+        ChainingFailure(output) => {
+            panic!("Chaining failure for input {input:?}, output {output:?}")
+        }
         LengthMismatch(output) => {
-            panic!("Length mismatch for input {:?}, output {:?}", input, output)
+            panic!("Length mismatch for input {input:?}, output {output:?}")
         }
         DominoMismatch(output) => {
-            panic!("Domino mismatch for input {:?}, output {:?}", input, output)
+            panic!("Domino mismatch for input {input:?}, output {output:?}")
         }
     }
 }

--- a/exercises/practice/parallel-letter-frequency/src/lib.rs
+++ b/exercises/practice/parallel-letter-frequency/src/lib.rs
@@ -6,7 +6,7 @@ pub fn frequency(input: &[&str], worker_count: usize) -> HashMap<char, usize> {
         input,
         match worker_count {
             1 => "1 worker".to_string(),
-            _ => format!("{} workers", worker_count),
+            _ => format!("{worker_count} workers"),
         }
     );
 }

--- a/exercises/practice/poker/tests/poker.rs
+++ b/exercises/practice/poker/tests/poker.rs
@@ -14,7 +14,7 @@ fn hs_from<'a>(input: &[&'a str]) -> HashSet<&'a str> {
 ///
 /// Note that the output can be in any order. Here, we use a HashSet to
 /// abstract away the order of outputs.
-fn test<'a, 'b>(input: &[&'a str], expected: &[&'b str]) {
+fn test(input: &[& str], expected: &[& str]) {
     assert_eq!(hs_from(&winning_hands(input)), hs_from(expected))
 }
 

--- a/exercises/practice/react/tests/react.rs
+++ b/exercises/practice/react/tests/react.rs
@@ -155,8 +155,7 @@ impl CallbackRecorder {
         assert_eq!(
             self.value.replace(Some(v)),
             None,
-            "Callback was called too many times; can't be called with {}",
-            v
+            "Callback was called too many times; can't be called with {v}"
         );
     }
 }

--- a/exercises/practice/simple-linked-list/tests/simple-linked-list.rs
+++ b/exercises/practice/simple-linked-list/tests/simple-linked-list.rs
@@ -38,24 +38,19 @@ fn test_is_empty() {
             list.push(i);
             assert!(
                 !list.is_empty(),
-                "List was empty after having inserted {}/{} elements",
-                i,
-                inserts
+                "List was empty after having inserted {i}/{inserts} elements"
             );
         }
         for i in 0..inserts {
             assert!(
                 !list.is_empty(),
-                "List was empty before removing {}/{} elements",
-                i,
-                inserts
+                "List was empty before removing {i}/{inserts} elements"
             );
             list.pop();
         }
         assert!(
             list.is_empty(),
-            "List wasn't empty after having removed {} elements",
-            inserts
+            "List wasn't empty after having removed {inserts} elements",
         );
     }
 }

--- a/exercises/practice/space-age/tests/space-age.rs
+++ b/exercises/practice/space-age/tests/space-age.rs
@@ -4,10 +4,7 @@ fn assert_in_delta(expected: f64, actual: f64) {
     let diff: f64 = (expected - actual).abs();
     let delta: f64 = 0.01;
     if diff > delta {
-        panic!(
-            "Your result of {} should be within {} of the expected result {}",
-            actual, delta, expected
-        )
+        panic!("Your result of {actual} should be within {delta} of the expected result {expected}")
     }
 }
 


### PR DESCRIPTION
Most of the warnings relate to idiomatic format strings. I think these warnings were introduced with Rust 1.67.

```
variables can be used directly in the `format!` string
for further information visit
https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
`#[warn(clippy::uninlined_format_args)]` on by default
```

There is one other warning I fixed about lifetimes that can be elided.

There are still a couple warnings about a `new` function without a default implementation. I didn't do anything about those because it seemed unclear to me what the best thing to do is.