### PR TITLE
Update broken links to learning-rust

### DIFF
--- a/concepts/structs/links.json
+++ b/concepts/structs/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "https://learning-rust.github.io/docs/b2.structs.html#Tuple-structs",
+    "url": "https://learning-rust.github.io/docs/structs/#tuple-structs",
     "description": "more information about tuple structs"
   },
   {
@@ -8,7 +8,7 @@
     "description": "examples of tuple and unit structs"
   },
   {
-    "url": "https://learning-rust.github.io/docs/b2.structs.html#C-like-structs",
+    "url": "https://learning-rust.github.io/docs/structs/#c-like-structs",
     "description": "good overview of the different types of structs and their syntax"
   }
 ]

--- a/exercises/concept/health-statistics/.meta/design.md
+++ b/exercises/concept/health-statistics/.meta/design.md
@@ -30,13 +30,13 @@
 
 ### Hints
 
-- [https://learning-rust.github.io/docs/b2.structs.html#C-like-structs](https://learning-rust.github.io/docs/b2.structs.html#C-like-structs)
+- [https://learning-rust.github.io/docs/structs/#c-like-structs](https://learning-rust.github.io/docs/structs/#c-like-structs)
 - [https://doc.rust-lang.org/book/ch05-01-defining-structs.html](https://doc.rust-lang.org/book/ch05-01-defining-structs.html)
 - [https://doc.rust-lang.org/book/ch05-03-method-syntax.html](https://doc.rust-lang.org/book/ch05-03-method-syntax.html)
 
 ### After
 
-- [https://learning-rust.github.io/docs/b2.structs.html#C-like-structs](https://learning-rust.github.io/docs/b2.structs.html#Tuple-structs)
+- [https://learning-rust.github.io/docs/structs/#tuple-structs](https://learning-rust.github.io/docs/structs/#tuple-structs)
 - [https://doc.rust-lang.org/stable/rust-by-example/custom_types/structs.html](https://doc.rust-lang.org/stable/rust-by-example/custom_types/structs.html)
 
 ## Representer

--- a/exercises/concept/role-playing-game/.meta/design.md
+++ b/exercises/concept/role-playing-game/.meta/design.md
@@ -34,7 +34,7 @@ The concepts this exercise unlocks are:
 
 - <https://doc.rust-lang.org/std/option/>
 - <https://doc.rust-lang.org/rust-by-example/std/option.html>
-- <https://learning-rust.github.io/docs/e3.option_and_result.html>
+- <https://learning-rust.github.io/docs/option-and-result/>
 - [The Billion-Dollar Mistake](https://www.infoq.com/presentations/Null-References-The-Billion-Dollar-Mistake-Tony-Hoare/)
 
 ### After


### PR DESCRIPTION
Learning Rust seems to have changed their URL structure since these hints and links were written.

Note: On [line 39, exercises/concept/health-statistics/.meta/design.md](https://github.com/exercism/rust/commit/556ca2e59d22280855caa8c5335cfb198e1c64c2#diff-efd9f9a611d6ad6e24df211f7139a83124c13f8aea1995cd76eeeab2cbd3afd2L39) the link text and link href is inconsistent, so I made a guess on which to keep.