### PR TITLE
Circular Buffer: added memory leak tests for `overwrite` and `read`

### DIFF
--- a/exercises/practice/circular-buffer/tests/circular-buffer.rs
+++ b/exercises/practice/circular-buffer/tests/circular-buffer.rs
@@ -106,6 +106,29 @@ fn clear_actually_frees_up_its_elements() {
 
 #[test]
 #[ignore]
+fn overwrite_frees_up_the_cleared_elements() {
+    let mut buffer = CircularBuffer::new(1);
+    let element_to_replace = Rc::new(());
+    let new_element = Rc::new(());
+    assert!(buffer.write(Rc::clone(&element_to_replace)).is_ok());
+    assert_eq!(Rc::strong_count(&element_to_replace), 2);
+    buffer.overwrite(Rc::clone(&new_element));
+    assert_eq!(Rc::strong_count(&element_to_replace), 1);
+}
+
+#[test]
+#[ignore]
+fn read_frees_up_the_read_element() {
+    let mut buffer = CircularBuffer::new(1);
+    let element = Rc::new(());
+    assert!(buffer.write(Rc::clone(&element)).is_ok());
+    assert_eq!(Rc::strong_count(&element), 2);
+    assert!(buffer.read().is_ok());
+    assert_eq!(Rc::strong_count(&element), 1);
+}
+
+#[test]
+#[ignore]
 fn overwrite_acts_like_write_on_non_full_buffer() {
     let mut buffer = CircularBuffer::new(2);
     assert!(buffer.write('1').is_ok());


### PR DESCRIPTION
When solving this with `unsafe`, my mentor pointed out that my `overwrite` method must've been leaking memory. He was correct! And I fixed this issue in my next iteration.

A few days ago however, I remembered that there was a test for memory leaks on the `clear` method. The test in question uses `Rc` and its strong count to check if memory has been freed or not from the buffer.

I decided to base a new couple of tests on the same technique, and well, indeed my earlier buffer fails the `overwrite` test.

I've added these two to make sure the test suite helps students implement a leak-free Buffer :)