### PR TITLE
Update link in Binary Search exercise instruction.

### DIFF
--- a/exercises/practice/binary-search/.docs/instructions.append.md
+++ b/exercises/practice/binary-search/.docs/instructions.append.md
@@ -8,7 +8,7 @@ For this exercise you should not use this function but just other basic tools in
 
 ## Hints
 
-[Slices](https://doc.rust-lang.org/book/2018-edition/ch04-03-slices.html) have additionally to
+[Slices](https://doc.rust-lang.org/book/ch04-03-slices.html) have additionally to
 the normal element access via indexing (slice[index]) many useful functions like
 [split_at](https://doc.rust-lang.org/std/primitive.slice.html#method.split_at) or [getting
 subslices](https://doc.rust-lang.org/std/primitive.slice.html#method.get) (slice[start..end]).


### PR DESCRIPTION
Link to Slices chapter in Rust Book was leading to 2018 version, which is no longer distributed with Rust's documentation. 
I have updated it to actual version of Rust Book.
It is small update, but still one click less, and better user experience