### PR TITLE
fix new clippy and shellcheck errors

### DIFF
--- a/_test/count_ignores.sh
+++ b/_test/count_ignores.sh
@@ -25,6 +25,12 @@ for e in "$repo"/exercises/*/*; do
       done
       want_ignores=$((total_tests - 1))
       if [ "$total_ignores" != "$want_ignores" ]; then
+        # ShellCheck wants us to use printf,
+        # but there are no other uses of printf in this repo,
+        # so printf hasn't been tested to work yet.
+        # (We would not be opposed to using printf and removing this disable;
+        # we just haven't tested it to confirm it works yet).
+        # shellcheck disable=SC2028
         echo "\033[1;31m$e: Has $total_tests tests and $total_ignores ignores (should be $want_ignores)\033[0m"
         exitcode=1
       fi

--- a/bin/test-exercise
+++ b/bin/test-exercise
@@ -92,7 +92,7 @@ done
 # run tests from within exercise directory
 # (use subshell so we auto-reset to current pwd after)
 (
-   cd $exercise
+   cd "$exercise"
    if [ -n "$CLIPPY" ]; then
      # Consider any Clippy to be an error in tests only.
      # For now, not the example solutions since they have many Clippy warnings,

--- a/concepts/destructuring/about.md
+++ b/concepts/destructuring/about.md
@@ -32,7 +32,7 @@ struct ArabianNights {
 let teller = ArabianNights { name: "Scheherazade".into(), stories: 1001 };
 {
     let ArabianNights { name, stories } = teller;
-    println!("{} told {} stories", name, stories);
+    println!("{name} told {stories} stories");
 }
 ```
 
@@ -42,7 +42,7 @@ The `..` operator can be used to ignore some fields when destructuring:
 
 ```rust
 let ArabianNights { name, .. } = teller;
-println!("{} survived by her wits", name);
+println!("{name} survived by her wits");
 ```
 
 ## Conditional Destructuring
@@ -51,6 +51,6 @@ Destructuring structs and tuples is infallible. However, enums can also be destr
 
 ```rust
 if let Some(foo) = foo {
-    println!("{:?}", foo);
+    println!("{foo:?}");
 }
 ```

--- a/concepts/fold/about.md
+++ b/concepts/fold/about.md
@@ -12,7 +12,7 @@ Once the iterator drains, the final value of the accumulator is returned.
 ```rust
 pub fn main() {
     let even_sum = (1..=10).fold(0, |acc, num| if num % 2 == 0 { acc + num } else { acc });
-    println!("{:?}", even_sum);
+    println!("{even_sum:?}");
 }
 ```
 
@@ -39,7 +39,7 @@ pub fn giant_grunts(initial: char) -> String {
 
 pub fn main() {
     let song = giant_grunts('F');
-    println!("{:?}", song);
+    println!("{song:?}");
 }
 ```
 

--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -23,7 +23,7 @@ In the following example the function takes in one parameter of type `i32`, bind
 
 ```rust
 fn print_integer(value: i32) {
-    println!("{:?}", value);
+    println!("{value:?}");
 }
 ```
 

--- a/concepts/hashmap/about.md
+++ b/concepts/hashmap/about.md
@@ -25,7 +25,7 @@ Other than the indexing operator, there are two other ways of accessing values s
 
 ```rust
 if let Some(blue_score) = scores.get("Blue") {
-    println!("Blue scored: {} \n", blue_score);
+    println!("Blue scored: {blue_score} \n");
 }
 ```
 
@@ -41,7 +41,7 @@ for vote in votes {
     *count += 1;
 }
 
-println!("{:#?}", vote_counter);
+println!("{vote_counter:#?}");
 ```
 
 This API makes certain common access patterns very convenient; it has an entire concept (Entry API) dedicated to it.

--- a/concepts/iterators/introduction.md
+++ b/concepts/iterators/introduction.md
@@ -23,6 +23,6 @@ assert_eq!(None, iter.next());
 
 // Loop over iterators with built-in methods, such as `map` and `collect`
 let w: HashMap<_, _> = v.into_iter().map(|x| (x, x + 1)).collect();
-println!("{:?}", w);
+println!("{w:?}");
 // => {1: 2, 0: 1, 2: 3}
 ```

--- a/concepts/loops/about.md
+++ b/concepts/loops/about.md
@@ -36,7 +36,7 @@ fn main() {
     let a = [10, 20, 30, 40, 50];
 
     for x in a {
-        println!("the value is: {}", x);
+        println!("the value is: {x}");
     }
 }
 ```
@@ -46,7 +46,7 @@ Ranges are iterators too, which makes iterating through them with the `for` loop
 ```rust
 fn main() {
     for x in 0..10 {
-        println!("the value is: {}", x);
+        println!("the value is: {x}");
     }
 }
 ```

--- a/concepts/match-basics/about.md
+++ b/concepts/match-basics/about.md
@@ -36,7 +36,7 @@ fn ordinal(n: u32) -> String {
         3 => "rd",
         _ => "th",
     };
-    format!("{}{}", n, ordinal)
+    format!("{n}{ordinal}")
 }
 ```
 
@@ -105,7 +105,7 @@ impl<E: std::fmt::Display> OrLog for Result<(), E> {
             // discard Ok results
             Ok(()) => {},
             // log errors
-            Err(err) => println!("ERROR: {}", err),
+            Err(err) => println!("ERROR: {err}"),
         }
     }
 }

--- a/concepts/references/about.md
+++ b/concepts/references/about.md
@@ -7,13 +7,13 @@ For example:
 fn log(msg: String) { // msg takes ownership of the value passed to it
     let formatted_datetime = String::new();
     // code  to format current datetime snipped
-    println!("{} at {}", msg, formatted_datetime);
+    println!("{msg} at {formatted_datetime}");
 } // msg is dropped here
 
 pub fn main() {
     let my_string = "Something happened".to_string();
     log(my_string); // passing my_string transfers ownership of its value to msg
-    //println!("{:?}", my_string); // uncommenting this line will error because my_string's value has been dropped while owned by msg
+    //println!("{my_string:?}"); // uncommenting this line will error because my_string's value has been dropped while owned by msg
 }
 ```
 
@@ -30,13 +30,13 @@ for the duration of that function.
 fn log(msg: &String) { //msg is defined as a reference with an ampersand
     let formatted_datetime: String;
     // code  to format current datetime snipped
-    println!("{} at {}", msg, formatted_datetime);
+    println!("{msg} at {formatted_datetime}");
 }
 
 pub fn main() {
     let my_string = "Something happened".to_string();
     log(&my_string); // my_string is passed as a reference with an ampersand
-    println!("{:?}", my_string);
+    println!("{my_string:?}");
 }
 ```
 
@@ -119,9 +119,9 @@ fn add_five(counter: &mut i32) { //counter is defined as a mutable reference
 
 pub fn main() {
     let mut my_count = 0; // my_count must be defined as mutable
-    println!("{:?}", my_count);
+    println!("{my_count:?}");
     add_five(&mut my_count); // my_count is passed as a mutable reference
-    println!("{:?}", my_count);
+    println!("{my_count:?}");
 }
 ```
 
@@ -138,11 +138,11 @@ fn add_five(counter: &mut i32) {
 
 pub fn main() {
     let mut my_count = 0;
-    println!("{:?}", my_count);
+    println!("{my_count:?}");
     let mut my_count2 = &mut my_count; // first mutable reference to my_count
     add_five(&mut my_count); // this errors because my_count's mutable borrow by my_count2 will be used on the next line
     add_five(my_count2);
-    println!("{:?}", my_count);
+    println!("{my_count:?}");
 }
 ```
 
@@ -155,11 +155,11 @@ fn add_five(counter: &mut i32) {
 
 pub fn main() {
     let mut my_count = 0;
-    println!("{:?}", my_count);
+    println!("{my_count:?}");
     let mut my_count2 = &mut my_count; // first mutable reference to my_count
     add_five(my_count2); // my_count2's borrow of my_count is not used afer this point
     add_five(&mut my_count); // compiler allows second mutable borrow of my_count
-    println!("{:?}", my_count); // because it does not conflict with first mutable borrow
+    println!("{my_count:?}"); // because it does not conflict with first mutable borrow
 }
 ```
 

--- a/concepts/string-slices/about.md
+++ b/concepts/string-slices/about.md
@@ -41,7 +41,7 @@ pub fn main() {
 }
 
 fn say_hi(phrase: &String) {
-    println!("{:?}", phrase);
+    println!("{phrase:?}");
 }
 
 // mismatched types
@@ -58,7 +58,7 @@ pub fn main() {
 }
 
 fn say_hi(phrase: &str) {
-    println!("{:?}", phrase);
+    println!("{phrase:?}");
 }
 ```
 

--- a/concepts/string-vs-str/about.md
+++ b/concepts/string-vs-str/about.md
@@ -39,7 +39,7 @@ println!("n_chars = {}", n_chars);             // 25
 println!("example.len() = {}", example.len()); // 27
 
 println!("final char: {}", example.chars().nth(n_chars-1).unwrap()); // ❤
-println!("final byte: {}", final_byte);                              // 164
+println!("final byte: {final_byte}");                                // 164
 println!("char of final byte: {}", final_byte as char);              // ¤
 ```
 

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -9,7 +9,7 @@ A String can be created using the `String::new()` or `String::from()` associated
 ```rust
 let my_string = String::from("The answer is");
 let answer = 42.to_string();
-println!("{} {}", my_string, answer);
+println!("{my_string} {answer}");
 ```
 
 ### The `format!` Macro
@@ -45,7 +45,7 @@ fn main() {
     let s3 = String::from("toe");
 
     let s = s1 + "-" + &s2 + "-" + &s3;
-    println!("{}", s);
+    println!("{s}");
 }
 ```
 
@@ -56,10 +56,10 @@ Since Rust strings are UTF-8 encoded individual characters are not all of the sa
 ```rust
 let alphabet: String = ('a'..='z').collect();
 for c in alphabet.chars() {
-    println!("{}", c);
+    println!("{c}");
 }
 let j = alphabet.chars().nth(9);
-println!("{:?}", j); // prints Some('j')
+println!("{j:?}"); // prints Some('j')
 ```
 
 ## More

--- a/exercises/concept/assembly-line/src/lib.rs
+++ b/exercises/concept/assembly-line/src/lib.rs
@@ -1,7 +1,3 @@
-// This stub file contains items that aren't used yet; feel free to remove this module attribute
-// to enable stricter warnings.
-#![allow(unused)]
-
 pub fn production_rate_per_hour(speed: u8) -> f64 {
     unimplemented!("calculate hourly production rate at speed: {}", speed)
 }

--- a/exercises/concept/assembly-line/src/lib.rs
+++ b/exercises/concept/assembly-line/src/lib.rs
@@ -1,7 +1,7 @@
 pub fn production_rate_per_hour(speed: u8) -> f64 {
-    unimplemented!("calculate hourly production rate at speed: {}", speed)
+    unimplemented!("calculate hourly production rate at speed: {speed}")
 }
 
 pub fn working_items_per_minute(speed: u8) -> u32 {
-    unimplemented!("calculate the amount of working items at speed: {}", speed)
+    unimplemented!("calculate the amount of working items at speed: {speed}")
 }

--- a/exercises/concept/csv-builder/src/lib.rs
+++ b/exercises/concept/csv-builder/src/lib.rs
@@ -14,10 +14,7 @@ impl CsvRecordBuilder {
 
     /// Adds an item to the list separated by a space and a comma.
     pub fn add(&mut self, val: &str) {
-        unimplemented!(
-            "implement the `CsvRecordBuilder::add` method, adding {}",
-            val
-        )
+        unimplemented!("implement the `CsvRecordBuilder::add` method, adding {val}")
     }
 
     /// Consumes the builder and returns the comma separated list

--- a/exercises/concept/lucians-luscious-lasagna/src/lib.rs
+++ b/exercises/concept/lucians-luscious-lasagna/src/lib.rs
@@ -4,22 +4,16 @@ pub fn expected_minutes_in_oven() -> i32 {
 
 pub fn remaining_minutes_in_oven(actual_minutes_in_oven: i32) -> i32 {
     unimplemented!(
-        "calculate remaining minutes in oven given actual minutes in oven: {}",
-        actual_minutes_in_oven
+        "calculate remaining minutes in oven given actual minutes in oven: {actual_minutes_in_oven}"
     )
 }
 
 pub fn preparation_time_in_minutes(number_of_layers: i32) -> i32 {
-    unimplemented!(
-        "calculate preparation time in minutes for number of layers: {}",
-        number_of_layers
-    )
+    unimplemented!("calculate preparation time in minutes for number of layers: {number_of_layers}")
 }
 
 pub fn elapsed_time_in_minutes(number_of_layers: i32, actual_minutes_in_oven: i32) -> i32 {
     unimplemented!(
-        "calculate elapsed time in minutes for number of layers {} and actual minutes in oven {}",
-        number_of_layers,
-        actual_minutes_in_oven
+        "calculate elapsed time in minutes for number of layers {number_of_layers} and actual minutes in oven {actual_minutes_in_oven}"
     )
 }

--- a/exercises/concept/lucians-luscious-lasagna/src/lib.rs
+++ b/exercises/concept/lucians-luscious-lasagna/src/lib.rs
@@ -1,7 +1,3 @@
-// This stub file contains items that aren't used yet; feel free to remove this module attribute
-// to enable stricter warnings.
-#![allow(unused)]
-
 pub fn expected_minutes_in_oven() -> i32 {
     unimplemented!("return expected minutes in the oven")
 }

--- a/exercises/concept/resistor-color/.meta/exemplar.rs
+++ b/exercises/concept/resistor-color/.meta/exemplar.rs
@@ -22,7 +22,7 @@ pub fn color_to_value(color: ResistorColor) -> usize {
 
 pub fn value_to_color_string(value: usize) -> String {
     ResistorColor::from_int(value)
-        .map(|color| format!("{:?}", color))
+        .map(|color| format!("{color:?}"))
         .unwrap_or_else(|_| "value out of range".into())
 }
 

--- a/exercises/concept/resistor-color/src/lib.rs
+++ b/exercises/concept/resistor-color/src/lib.rs
@@ -12,8 +12,8 @@ pub enum ResistorColor {
     Yellow,
 }
 
-pub fn color_to_value(_color: ResistorColor) -> u32 {
-    unimplemented!("convert a color into a numerical representation")
+pub fn color_to_value(color: ResistorColor) -> u32 {
+    unimplemented!("convert color {color:?} into a numerical representation")
 }
 
 pub fn value_to_color_string(value: u32) -> String {

--- a/exercises/concept/resistor-color/src/lib.rs
+++ b/exercises/concept/resistor-color/src/lib.rs
@@ -17,10 +17,7 @@ pub fn color_to_value(color: ResistorColor) -> u32 {
 }
 
 pub fn value_to_color_string(value: u32) -> String {
-    unimplemented!(
-        "convert the value {} into a string representation of color",
-        value
-    )
+    unimplemented!("convert the value {value} into a string representation of color")
 }
 
 pub fn colors() -> Vec<ResistorColor> {

--- a/exercises/concept/role-playing-game/src/lib.rs
+++ b/exercises/concept/role-playing-game/src/lib.rs
@@ -1,7 +1,3 @@
-// This stub file contains items that aren't used yet; feel free to remove this module attribute
-// to enable stricter warnings.
-#![allow(unused)]
-
 pub struct Player {
     pub health: u32,
     pub mana: Option<u32>,

--- a/exercises/concept/role-playing-game/src/lib.rs
+++ b/exercises/concept/role-playing-game/src/lib.rs
@@ -10,6 +10,6 @@ impl Player {
     }
 
     pub fn cast_spell(&mut self, mana_cost: u32) -> u32 {
-        unimplemented!("Cast a spell of cost {}", mana_cost)
+        unimplemented!("Cast a spell of cost {mana_cost}")
     }
 }

--- a/exercises/concept/rpn-calculator/.docs/instructions.md
+++ b/exercises/concept/rpn-calculator/.docs/instructions.md
@@ -106,8 +106,7 @@ pub enum CalculatorInput {
 
 pub fn evaluate(inputs: &[CalculatorInput]) -> Option<i32> {
     unimplemented!(
-        "Given the inputs: {:?}, evaluate them as though they were a Reverse Polish notation expression",
-        inputs,
+        "Given the inputs: {inputs:?}, evaluate them as though they were a Reverse Polish notation expression"
     );
 }
 ```

--- a/exercises/concept/rpn-calculator/.docs/instructions.md
+++ b/exercises/concept/rpn-calculator/.docs/instructions.md
@@ -106,8 +106,8 @@ pub enum CalculatorInput {
 
 pub fn evaluate(inputs: &[CalculatorInput]) -> Option<i32> {
     unimplemented!(
-		"Given the inputs: {:?}, evaluate them as though they were a Reverse Polish notation expression",
-		inputs,
-	);
+        "Given the inputs: {:?}, evaluate them as though they were a Reverse Polish notation expression",
+        inputs,
+    );
 }
 ```

--- a/exercises/concept/rpn-calculator/src/lib.rs
+++ b/exercises/concept/rpn-calculator/src/lib.rs
@@ -9,7 +9,7 @@ pub enum CalculatorInput {
 
 pub fn evaluate(inputs: &[CalculatorInput]) -> Option<i32> {
     unimplemented!(
-		"Given the inputs: {:?}, evaluate them as though they were a Reverse Polish notation expression",
-		inputs,
-	);
+        "Given the inputs: {:?}, evaluate them as though they were a Reverse Polish notation expression",
+        inputs,
+    );
 }

--- a/exercises/concept/rpn-calculator/src/lib.rs
+++ b/exercises/concept/rpn-calculator/src/lib.rs
@@ -9,7 +9,6 @@ pub enum CalculatorInput {
 
 pub fn evaluate(inputs: &[CalculatorInput]) -> Option<i32> {
     unimplemented!(
-        "Given the inputs: {:?}, evaluate them as though they were a Reverse Polish notation expression",
-        inputs,
+        "Given the inputs: {inputs:?}, evaluate them as though they were a Reverse Polish notation expression"
     );
 }

--- a/exercises/concept/semi-structured-logs/.meta/exemplar.rs
+++ b/exercises/concept/semi-structured-logs/.meta/exemplar.rs
@@ -10,15 +10,15 @@ pub fn log(level: LogLevel, message: &str) -> String {
         LogLevel::Info => info(message),
         LogLevel::Warning => warn(message),
         LogLevel::Error => error(message),
-        LogLevel::Debug => format!("[DEBUG]: {}", message),
+        LogLevel::Debug => format!("[DEBUG]: {message}"),
     }
 }
 pub fn info(message: &str) -> String {
-    format!("[INFO]: {}", message)
+    format!("[INFO]: {message}")
 }
 pub fn warn(message: &str) -> String {
-    format!("[WARNING]: {}", message)
+    format!("[WARNING]: {message}")
 }
 pub fn error(message: &str) -> String {
-    format!("[ERROR]: {}", message)
+    format!("[ERROR]: {message}")
 }

--- a/exercises/concept/short-fibonacci/src/lib.rs
+++ b/exercises/concept/short-fibonacci/src/lib.rs
@@ -7,7 +7,7 @@ pub fn create_empty() -> Vec<u8> {
 ///
 /// Applications often use buffers when serializing data to send over the network.
 pub fn create_buffer(count: usize) -> Vec<u8> {
-    unimplemented!("create a zeroized buffer of {} bytes", count)
+    unimplemented!("create a zeroized buffer of {count} bytes")
 }
 
 /// Create a vector containing the first five elements of the Fibonacci sequence.

--- a/exercises/practice/accumulate/src/lib.rs
+++ b/exercises/practice/accumulate/src/lib.rs
@@ -1,4 +1,4 @@
 /// What should the type of _function be?
 pub fn map(input: Vec<i32>, _function: ???) -> Vec<i32> {
-    unimplemented!("Transform input vector {:?} using passed function", input);
+    unimplemented!("Transform input vector {input:?} using passed function");
 }

--- a/exercises/practice/acronym/src/lib.rs
+++ b/exercises/practice/acronym/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn abbreviate(phrase: &str) -> String {
-    unimplemented!("Given the phrase '{}', return its acronym", phrase);
+    unimplemented!("Given the phrase '{phrase}', return its acronym");
 }

--- a/exercises/practice/affine-cipher/src/lib.rs
+++ b/exercises/practice/affine-cipher/src/lib.rs
@@ -8,11 +8,11 @@ pub enum AffineCipherError {
 /// Encodes the plaintext using the affine cipher with key (`a`, `b`). Note that, rather than
 /// returning a return code, the more common convention in Rust is to return a `Result`.
 pub fn encode(plaintext: &str, a: i32, b: i32) -> Result<String, AffineCipherError> {
-    unimplemented!("Encode {} with the key ({}, {})", plaintext, a, b);
+    unimplemented!("Encode {plaintext} with the key ({a}, {b})");
 }
 
 /// Decodes the ciphertext using the affine cipher with key (`a`, `b`). Note that, rather than
 /// returning a return code, the more common convention in Rust is to return a `Result`.
 pub fn decode(ciphertext: &str, a: i32, b: i32) -> Result<String, AffineCipherError> {
-    unimplemented!("Decode {} with the key ({}, {})", ciphertext, a, b);
+    unimplemented!("Decode {ciphertext} with the key ({a}, {b})");
 }

--- a/exercises/practice/affine-cipher/tests/affine-cipher.rs
+++ b/exercises/practice/affine-cipher/tests/affine-cipher.rs
@@ -62,13 +62,9 @@ fn encode_with_a_not_coprime_to_m() {
     const EXPECTED_ERROR: AffineCipherError = AffineCipherError::NotCoprime(6);
     match encode("This is a test.", 6, 17) {
         Err(EXPECTED_ERROR) => (),
-        Err(err) => panic!(
-            "Incorrect error: expected: {:?}, actual: {:?}.",
-            EXPECTED_ERROR, err
-        ),
+        Err(err) => panic!("Incorrect error: expected: {EXPECTED_ERROR:?}, actual: {err:?}."),
         Ok(r) => panic!(
-            "Cannot encode/decode when a is coprime to m: expected: {:?}, actual: {:?}.",
-            EXPECTED_ERROR, r
+            "Cannot encode/decode when a is coprime to m: expected: {EXPECTED_ERROR:?}, actual: {r:?}."
         ),
     }
 }
@@ -134,13 +130,9 @@ fn decode_with_a_not_coprime_to_m() {
     const EXPECTED_ERROR: AffineCipherError = AffineCipherError::NotCoprime(13);
     match decode("Test", 13, 11) {
         Err(EXPECTED_ERROR) => (),
-        Err(e) => panic!(
-            "Incorrect error: expected: {:?}, actual: {:?}.",
-            EXPECTED_ERROR, e
-        ),
+        Err(e) => panic!("Incorrect error: expected: {EXPECTED_ERROR:?}, actual: {e:?}."),
         Ok(r) => panic!(
-            "Cannot encode/decode when a is coprime to m: expected: {:?}, actual: {:?}.",
-            EXPECTED_ERROR, r
+            "Cannot encode/decode when a is coprime to m: expected: {EXPECTED_ERROR:?}, actual: {r:?}."
         ),
     }
 }

--- a/exercises/practice/all-your-base/src/lib.rs
+++ b/exercises/practice/all-your-base/src/lib.rs
@@ -37,10 +37,5 @@ pub enum Error {
 ///    However, your function must be able to process input with leading 0 digits.
 ///
 pub fn convert(number: &[u32], from_base: u32, to_base: u32) -> Result<Vec<u32>, Error> {
-    unimplemented!(
-        "Convert {:?} from base {} to base {}",
-        number,
-        from_base,
-        to_base
-    )
+    unimplemented!("Convert {number:?} from base {from_base} to base {to_base}")
 }

--- a/exercises/practice/allergies/src/lib.rs
+++ b/exercises/practice/allergies/src/lib.rs
@@ -14,17 +14,11 @@ pub enum Allergen {
 
 impl Allergies {
     pub fn new(score: u32) -> Self {
-        unimplemented!(
-            "Given the '{}' score, construct a new Allergies struct.",
-            score
-        );
+        unimplemented!("Given the '{score}' score, construct a new Allergies struct.");
     }
 
     pub fn is_allergic_to(&self, allergen: &Allergen) -> bool {
-        unimplemented!(
-            "Determine if the patient is allergic to the '{:?}' allergen.",
-            allergen
-        );
+        unimplemented!("Determine if the patient is allergic to the '{allergen:?}' allergen.");
     }
 
     pub fn allergies(&self) -> Vec<Allergen> {

--- a/exercises/practice/allergies/tests/allergies.rs
+++ b/exercises/practice/allergies/tests/allergies.rs
@@ -3,17 +3,13 @@ use allergies::*;
 fn compare_allergy_vectors(expected: &[Allergen], actual: &[Allergen]) {
     for element in expected {
         if !actual.contains(element) {
-            panic!(
-                "Allergen missing\n  {:?} should be in {:?}",
-                element, actual
-            );
+            panic!("Allergen missing\n  {element:?} should be in {actual:?}");
         }
     }
 
     if actual.len() != expected.len() {
         panic!(
-            "Allergy vectors are of different lengths\n  expected {:?}\n  got {:?}",
-            expected, actual
+            "Allergy vectors are of different lengths\n  expected {expected:?}\n  got {actual:?}"
         );
     }
 }

--- a/exercises/practice/alphametics/src/lib.rs
+++ b/exercises/practice/alphametics/src/lib.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
 
 pub fn solve(input: &str) -> Option<HashMap<char, u8>> {
-    unimplemented!("Solve the alphametic {:?}", input)
+    unimplemented!("Solve the alphametic {input:?}")
 }

--- a/exercises/practice/anagram/src/lib.rs
+++ b/exercises/practice/anagram/src/lib.rs
@@ -2,8 +2,6 @@ use std::collections::HashSet;
 
 pub fn anagrams_for<'a>(word: &str, possible_anagrams: &[&str]) -> HashSet<&'a str> {
     unimplemented!(
-        "For the '{}' word find anagrams among the following words: {:?}",
-        word,
-        possible_anagrams
+        "For the '{word}' word find anagrams among the following words: {possible_anagrams:?}"
     );
 }

--- a/exercises/practice/armstrong-numbers/src/lib.rs
+++ b/exercises/practice/armstrong-numbers/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn is_armstrong_number(num: u32) -> bool {
-    unimplemented!("true if {} is an armstrong number", num)
+    unimplemented!("true if {num} is an armstrong number")
 }

--- a/exercises/practice/atbash-cipher/src/lib.rs
+++ b/exercises/practice/atbash-cipher/src/lib.rs
@@ -1,9 +1,9 @@
 /// "Encipher" with the Atbash cipher.
 pub fn encode(plain: &str) -> String {
-    unimplemented!("Encoding of {:?} in Atbash cipher.", plain);
+    unimplemented!("Encoding of {plain:?} in Atbash cipher.");
 }
 
 /// "Decipher" with the Atbash cipher.
 pub fn decode(cipher: &str) -> String {
-    unimplemented!("Decoding of {:?} in Atbash cipher.", cipher);
+    unimplemented!("Decoding of {cipher:?} in Atbash cipher.");
 }

--- a/exercises/practice/beer-song/src/lib.rs
+++ b/exercises/practice/beer-song/src/lib.rs
@@ -1,7 +1,7 @@
 pub fn verse(n: u32) -> String {
-    unimplemented!("emit verse {}", n)
+    unimplemented!("emit verse {n}")
 }
 
 pub fn sing(start: u32, end: u32) -> String {
-    unimplemented!("sing verses {} to {}, inclusive", start, end)
+    unimplemented!("sing verses {start} to {end}, inclusive")
 }

--- a/exercises/practice/binary-search/src/lib.rs
+++ b/exercises/practice/binary-search/src/lib.rs
@@ -1,7 +1,5 @@
 pub fn find(array: &[i32], key: i32) -> Option<usize> {
     unimplemented!(
-        "Using the binary search algorithm, find the element '{}' in the array '{:?}' and return its index.",
-        key,
-        array
+        "Using the binary search algorithm, find the element '{key}' in the array '{array:?}' and return its index."
     );
 }

--- a/exercises/practice/bob/src/lib.rs
+++ b/exercises/practice/bob/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn reply(message: &str) -> &str {
-    unimplemented!("have Bob reply to the incoming message: {}", message)
+    unimplemented!("have Bob reply to the incoming message: {message}")
 }

--- a/exercises/practice/book-store/src/lib.rs
+++ b/exercises/practice/book-store/src/lib.rs
@@ -1,6 +1,3 @@
 pub fn lowest_price(books: &[u32]) -> u32 {
-    unimplemented!(
-        "Find the lowest price of the bookbasket with books {:?}",
-        books
-    )
+    unimplemented!("Find the lowest price of the bookbasket with books {books:?}")
 }

--- a/exercises/practice/bowling/src/lib.rs
+++ b/exercises/practice/bowling/src/lib.rs
@@ -12,7 +12,7 @@ impl BowlingGame {
     }
 
     pub fn roll(&mut self, pins: u16) -> Result<(), Error> {
-        unimplemented!("Record that {} pins have been scored", pins);
+        unimplemented!("Record that {pins} pins have been scored");
     }
 
     pub fn score(&self) -> Option<u16> {

--- a/exercises/practice/circular-buffer/src/lib.rs
+++ b/exercises/practice/circular-buffer/src/lib.rs
@@ -16,7 +16,7 @@ impl<T> CircularBuffer<T> {
             "Construct a new CircularBuffer with the capacity to hold {}.",
             match capacity {
                 1 => "1 element".to_string(),
-                _ => format!("{} elements", capacity),
+                _ => format!("{capacity} elements"),
             }
         );
     }

--- a/exercises/practice/clock/src/lib.rs
+++ b/exercises/practice/clock/src/lib.rs
@@ -2,14 +2,10 @@ pub struct Clock;
 
 impl Clock {
     pub fn new(hours: i32, minutes: i32) -> Self {
-        unimplemented!(
-            "Construct a new Clock from {} hours and {} minutes",
-            hours,
-            minutes
-        );
+        unimplemented!("Construct a new Clock from {hours} hours and {minutes} minutes");
     }
 
     pub fn add_minutes(&self, minutes: i32) -> Self {
-        unimplemented!("Add {} minutes to existing Clock time", minutes);
+        unimplemented!("Add {minutes} minutes to existing Clock time");
     }
 }

--- a/exercises/practice/collatz-conjecture/src/lib.rs
+++ b/exercises/practice/collatz-conjecture/src/lib.rs
@@ -1,6 +1,5 @@
 pub fn collatz(n: u64) -> Option<u64> {
     unimplemented!(
-        "return Some(x) where x is the number of steps required to reach 1 starting with {}",
-        n,
+        "return Some(x) where x is the number of steps required to reach 1 starting with {n}"
     )
 }

--- a/exercises/practice/crypto-square/src/lib.rs
+++ b/exercises/practice/crypto-square/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn encrypt(input: &str) -> String {
-    unimplemented!("Encrypt {:?} using a square code", input)
+    unimplemented!("Encrypt {input:?} using a square code")
 }

--- a/exercises/practice/decimal/src/lib.rs
+++ b/exercises/practice/decimal/src/lib.rs
@@ -5,6 +5,6 @@ pub struct Decimal {
 
 impl Decimal {
     pub fn try_from(input: &str) -> Option<Decimal> {
-        unimplemented!("Create a new decimal with a value of {}", input)
+        unimplemented!("Create a new decimal with a value of {input}")
     }
 }

--- a/exercises/practice/diamond/src/lib.rs
+++ b/exercises/practice/diamond/src/lib.rs
@@ -1,6 +1,5 @@
 pub fn get_diamond(c: char) -> Vec<String> {
     unimplemented!(
-        "Return the vector of strings which represent the diamond with particular char {}",
-        c
+        "Return the vector of strings which represent the diamond with particular char {c}"
     );
 }

--- a/exercises/practice/difference-of-squares/src/lib.rs
+++ b/exercises/practice/difference-of-squares/src/lib.rs
@@ -1,14 +1,11 @@
 pub fn square_of_sum(n: u32) -> u32 {
-    unimplemented!("square of sum of 1...{}", n)
+    unimplemented!("square of sum of 1...{n}")
 }
 
 pub fn sum_of_squares(n: u32) -> u32 {
-    unimplemented!("sum of squares of 1...{}", n)
+    unimplemented!("sum of squares of 1...{n}")
 }
 
 pub fn difference(n: u32) -> u32 {
-    unimplemented!(
-        "difference between square of sum of 1...{n} and sum of squares of 1...{n}",
-        n = n,
-    )
+    unimplemented!("difference between square of sum of 1...{n} and sum of squares of 1...{n}")
 }

--- a/exercises/practice/diffie-hellman/src/lib.rs
+++ b/exercises/practice/diffie-hellman/src/lib.rs
@@ -1,21 +1,13 @@
 pub fn private_key(p: u64) -> u64 {
-    unimplemented!("Pick a private key greater than 1 and less than {}", p)
+    unimplemented!("Pick a private key greater than 1 and less than {p}")
 }
 
 pub fn public_key(p: u64, g: u64, a: u64) -> u64 {
-    unimplemented!(
-        "Calculate public key using prime numbers {} and {}, and private key {}",
-        p,
-        g,
-        a
-    )
+    unimplemented!("Calculate public key using prime numbers {p} and {g}, and private key {a}")
 }
 
 pub fn secret(p: u64, b_pub: u64, a: u64) -> u64 {
     unimplemented!(
-        "Calculate secret key using prime number {}, public key {}, and private key {}",
-        p,
-        b_pub,
-        a
+        "Calculate secret key using prime number {p}, public key {b_pub}, and private key {a}"
     )
 }

--- a/exercises/practice/dominoes/src/lib.rs
+++ b/exercises/practice/dominoes/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn chain(input: &[(u8, u8)]) -> Option<Vec<(u8, u8)>> {
-    unimplemented!("From the given input '{:?}' construct a proper dominoes chain or return None if it is not possible.", input);
+    unimplemented!("From the given input '{input:?}' construct a proper dominoes chain or return None if it is not possible.");
 }

--- a/exercises/practice/dominoes/tests/dominoes.rs
+++ b/exercises/practice/dominoes/tests/dominoes.rs
@@ -67,16 +67,15 @@ fn check(input: &[Domino]) -> CheckResult {
 fn assert_correct(input: &[Domino]) {
     match check(input) {
         Correct => (),
-        GotInvalid => panic!("Unexpectedly got invalid on input {:?}", input),
-        ChainingFailure(output) => panic!(
-            "Chaining failure for input {:?}, output {:?}",
-            input, output
-        ),
+        GotInvalid => panic!("Unexpectedly got invalid on input {input:?}"),
+        ChainingFailure(output) => {
+            panic!("Chaining failure for input {input:?}, output {output:?}")
+        }
         LengthMismatch(output) => {
-            panic!("Length mismatch for input {:?}, output {:?}", input, output)
+            panic!("Length mismatch for input {input:?}, output {output:?}")
         }
         DominoMismatch(output) => {
-            panic!("Domino mismatch for input {:?}, output {:?}", input, output)
+            panic!("Domino mismatch for input {input:?}, output {output:?}")
         }
     }
 }

--- a/exercises/practice/etl/src/lib.rs
+++ b/exercises/practice/etl/src/lib.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
 
 pub fn transform(h: &BTreeMap<i32, Vec<char>>) -> BTreeMap<char, i32> {
-    unimplemented!("How will you transform the tree {:?}?", h)
+    unimplemented!("How will you transform the tree {h:?}?")
 }

--- a/exercises/practice/fizzy/tests/fizzy.rs
+++ b/exercises/practice/fizzy/tests/fizzy.rs
@@ -92,7 +92,7 @@ fn test_minimal_generic_bounds() {
     impl fmt::Display for Fizzable {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             let Fizzable(ref n) = self;
-            write!(f, "{}", n)
+            write!(f, "{n}")
         }
     }
 

--- a/exercises/practice/forth/src/lib.rs
+++ b/exercises/practice/forth/src/lib.rs
@@ -21,6 +21,6 @@ impl Forth {
     }
 
     pub fn eval(&mut self, input: &str) -> Result {
-        unimplemented!("result of evaluating '{}'", input)
+        unimplemented!("result of evaluating '{input}'")
     }
 }

--- a/exercises/practice/gigasecond/src/lib.rs
+++ b/exercises/practice/gigasecond/src/lib.rs
@@ -2,5 +2,5 @@ use time::PrimitiveDateTime as DateTime;
 
 // Returns a DateTime one billion seconds after start.
 pub fn after(start: DateTime) -> DateTime {
-    unimplemented!("What time is a gigasecond later than {}", start);
+    unimplemented!("What time is a gigasecond later than {start}");
 }

--- a/exercises/practice/grade-school/src/lib.rs
+++ b/exercises/practice/grade-school/src/lib.rs
@@ -13,7 +13,7 @@ impl School {
     }
 
     pub fn add(&mut self, grade: u32, student: &str) {
-        unimplemented!("Add {} to the roster for {}", student, grade)
+        unimplemented!("Add {student} to the roster for {grade}")
     }
 
     pub fn grades(&self) -> Vec<u32> {
@@ -25,6 +25,6 @@ impl School {
     // the internal structure can be completely arbitrary. The tradeoff is that some data
     // must be copied each time `grade` is called.
     pub fn grade(&self, grade: u32) -> Vec<String> {
-        unimplemented!("Return the list of students in {}", grade)
+        unimplemented!("Return the list of students in {grade}")
     }
 }

--- a/exercises/practice/grains/src/lib.rs
+++ b/exercises/practice/grains/src/lib.rs
@@ -1,5 +1,5 @@
 pub fn square(s: u32) -> u64 {
-    unimplemented!("grains of rice on square {}", s);
+    unimplemented!("grains of rice on square {s}");
 }
 
 pub fn total() -> u64 {

--- a/exercises/practice/grep/src/lib.rs
+++ b/exercises/practice/grep/src/lib.rs
@@ -18,17 +18,13 @@ pub struct Flags;
 impl Flags {
     pub fn new(flags: &[&str]) -> Self {
         unimplemented!(
-            "Given the flags {:?} implement your own 'Flags' struct to handle flags-related logic",
-            flags
+            "Given the flags {flags:?} implement your own 'Flags' struct to handle flags-related logic"
         );
     }
 }
 
 pub fn grep(pattern: &str, flags: &Flags, files: &[&str]) -> Result<Vec<String>, Error> {
     unimplemented!(
-        "Search the files '{:?}' for '{}' pattern and save the matches in a vector. Your search logic should be aware of the given flags '{:?}'",
-        files,
-        pattern,
-        flags
+        "Search the files '{files:?}' for '{pattern}' pattern and save the matches in a vector. Your search logic should be aware of the given flags '{flags:?}'"
     );
 }

--- a/exercises/practice/grep/tests/grep.rs
+++ b/exercises/practice/grep/tests/grep.rs
@@ -87,8 +87,7 @@ fn set_up_files(files: &[(&str, &str)]) {
     for (file_name, file_content) in files {
         fs::write(file_name, file_content).unwrap_or_else(|_| {
             panic!(
-                "Error setting up file '{}' with the following content:\n{}",
-                file_name, file_content
+                "Error setting up file '{file_name}' with the following content:\n{file_content}"
             )
         });
     }
@@ -97,7 +96,7 @@ fn set_up_files(files: &[(&str, &str)]) {
 fn tear_down_files(files: &[&str]) {
     for file_name in files {
         fs::remove_file(file_name)
-            .unwrap_or_else(|_| panic!("Could not delete file '{}'", file_name));
+            .unwrap_or_else(|_| panic!("Could not delete file '{file_name}'"));
     }
 }
 

--- a/exercises/practice/hamming/src/lib.rs
+++ b/exercises/practice/hamming/src/lib.rs
@@ -1,5 +1,5 @@
 /// Return the Hamming distance between the strings,
 /// or None if the lengths are mismatched.
 pub fn hamming_distance(s1: &str, s2: &str) -> Option<usize> {
-    unimplemented!("What is the Hamming Distance between {} and {}", s1, s2);
+    unimplemented!("What is the Hamming Distance between {s1} and {s2}");
 }

--- a/exercises/practice/high-scores/src/lib.rs
+++ b/exercises/practice/high-scores/src/lib.rs
@@ -3,10 +3,7 @@ pub struct HighScores;
 
 impl HighScores {
     pub fn new(scores: &[u32]) -> Self {
-        unimplemented!(
-            "Construct a HighScores struct, given the scores: {:?}",
-            scores
-        )
+        unimplemented!("Construct a HighScores struct, given the scores: {scores:?}")
     }
 
     pub fn scores(&self) -> &[u32] {

--- a/exercises/practice/isbn-verifier/src/lib.rs
+++ b/exercises/practice/isbn-verifier/src/lib.rs
@@ -1,4 +1,4 @@
 /// Determines whether the supplied string is a valid ISBN number
 pub fn is_valid_isbn(isbn: &str) -> bool {
-    unimplemented!("Is {:?} a valid ISBN number?", isbn);
+    unimplemented!("Is {isbn:?} a valid ISBN number?");
 }

--- a/exercises/practice/isogram/src/lib.rs
+++ b/exercises/practice/isogram/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn check(candidate: &str) -> bool {
-    unimplemented!("Is {} an isogram?", candidate);
+    unimplemented!("Is {candidate} an isogram?");
 }

--- a/exercises/practice/largest-series-product/src/lib.rs
+++ b/exercises/practice/largest-series-product/src/lib.rs
@@ -5,9 +5,5 @@ pub enum Error {
 }
 
 pub fn lsp(string_digits: &str, span: usize) -> Result<u64, Error> {
-    unimplemented!(
-        "largest series product of a span of {} digits in {}",
-        span,
-        string_digits
-    );
+    unimplemented!("largest series product of a span of {span} digits in {string_digits}");
 }

--- a/exercises/practice/leap/src/lib.rs
+++ b/exercises/practice/leap/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn is_leap_year(year: u64) -> bool {
-    unimplemented!("true if {} is a leap year", year)
+    unimplemented!("true if {year} is a leap year")
 }

--- a/exercises/practice/leap/tests/leap.rs
+++ b/exercises/practice/leap/tests/leap.rs
@@ -95,6 +95,6 @@ fn test_years_1600_to_1699() {
         .collect::<Vec<_>>();
 
     if !incorrect_years.is_empty() {
-        panic!("incorrect result for years: {:?}", incorrect_years);
+        panic!("incorrect result for years: {incorrect_years:?}");
     }
 }

--- a/exercises/practice/luhn-from/src/lib.rs
+++ b/exercises/practice/luhn-from/src/lib.rs
@@ -13,6 +13,6 @@ impl Luhn {
 /// Perhaps there exists a better solution for this problem?
 impl<'a> From<&'a str> for Luhn {
     fn from(input: &'a str) -> Self {
-        unimplemented!("From the given input '{}' create a new Luhn struct.", input);
+        unimplemented!("From the given input '{input}' create a new Luhn struct.");
     }
 }

--- a/exercises/practice/luhn-trait/src/lib.rs
+++ b/exercises/practice/luhn-trait/src/lib.rs
@@ -9,6 +9,6 @@ pub trait Luhn {
 /// Perhaps there exists a better solution for this problem?
 impl<'a> Luhn for &'a str {
     fn valid_luhn(&self) -> bool {
-        unimplemented!("Determine if '{}' is a valid credit card number.", self);
+        unimplemented!("Determine if '{self}' is a valid credit card number.");
     }
 }

--- a/exercises/practice/luhn/src/lib.rs
+++ b/exercises/practice/luhn/src/lib.rs
@@ -1,4 +1,4 @@
 /// Check a Luhn checksum.
 pub fn is_valid(code: &str) -> bool {
-    unimplemented!("Is the Luhn checksum for {} valid?", code);
+    unimplemented!("Is the Luhn checksum for {code} valid?");
 }

--- a/exercises/practice/macros/tests/macros.rs
+++ b/exercises/practice/macros/tests/macros.rs
@@ -207,8 +207,7 @@ mod simple_trybuild {
         if let Ok(result) = result {
             assert!(
                 !result.status.success(),
-                "Expected {:?} to fail to compile, but it succeeded.",
-                file_path
+                "Expected {file_path:?} to fail to compile, but it succeeded."
             );
         } else {
             panic!("Running subprocess failed.");

--- a/exercises/practice/matching-brackets/src/lib.rs
+++ b/exercises/practice/matching-brackets/src/lib.rs
@@ -1,6 +1,3 @@
 pub fn brackets_are_balanced(string: &str) -> bool {
-    unimplemented!(
-        "Check if the string \"{}\" contains balanced brackets",
-        string
-    );
+    unimplemented!("Check if the string \"{string}\" contains balanced brackets");
 }

--- a/exercises/practice/minesweeper/src/lib.rs
+++ b/exercises/practice/minesweeper/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn annotate(minefield: &[&str]) -> Vec<String> {
-    unimplemented!("\nAnnotate each square of the given minefield with the number of mines that surround said square (blank if there are no surrounding mines):\n{:#?}\n", minefield);
+    unimplemented!("\nAnnotate each square of the given minefield with the number of mines that surround said square (blank if there are no surrounding mines):\n{minefield:#?}\n");
 }

--- a/exercises/practice/nth-prime/src/lib.rs
+++ b/exercises/practice/nth-prime/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn nth(n: u32) -> u32 {
-    unimplemented!("What is the 0-indexed {}th prime number?", n)
+    unimplemented!("What is the 0-indexed {n}th prime number?")
 }

--- a/exercises/practice/nucleotide-count/src/lib.rs
+++ b/exercises/practice/nucleotide-count/src/lib.rs
@@ -2,15 +2,10 @@ use std::collections::HashMap;
 
 pub fn count(nucleotide: char, dna: &str) -> Result<usize, char> {
     unimplemented!(
-        "How much of nucleotide type '{}' is contained inside DNA string '{}'?",
-        nucleotide,
-        dna
+        "How much of nucleotide type '{nucleotide}' is contained inside DNA string '{dna}'?"
     );
 }
 
 pub fn nucleotide_counts(dna: &str) -> Result<HashMap<char, usize>, char> {
-    unimplemented!(
-        "How much of every nucleotide type is contained inside DNA string '{}'?",
-        dna
-    );
+    unimplemented!("How much of every nucleotide type is contained inside DNA string '{dna}'?");
 }

--- a/exercises/practice/ocr-numbers/src/lib.rs
+++ b/exercises/practice/ocr-numbers/src/lib.rs
@@ -8,5 +8,5 @@ pub enum Error {
 }
 
 pub fn convert(input: &str) -> Result<String, Error> {
-    unimplemented!("Convert the input '{}' to a string", input);
+    unimplemented!("Convert the input '{input}' to a string");
 }

--- a/exercises/practice/paasio/src/lib.rs
+++ b/exercises/practice/paasio/src/lib.rs
@@ -25,7 +25,7 @@ impl<R: Read> ReadStats<R> {
 
 impl<R: Read> Read for ReadStats<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        unimplemented!("Collect statistics about this call reading {:?}", buf)
+        unimplemented!("Collect statistics about this call reading {buf:?}")
     }
 }
 
@@ -54,7 +54,7 @@ impl<W: Write> WriteStats<W> {
 
 impl<W: Write> Write for WriteStats<W> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        unimplemented!("Collect statistics about this call writing {:?}", buf)
+        unimplemented!("Collect statistics about this call writing {buf:?}")
     }
 
     fn flush(&mut self) -> Result<()> {

--- a/exercises/practice/palindrome-products/src/lib.rs
+++ b/exercises/practice/palindrome-products/src/lib.rs
@@ -8,10 +8,7 @@ pub struct Palindrome(u64);
 impl Palindrome {
     /// Create a `Palindrome` only if `value` is in fact a palindrome when represented in base ten. Otherwise, `None`.
     pub fn new(value: u64) -> Option<Palindrome> {
-        unimplemented!(
-            "if the value {} is a palindrome return Some, otherwise return None",
-            value
-        );
+        unimplemented!("if the value {value} is a palindrome return Some, otherwise return None");
     }
 
     /// Get the value of this palindrome.
@@ -22,7 +19,6 @@ impl Palindrome {
 
 pub fn palindrome_products(min: u64, max: u64) -> Option<(Palindrome, Palindrome)> {
     unimplemented!(
-        "returns the minimum and maximum number of palindromes of the products of two factors in the range {} to {}",
-        min, max
+        "returns the minimum and maximum number of palindromes of the products of two factors in the range {min} to {max}"
     );
 }

--- a/exercises/practice/pangram/src/lib.rs
+++ b/exercises/practice/pangram/src/lib.rs
@@ -1,4 +1,4 @@
 /// Determine whether a sentence is a pangram.
 pub fn is_pangram(sentence: &str) -> bool {
-    unimplemented!("Is {} a pangram?", sentence);
+    unimplemented!("Is {sentence} a pangram?");
 }

--- a/exercises/practice/parallel-letter-frequency/src/lib.rs
+++ b/exercises/practice/parallel-letter-frequency/src/lib.rs
@@ -2,8 +2,7 @@ use std::collections::HashMap;
 
 pub fn frequency(input: &[&str], worker_count: usize) -> HashMap<char, usize> {
     unimplemented!(
-        "Count the frequency of letters in the given input '{:?}'. Ensure that you are using {} to process the input.",
-        input,
+        "Count the frequency of letters in the given input '{input:?}'. Ensure that you are using {} to process the input.",
         match worker_count {
             1 => "1 worker".to_string(),
             _ => format!("{worker_count} workers"),

--- a/exercises/practice/parallel-letter-frequency/src/lib.rs
+++ b/exercises/practice/parallel-letter-frequency/src/lib.rs
@@ -6,7 +6,7 @@ pub fn frequency(input: &[&str], worker_count: usize) -> HashMap<char, usize> {
         input,
         match worker_count {
             1 => "1 worker".to_string(),
-            _ => format!("{} workers", worker_count),
+            _ => format!("{worker_count} workers"),
         }
     );
 }

--- a/exercises/practice/pascals-triangle/src/lib.rs
+++ b/exercises/practice/pascals-triangle/src/lib.rs
@@ -2,7 +2,7 @@ pub struct PascalsTriangle;
 
 impl PascalsTriangle {
     pub fn new(row_count: u32) -> Self {
-        unimplemented!("create Pascal's triangle with {} rows", row_count);
+        unimplemented!("create Pascal's triangle with {row_count} rows");
     }
 
     pub fn rows(&self) -> Vec<Vec<u32>> {

--- a/exercises/practice/perfect-numbers/src/lib.rs
+++ b/exercises/practice/perfect-numbers/src/lib.rs
@@ -6,5 +6,5 @@ pub enum Classification {
 }
 
 pub fn classify(num: u64) -> Option<Classification> {
-    unimplemented!("classify {}", num);
+    unimplemented!("classify {num}");
 }

--- a/exercises/practice/phone-number/src/lib.rs
+++ b/exercises/practice/phone-number/src/lib.rs
@@ -1,6 +1,5 @@
 pub fn number(user_number: &str) -> Option<String> {
     unimplemented!(
-        "Given the number entered by user '{}', convert it into SMS-friendly format. If the entered number is not a valid NANP number, return None.",
-        user_number
+        "Given the number entered by user '{user_number}', convert it into SMS-friendly format. If the entered number is not a valid NANP number, return None."
     );
 }

--- a/exercises/practice/pig-latin/src/lib.rs
+++ b/exercises/practice/pig-latin/src/lib.rs
@@ -1,6 +1,5 @@
 pub fn translate(input: &str) -> String {
     unimplemented!(
-        "Using the Pig Latin text transformation rules, convert the given input '{}'",
-        input
+        "Using the Pig Latin text transformation rules, convert the given input '{input}'"
     );
 }

--- a/exercises/practice/poker/src/lib.rs
+++ b/exercises/practice/poker/src/lib.rs
@@ -3,5 +3,5 @@
 /// Note the type signature: this function should return _the same_ reference to
 /// the winning hand(s) as were passed in, not reconstructed strings which happen to be equal.
 pub fn winning_hands<'a>(hands: &[&'a str]) -> Vec<&'a str> {
-    unimplemented!("Out of {:?}, which hand wins?", hands)
+    unimplemented!("Out of {hands:?}, which hand wins?")
 }

--- a/exercises/practice/poker/tests/poker.rs
+++ b/exercises/practice/poker/tests/poker.rs
@@ -14,7 +14,7 @@ fn hs_from<'a>(input: &[&'a str]) -> HashSet<&'a str> {
 ///
 /// Note that the output can be in any order. Here, we use a HashSet to
 /// abstract away the order of outputs.
-fn test<'a, 'b>(input: &[&'a str], expected: &[&'b str]) {
+fn test(input: &[&str], expected: &[&str]) {
     assert_eq!(hs_from(&winning_hands(input)), hs_from(expected))
 }
 

--- a/exercises/practice/prime-factors/src/lib.rs
+++ b/exercises/practice/prime-factors/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn factors(n: u64) -> Vec<u64> {
-    unimplemented!("This should calculate the prime factors of {}", n)
+    unimplemented!("This should calculate the prime factors of {n}")
 }

--- a/exercises/practice/protein-translation/src/lib.rs
+++ b/exercises/practice/protein-translation/src/lib.rs
@@ -7,19 +7,15 @@ pub struct CodonsInfo<'a> {
 impl<'a> CodonsInfo<'a> {
     pub fn name_for(&self, codon: &str) -> Option<&'a str> {
         unimplemented!(
-            "Return the protein name for a '{}' codon or None, if codon string is invalid",
-            codon
+            "Return the protein name for a '{codon}' codon or None, if codon string is invalid"
         );
     }
 
     pub fn of_rna(&self, rna: &str) -> Option<Vec<&'a str>> {
-        unimplemented!("Return a list of protein names that correspond to the '{}' RNA string or None if the RNA string is invalid", rna);
+        unimplemented!("Return a list of protein names that correspond to the '{rna}' RNA string or None if the RNA string is invalid");
     }
 }
 
 pub fn parse<'a>(pairs: Vec<(&'a str, &'a str)>) -> CodonsInfo<'a> {
-    unimplemented!(
-        "Construct a new CodonsInfo struct from given pairs: {:?}",
-        pairs
-    );
+    unimplemented!("Construct a new CodonsInfo struct from given pairs: {pairs:?}");
 }

--- a/exercises/practice/proverb/src/lib.rs
+++ b/exercises/practice/proverb/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn build_proverb(list: &[&str]) -> String {
-    unimplemented!("build a proverb from this list of items: {:?}", list)
+    unimplemented!("build a proverb from this list of items: {list:?}")
 }

--- a/exercises/practice/pythagorean-triplet/src/lib.rs
+++ b/exercises/practice/pythagorean-triplet/src/lib.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
 
 pub fn find(sum: u32) -> HashSet<[u32; 3]> {
-    unimplemented!("Given the sum {}, return all possible Pythagorean triplets, which produce the said sum, or an empty HashSet if there are no such triplets. Note that you are expected to return triplets in [a, b, c] order, where a < b < c", sum);
+    unimplemented!("Given the sum {sum}, return all possible Pythagorean triplets, which produce the said sum, or an empty HashSet if there are no such triplets. Note that you are expected to return triplets in [a, b, c] order, where a < b < c");
 }

--- a/exercises/practice/queen-attack/src/lib.rs
+++ b/exercises/practice/queen-attack/src/lib.rs
@@ -7,25 +7,17 @@ pub struct Queen;
 impl ChessPosition {
     pub fn new(rank: i32, file: i32) -> Option<Self> {
         unimplemented!(
-            "Construct a ChessPosition struct, given the following rank, file: ({}, {}). If the position is invalid return None.",
-            rank,
-            file
+            "Construct a ChessPosition struct, given the following rank, file: ({rank}, {file}). If the position is invalid return None."
         );
     }
 }
 
 impl Queen {
     pub fn new(position: ChessPosition) -> Self {
-        unimplemented!(
-            "Given the chess position {:?}, construct a Queen struct.",
-            position
-        );
+        unimplemented!("Given the chess position {position:?}, construct a Queen struct.");
     }
 
     pub fn can_attack(&self, other: &Queen) -> bool {
-        unimplemented!(
-            "Determine if this Queen can attack the other Queen {:?}",
-            other
-        );
+        unimplemented!("Determine if this Queen can attack the other Queen {other:?}");
     }
 }

--- a/exercises/practice/rail-fence-cipher/src/lib.rs
+++ b/exercises/practice/rail-fence-cipher/src/lib.rs
@@ -2,14 +2,14 @@ pub struct RailFence;
 
 impl RailFence {
     pub fn new(rails: u32) -> RailFence {
-        unimplemented!("Construct a new fence with {} rails", rails)
+        unimplemented!("Construct a new fence with {rails} rails")
     }
 
     pub fn encode(&self, text: &str) -> String {
-        unimplemented!("Encode this text: {}", text)
+        unimplemented!("Encode this text: {text}")
     }
 
     pub fn decode(&self, cipher: &str) -> String {
-        unimplemented!("Decode this ciphertext: {}", cipher)
+        unimplemented!("Decode this ciphertext: {cipher}")
     }
 }

--- a/exercises/practice/raindrops/src/lib.rs
+++ b/exercises/practice/raindrops/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn raindrops(n: u32) -> String {
-    unimplemented!("what sound does Raindrop #{} make?", n)
+    unimplemented!("what sound does Raindrop #{n} make?")
 }

--- a/exercises/practice/react/src/lib.rs
+++ b/exercises/practice/react/src/lib.rs
@@ -78,7 +78,7 @@ impl<T: Copy + PartialEq> Reactor<T> {
     // It turns out this introduces a significant amount of extra complexity to this exercise.
     // We chose not to cover this here, since this exercise is probably enough work as-is.
     pub fn value(&self, id: CellId) -> Option<T> {
-        unimplemented!("Get the value of the cell whose id is {:?}", id)
+        unimplemented!("Get the value of the cell whose id is {id:?}")
     }
 
     // Sets the value of the specified input cell.
@@ -124,9 +124,7 @@ impl<T: Copy + PartialEq> Reactor<T> {
         callback: CallbackId,
     ) -> Result<(), RemoveCallbackError> {
         unimplemented!(
-            "Remove the callback identified by the CallbackId {:?} from the cell {:?}",
-            callback,
-            cell,
+            "Remove the callback identified by the CallbackId {callback:?} from the cell {cell:?}"
         )
     }
 }

--- a/exercises/practice/react/tests/react.rs
+++ b/exercises/practice/react/tests/react.rs
@@ -155,8 +155,7 @@ impl CallbackRecorder {
         assert_eq!(
             self.value.replace(Some(v)),
             None,
-            "Callback was called too many times; can't be called with {}",
-            v
+            "Callback was called too many times; can't be called with {v}"
         );
     }
 }

--- a/exercises/practice/rectangles/src/lib.rs
+++ b/exercises/practice/rectangles/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn count(lines: &[&str]) -> u32 {
-    unimplemented!("\nDetermine the count of rectangles in the ASCII diagram represented by the following lines:\n{:#?}\n.", lines);
+    unimplemented!("\nDetermine the count of rectangles in the ASCII diagram represented by the following lines:\n{lines:#?}\n.");
 }

--- a/exercises/practice/reverse-string/src/lib.rs
+++ b/exercises/practice/reverse-string/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn reverse(input: &str) -> String {
-    unimplemented!("Write a function to reverse {}", input);
+    unimplemented!("Write a function to reverse {input}");
 }

--- a/exercises/practice/rna-transcription/src/lib.rs
+++ b/exercises/practice/rna-transcription/src/lib.rs
@@ -6,16 +6,16 @@ pub struct Rna;
 
 impl Dna {
     pub fn new(dna: &str) -> Result<Dna, usize> {
-        unimplemented!("Construct new Dna from '{}' string. If string contains invalid nucleotides return index of first invalid nucleotide", dna);
+        unimplemented!("Construct new Dna from '{dna}' string. If string contains invalid nucleotides return index of first invalid nucleotide");
     }
 
     pub fn into_rna(self) -> Rna {
-        unimplemented!("Transform Dna {:?} into corresponding Rna", self);
+        unimplemented!("Transform Dna {self:?} into corresponding Rna");
     }
 }
 
 impl Rna {
     pub fn new(rna: &str) -> Result<Rna, usize> {
-        unimplemented!("Construct new Rna from '{}' string. If string contains invalid nucleotides return index of first invalid nucleotide", rna);
+        unimplemented!("Construct new Rna from '{rna}' string. If string contains invalid nucleotides return index of first invalid nucleotide");
     }
 }

--- a/exercises/practice/robot-name/tests/robot-name.rs
+++ b/exercises/practice/robot-name/tests/robot-name.rs
@@ -3,11 +3,11 @@ use robot_name as robot;
 fn assert_name_matches_pattern(n: &str) {
     assert!(n.len() == 5, "name is exactly 5 characters long");
     assert!(
-        n[0..2].chars().all(|c| ('A'..='Z').contains(&c)),
+        n[0..2].chars().all(|c| c.is_ascii_uppercase()),
         "name starts with 2 uppercase letters"
     );
     assert!(
-        n[2..].chars().all(|c| ('0'..='9').contains(&c)),
+        n[2..].chars().all(|c| c.is_ascii_digit()),
         "name ends with 3 numbers"
     );
 }

--- a/exercises/practice/robot-simulator/src/lib.rs
+++ b/exercises/practice/robot-simulator/src/lib.rs
@@ -13,7 +13,7 @@ pub struct Robot;
 
 impl Robot {
     pub fn new(x: i32, y: i32, d: Direction) -> Self {
-        unimplemented!("Create a robot at (x, y) ({}, {}) facing {:?}", x, y, d,)
+        unimplemented!("Create a robot at (x, y) ({x}, {y}) facing {d:?}")
     }
 
     #[must_use]
@@ -33,10 +33,7 @@ impl Robot {
 
     #[must_use]
     pub fn instructions(self, instructions: &str) -> Self {
-        unimplemented!(
-            "Follow the given sequence of instructions: {}",
-            instructions
-        )
+        unimplemented!("Follow the given sequence of instructions: {instructions}")
     }
 
     pub fn position(&self) -> (i32, i32) {

--- a/exercises/practice/roman-numerals/src/lib.rs
+++ b/exercises/practice/roman-numerals/src/lib.rs
@@ -10,6 +10,6 @@ impl Display for Roman {
 
 impl From<u32> for Roman {
     fn from(num: u32) -> Self {
-        unimplemented!("Construct a Roman object from the '{}' number", num);
+        unimplemented!("Construct a Roman object from the '{num}' number");
     }
 }

--- a/exercises/practice/rotational-cipher/src/lib.rs
+++ b/exercises/practice/rotational-cipher/src/lib.rs
@@ -1,7 +1,5 @@
 pub fn rotate(input: &str, key: i8) -> String {
     unimplemented!(
-        "How would input text '{}' transform when every letter is shifted using key '{}'?",
-        input,
-        key
+        "How would input text '{input}' transform when every letter is shifted using key '{key}'?"
     );
 }

--- a/exercises/practice/run-length-encoding/src/lib.rs
+++ b/exercises/practice/run-length-encoding/src/lib.rs
@@ -1,7 +1,7 @@
 pub fn encode(source: &str) -> String {
-    unimplemented!("Return the run-length encoding of {}.", source);
+    unimplemented!("Return the run-length encoding of {source}.");
 }
 
 pub fn decode(source: &str) -> String {
-    unimplemented!("Return the run-length decoding of {}.", source);
+    unimplemented!("Return the run-length decoding of {source}.");
 }

--- a/exercises/practice/saddle-points/src/lib.rs
+++ b/exercises/practice/saddle-points/src/lib.rs
@@ -1,6 +1,3 @@
 pub fn find_saddle_points(input: &[Vec<u64>]) -> Vec<(usize, usize)> {
-    unimplemented!(
-        "find the saddle points of the following matrix: {:?}",
-        input
-    )
+    unimplemented!("find the saddle points of the following matrix: {input:?}")
 }

--- a/exercises/practice/say/src/lib.rs
+++ b/exercises/practice/say/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn encode(n: u64) -> String {
-    unimplemented!("Say {} in English.", n);
+    unimplemented!("Say {n} in English.");
 }

--- a/exercises/practice/scale-generator/src/lib.rs
+++ b/exercises/practice/scale-generator/src/lib.rs
@@ -16,15 +16,11 @@ pub struct Scale;
 
 impl Scale {
     pub fn new(tonic: &str, intervals: &str) -> Result<Scale, Error> {
-        unimplemented!(
-            "Construct a new scale with tonic {} and intervals {}",
-            tonic,
-            intervals
-        )
+        unimplemented!("Construct a new scale with tonic {tonic} and intervals {intervals}")
     }
 
     pub fn chromatic(tonic: &str) -> Result<Scale, Error> {
-        unimplemented!("Construct a new chromatic scale with tonic {}", tonic)
+        unimplemented!("Construct a new chromatic scale with tonic {tonic}")
     }
 
     pub fn enumerate(&self) -> Vec<String> {

--- a/exercises/practice/scrabble-score/src/lib.rs
+++ b/exercises/practice/scrabble-score/src/lib.rs
@@ -1,4 +1,4 @@
 /// Compute the Scrabble score for a word.
 pub fn score(word: &str) -> u64 {
-    unimplemented!("Score {} in Scrabble.", word);
+    unimplemented!("Score {word} in Scrabble.");
 }

--- a/exercises/practice/series/src/lib.rs
+++ b/exercises/practice/series/src/lib.rs
@@ -1,7 +1,3 @@
 pub fn series(digits: &str, len: usize) -> Vec<String> {
-    unimplemented!(
-        "What are the series of length {} in string {:?}",
-        len,
-        digits
-    )
+    unimplemented!("What are the series of length {len} in string {digits:?}")
 }

--- a/exercises/practice/sieve/src/lib.rs
+++ b/exercises/practice/sieve/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn primes_up_to(upper_bound: u64) -> Vec<u64> {
-    unimplemented!("Construct a vector of all primes up to {}", upper_bound);
+    unimplemented!("Construct a vector of all primes up to {upper_bound}");
 }

--- a/exercises/practice/simple-cipher/src/lib.rs
+++ b/exercises/practice/simple-cipher/src/lib.rs
@@ -1,14 +1,13 @@
 pub fn encode(key: &str, s: &str) -> Option<String> {
-    unimplemented!("Use {} to encode {} using shift cipher", key, s)
+    unimplemented!("Use {key} to encode {s} using shift cipher")
 }
 
 pub fn decode(key: &str, s: &str) -> Option<String> {
-    unimplemented!("Use {} to decode {} using shift cipher", key, s)
+    unimplemented!("Use {key} to decode {s} using shift cipher")
 }
 
 pub fn encode_random(s: &str) -> (String, String) {
     unimplemented!(
-        "Generate random key with only a-z chars and encode {}. Return tuple (key, encoded s)",
-        s
+        "Generate random key with only a-z chars and encode {s}. Return tuple (key, encoded s)"
     )
 }

--- a/exercises/practice/simple-linked-list/tests/simple-linked-list.rs
+++ b/exercises/practice/simple-linked-list/tests/simple-linked-list.rs
@@ -38,24 +38,19 @@ fn test_is_empty() {
             list.push(i);
             assert!(
                 !list.is_empty(),
-                "List was empty after having inserted {}/{} elements",
-                i,
-                inserts
+                "List was empty after having inserted {i}/{inserts} elements"
             );
         }
         for i in 0..inserts {
             assert!(
                 !list.is_empty(),
-                "List was empty before removing {}/{} elements",
-                i,
-                inserts
+                "List was empty before removing {i}/{inserts} elements"
             );
             list.pop();
         }
         assert!(
             list.is_empty(),
-            "List wasn't empty after having removed {} elements",
-            inserts
+            "List wasn't empty after having removed {inserts} elements"
         );
     }
 }

--- a/exercises/practice/space-age/src/lib.rs
+++ b/exercises/practice/space-age/src/lib.rs
@@ -6,15 +6,14 @@ pub struct Duration;
 
 impl From<u64> for Duration {
     fn from(s: u64) -> Self {
-        unimplemented!("s, measured in seconds: {}", s)
+        unimplemented!("s, measured in seconds: {s}")
     }
 }
 
 pub trait Planet {
     fn years_during(d: &Duration) -> f64 {
         unimplemented!(
-            "convert a duration ({:?}) to the number of years on this planet for that duration",
-            d,
+            "convert a duration ({d:?}) to the number of years on this planet for that duration"
         );
     }
 }

--- a/exercises/practice/space-age/tests/space-age.rs
+++ b/exercises/practice/space-age/tests/space-age.rs
@@ -4,10 +4,7 @@ fn assert_in_delta(expected: f64, actual: f64) {
     let diff: f64 = (expected - actual).abs();
     let delta: f64 = 0.01;
     if diff > delta {
-        panic!(
-            "Your result of {} should be within {} of the expected result {}",
-            actual, delta, expected
-        )
+        panic!("Your result of {actual} should be within {delta} of the expected result {expected}")
     }
 }
 

--- a/exercises/practice/spiral-matrix/src/lib.rs
+++ b/exercises/practice/spiral-matrix/src/lib.rs
@@ -1,6 +1,3 @@
 pub fn spiral_matrix(size: u32) -> Vec<Vec<u32>> {
-    unimplemented!(
-        "Function that returns the spiral matrix of square size {}",
-        size
-    );
+    unimplemented!("Function that returns the spiral matrix of square size {size}");
 }

--- a/exercises/practice/sum-of-multiples/src/lib.rs
+++ b/exercises/practice/sum-of-multiples/src/lib.rs
@@ -1,7 +1,3 @@
 pub fn sum_of_multiples(limit: u32, factors: &[u32]) -> u32 {
-    unimplemented!(
-        "Sum the multiples of all of {:?} which are less than {}",
-        factors,
-        limit
-    )
+    unimplemented!("Sum the multiples of all of {factors:?} which are less than {limit}")
 }

--- a/exercises/practice/tournament/src/lib.rs
+++ b/exercises/practice/tournament/src/lib.rs
@@ -1,6 +1,5 @@
 pub fn tally(match_results: &str) -> String {
     unimplemented!(
-        "Given the result of the played matches '{}' return a properly formatted tally table string.",
-        match_results
+        "Given the result of the played matches '{match_results}' return a properly formatted tally table string."
     );
 }

--- a/exercises/practice/triangle/src/lib.rs
+++ b/exercises/practice/triangle/src/lib.rs
@@ -2,7 +2,7 @@ pub struct Triangle;
 
 impl Triangle {
     pub fn build(sides: [u64; 3]) -> Option<Triangle> {
-        unimplemented!("Construct new Triangle from following sides: {:?}. Return None if the sides are invalid.", sides);
+        unimplemented!("Construct new Triangle from following sides: {sides:?}. Return None if the sides are invalid.");
     }
 
     pub fn is_equilateral(&self) -> bool {

--- a/exercises/practice/two-bucket/src/lib.rs
+++ b/exercises/practice/two-bucket/src/lib.rs
@@ -24,10 +24,6 @@ pub fn solve(
     start_bucket: &Bucket,
 ) -> Option<BucketStats> {
     unimplemented!(
-        "Given one bucket of capacity {}, another of capacity {}, starting with {:?}, find pours to reach {}, or None if impossible",
-        capacity_1,
-        capacity_2,
-        start_bucket,
-        goal,
+        "Given one bucket of capacity {capacity_1}, another of capacity {capacity_2}, starting with {start_bucket:?}, find pours to reach {goal}, or None if impossible"
     );
 }

--- a/exercises/practice/two-fer/src/lib.rs
+++ b/exercises/practice/two-fer/src/lib.rs
@@ -1,3 +1,3 @@
 pub fn twofer(name: &str) -> String {
-    unimplemented!("how many for {}", name)
+    unimplemented!("how many for {name}")
 }

--- a/exercises/practice/variable-length-quantity/src/lib.rs
+++ b/exercises/practice/variable-length-quantity/src/lib.rs
@@ -6,10 +6,10 @@ pub enum Error {
 
 /// Convert a list of numbers to a stream of bytes encoded with variable length encoding.
 pub fn to_bytes(values: &[u32]) -> Vec<u8> {
-    unimplemented!("Convert the values {:?} to a list of bytes", values)
+    unimplemented!("Convert the values {values:?} to a list of bytes")
 }
 
 /// Given a stream of bytes, extract all numbers which are encoded in there.
 pub fn from_bytes(bytes: &[u8]) -> Result<Vec<u32>, Error> {
-    unimplemented!("Convert the list of bytes {:?} to a list of numbers", bytes)
+    unimplemented!("Convert the list of bytes {bytes:?} to a list of numbers")
 }

--- a/exercises/practice/word-count/src/lib.rs
+++ b/exercises/practice/word-count/src/lib.rs
@@ -2,5 +2,5 @@ use std::collections::HashMap;
 
 /// Count occurrences of words.
 pub fn word_count(words: &str) -> HashMap<String, u32> {
-    unimplemented!("Count of occurrences of words in {:?}", words);
+    unimplemented!("Count of occurrences of words in {words:?}");
 }

--- a/exercises/practice/wordy/src/lib.rs
+++ b/exercises/practice/wordy/src/lib.rs
@@ -1,6 +1,5 @@
 pub fn answer(command: &str) -> Option<i32> {
     unimplemented!(
-        "Return the result of the command '{}' or None, if the command is invalid.",
-        command
+        "Return the result of the command '{command}' or None, if the command is invalid."
     );
 }


### PR DESCRIPTION
Most of the warnings relate to idiomatic format strings. I think these warnings were introduced with Rust 1.67.

```
variables can be used directly in the `format!` string
for further information visit
https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
`#[warn(clippy::uninlined_format_args)]` on by default
```

There is one other warning I fixed about lifetimes that can be elided.

There are still a couple warnings about a `new` function without a default implementation. I didn't do anything about those because it seemed unclear to me what the best thing to do is.