### PR TITLE
Disable learning mode

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "slug": "rust",
   "active": true,
   "status": {
-    "concept_exercises": true,
+    "concept_exercises": false,
     "test_runner": true,
     "representer": true,
     "analyzer": true


### PR DESCRIPTION
We've had several complaints from students that the learning mode doesn't work well for them. I think it's best to disable it temporarily and then look at ways how to fix it.