### PR TITLE
Overflow test doesn't make sense

### DIFF
--- a/exercises/concept/role-playing-game/tests/role-playing-game.rs
+++ b/exercises/concept/role-playing-game/tests/role-playing-game.rs
@@ -117,20 +117,3 @@ fn test_cast_spell_with_no_mana_pool() {
     assert_eq!(underleveled_player.mana, clone.mana);
     assert_eq!(underleveled_player.level, clone.level);
 }
-
-#[test]
-#[ignore]
-fn test_cast_large_spell_with_no_mana_pool() {
-    const MANA_COST: u32 = 30;
-
-    let mut underleveled_player = Player {
-        health: 20,
-        mana: None,
-        level: 6,
-    };
-
-    assert_eq!(underleveled_player.cast_spell(MANA_COST), 0);
-    assert_eq!(underleveled_player.health, 0);
-    assert_eq!(underleveled_player.mana, None);
-    assert_eq!(underleveled_player.level, 6);
-}


### PR DESCRIPTION
I propose to remove this test from test pool, i think it doesn't make sense to test the overflow since we are using u32 to represent the player health. In another words the program shouldn't allow to cast a spell if the player is under level and the mana cost is higher than his health. if this is a expected behavior then we should not use unsinged integers so the program should cover the case of going "negative" but it actually should never go negative.