### PR TITLE
Fix new clippy warnings

### DIFF
--- a/exercises/practice/paasio/tests/paasio.rs
+++ b/exercises/practice/paasio/tests/paasio.rs
@@ -11,7 +11,8 @@ macro_rules! test_read {
             #[test]
             fn test_read_passthrough() {
                 let data = $input;
-                let size = $len(&data);
+                let len = $len;
+                let size = len(&data);
                 let mut reader = ReadStats::new(data);
 
                 let mut buffer = Vec::with_capacity(size);
@@ -31,7 +32,8 @@ macro_rules! test_read {
             #[test]
             fn test_read_chunks() {
                 let data = $input;
-                let size = $len(&data);
+                let len = $len;
+                let size = len(&data);
                 let mut reader = ReadStats::new(data);
 
                 let mut buffer = [0_u8; CHUNK_SIZE];
@@ -51,7 +53,8 @@ macro_rules! test_read {
             #[test]
             fn test_read_buffered_chunks() {
                 let data = $input;
-                let size = $len(&data);
+                let len = $len;
+                let size = len(&data);
                 let mut reader = BufReader::new(ReadStats::new(data));
 
                 let mut buffer = [0_u8; CHUNK_SIZE];
@@ -84,7 +87,8 @@ macro_rules! test_write {
             #[test]
             fn test_write_passthrough() {
                 let data = $input;
-                let size = $len(&data);
+                let len = $len;
+                let size = len(&data);
                 let mut writer = WriteStats::new(Vec::with_capacity(size));
                 let written = writer.write(data);
                 assert!(written.is_ok());
@@ -98,7 +102,8 @@ macro_rules! test_write {
             #[test]
             fn test_sink_oneshot() {
                 let data = $input;
-                let size = $len(&data);
+                let len = $len;
+                let size = len(&data);
                 let mut writer = WriteStats::new(io::sink());
                 let written = writer.write(data);
                 assert!(written.is_ok());
@@ -111,7 +116,8 @@ macro_rules! test_write {
             #[test]
             fn test_sink_windowed() {
                 let data = $input;
-                let size = $len(&data);
+                let len = $len;
+                let size = len(&data);
                 let mut writer = WriteStats::new(io::sink());
 
                 let mut chunk_count = 0;
@@ -129,7 +135,8 @@ macro_rules! test_write {
             #[test]
             fn test_sink_buffered_windowed() {
                 let data = $input;
-                let size = $len(&data);
+                let len = $len;
+                let size = len(&data);
                 let mut writer = BufWriter::new(WriteStats::new(io::sink()));
 
                 for chunk in data.chunks(CHUNK_SIZE) {

--- a/exercises/practice/proverb/tests/proverb.rs
+++ b/exercises/practice/proverb/tests/proverb.rs
@@ -3,7 +3,7 @@ use proverb::build_proverb;
 #[test]
 fn test_two_pieces() {
     let input = vec!["nail", "shoe"];
-    let expected = vec![
+    let expected = [
         "For want of a nail the shoe was lost.",
         "And all for the want of a nail.",
     ]
@@ -16,7 +16,7 @@ fn test_two_pieces() {
 #[ignore]
 fn test_three_pieces() {
     let input = vec!["nail", "shoe", "horse"];
-    let expected = vec![
+    let expected = [
         "For want of a nail the shoe was lost.",
         "For want of a shoe the horse was lost.",
         "And all for the want of a nail.",
@@ -47,7 +47,7 @@ fn test_full() {
     let input = vec![
         "nail", "shoe", "horse", "rider", "message", "battle", "kingdom",
     ];
-    let expected = vec![
+    let expected = [
         "For want of a nail the shoe was lost.",
         "For want of a shoe the horse was lost.",
         "For want of a horse the rider was lost.",
@@ -64,7 +64,7 @@ fn test_full() {
 #[ignore]
 fn test_three_pieces_modernized() {
     let input = vec!["pin", "gun", "soldier", "battle"];
-    let expected = vec![
+    let expected = [
         "For want of a pin the gun was lost.",
         "For want of a gun the soldier was lost.",
         "For want of a soldier the battle was lost.",


### PR DESCRIPTION
[no important files changed]

The Rust 1.72 beta introduced [a couple new clippy warnings](https://github.com/exercism/rust/actions/runs/5609359865/jobs/10262955846), which need fixing for our CI.

`clippy::redundant_closure_call`:

> try not to call a closure in the expression where it is declared

and `clippy::useless_vec`.