### PR TITLE
Remove impls of deprecated exercises

### DIFF
--- a/exercises/practice/hexadecimal/src/lib.rs
+++ b/exercises/practice/hexadecimal/src/lib.rs
@@ -1,33 +1,9 @@
-fn parse_hex_digit(c: char) -> Option<i64> {
-    match c {
-        '0' => Some(0),
-        '1' => Some(1),
-        '2' => Some(2),
-        '3' => Some(3),
-        '4' => Some(4),
-        '5' => Some(5),
-        '6' => Some(6),
-        '7' => Some(7),
-        '8' => Some(8),
-        '9' => Some(9),
-        'a' => Some(10),
-        'b' => Some(11),
-        'c' => Some(12),
-        'd' => Some(13),
-        'e' => Some(14),
-        'f' => Some(15),
-        _ => None,
-    }
-}
+// This exercise is deprecated.
+// Consider working on all-your-base instead.
 
 pub fn hex_to_int(string: &str) -> Option<i64> {
-    let base: i64 = 16;
-
-    string
-        .chars()
-        .rev()
-        .enumerate()
-        .fold(Some(0), |acc, (pos, c)| {
-            parse_hex_digit(c).and_then(|n| acc.map(|acc| acc + n * base.pow(pos as u32)))
-        })
+    unimplemented!(
+        "what integer is represented by the base-16 digits {}?",
+        string
+    );
 }

--- a/exercises/practice/nucleotide-codons/src/lib.rs
+++ b/exercises/practice/nucleotide-codons/src/lib.rs
@@ -1,46 +1,35 @@
-use std::collections::HashMap;
+// This exercise is deprecated.
+// Consider working on protein-translation instead.
 
-pub struct CodonInfo<'a> {
-    actual_codons: HashMap<&'a str, &'a str>,
+use std::marker::PhantomData;
+
+pub struct CodonsInfo<'a> {
+    // This field is here to make the template compile and not to
+    // complain about unused type lifetime parameter "'a". Once you start
+    // solving the exercise, delete this field and the 'std::marker::PhantomData'
+    // import.
+    phantom: PhantomData<&'a ()>,
 }
 
-pub fn parse<'a>(pairs: Vec<(&'a str, &'a str)>) -> CodonInfo<'a> {
-    CodonInfo {
-        actual_codons: pairs.into_iter().collect(),
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Error;
+
+impl<'a> CodonsInfo<'a> {
+    pub fn name_for(&self, codon: &str) -> Result<&'a str, Error> {
+        unimplemented!(
+            "Return the protein name for a '{}' codon or Err, if codon string is invalid",
+            codon
+        );
+    }
+
+    pub fn of_rna(&self, rna: &str) -> Result<Vec<&'a str>, Error> {
+        unimplemented!("Return a list of protein names that correspond to the '{}' RNA string or Err if the RNA string is invalid", rna);
     }
 }
 
-impl<'a> CodonInfo<'a> {
-    pub fn name_for(&self, codon: &str) -> Result<&'a str, &'static str> {
-        if codon.len() != 3 {
-            return Err("invalid length");
-        }
-
-        let mut valid = true;
-        let lookup: String = codon
-            .chars()
-            .map(|l| {
-                // Get an example of a "letter" represented by the possibly encoded letter.
-                // Since every codon represented by the compressed notation has to be of
-                // the desired amino acid just picking one at random will do.
-                match l {
-                    'A' | 'W' | 'M' | 'R' | 'D' | 'H' | 'V' | 'N' => 'A',
-                    'C' | 'S' | 'Y' | 'B' => 'C',
-                    'G' | 'K' => 'G',
-                    'T' => 'T',
-                    _ => {
-                        valid = false;
-                        ' '
-                    }
-                }
-            })
-            .collect();
-        if !valid {
-            return Err("invalid char");
-        }
-
-        // If the input table is correct (which it is) every valid codon is in it
-        // so unwrap() shouldn't panic.
-        Ok(self.actual_codons.get(&lookup.as_ref()).unwrap())
-    }
+pub fn parse<'a>(pairs: Vec<(&'a str, &'a str)>) -> CodonsInfo<'a> {
+    unimplemented!(
+        "Construct a new CodonsInfo struct from given pairs: {:?}",
+        pairs
+    );
 }


### PR DESCRIPTION
I missed [one more clippy warning](https://github.com/exercism/rust/actions/runs/5612515528/job/15206434155) in the stubs.

It actually occurred in the stub of a deprecated exercise, which had a full implementation as a stub because of https://github.com/exercism/rust/pull/832.

I turned them back into regular stubs, so we don't have to maintain implementations of deprecated exercises.