### PR TITLE
Added digit 9 test case from the canonical test suite.

### DIFF
--- a/exercises/practice/luhn-from/tests/luhn-from.rs
+++ b/exercises/practice/luhn-from/tests/luhn-from.rs
@@ -97,3 +97,9 @@ fn invalid_credit_card_is_invalid() {
 fn strings_that_contain_non_digits_are_invalid() {
     assert!(!Luhn::from("046a 454 286").is_valid());
 }
+
+#[test]
+#[ignore]
+fn test_input_digit_9_is_still_correctly_converted_to_output_digit_9() {
+    assert!(Luhn::from("091").is_valid());
+}

--- a/exercises/practice/luhn-trait/tests/luhn-trait.rs
+++ b/exercises/practice/luhn-trait/tests/luhn-trait.rs
@@ -55,3 +55,9 @@ fn you_can_validate_from_a_usize() {
     assert!(valid.valid_luhn());
     assert!(!invalid.valid_luhn());
 }
+
+#[test]
+#[ignore]
+fn test_input_digit_9_is_still_correctly_converted_to_output_digit_9() {
+    assert!("091".valid_luhn());
+}


### PR DESCRIPTION
9 is an edge case that is very important to keep testing in the advanced Luhn iteration exercises (Luhn From and Luhn Trait).

I know it because I was optimizing my solutions and after passing all the From and Trait tests, when I put those optimizations in my original Luhn solution, it failed the Luhn tests. Turns out the canonical specification had a test case for this! So I'm adding it to the advanced exercises as well.