### PR TITLE
Clarify constructor return types for RNA Transcription exercise

### DIFF
--- a/exercises/practice/rna-transcription/.docs/instructions.append.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.append.md
@@ -7,3 +7,7 @@ string has a valid RNA string, we don't need to return a `Result`/`Option` from
 `into_rna`.
 
 This explains the type signatures you will see in the tests.
+
+The return types of both `DNA::new()` and `RNA::new()` are `Result<Self, usize>`,
+where the error type `usize` represents the index of the first invalid character 
+(char index, not utf8).


### PR DESCRIPTION
I recently completed https://exercism.org/tracks/rust/exercises/rna-transcription, but couldn't quite figure out what the error type in the signatures of `DNA::new()` and `RNA::new()` was supposed to mean from looking at the tests. Unfortunately, I interpreted it as "the number of different nucleotides used before encountering the first invalid char", which just so happened to pass the test cases, even though it was wrong. (I can submit a separate PR for fixing up those test cases.)

It turns out though that the `usize` in `Result<Self, usize>` was meant to mean "the first invalid character index": https://exercism.org/tracks/rust/exercises/rna-transcription

This PR clarifies the meaning of the error value in the return type.