### PR TITLE
Document available crates

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,8 +1,12 @@
 # Writing the Code
 
-Write your code in `src/lib.rs`. Some exercises come with a stub file in `src/lib.rs` that will show you the signatures of the code you'll need to write. If the exercise does not come with a `src/lib.rs` file, create one.
+Write your code in `src/lib.rs`.
+The exercises come with a stub file in `src/lib.rs` that will show you the signatures of the code you'll need to write.
 
-The directory must be named `src` and the file must be named `lib.rs` otherwise your code will not compile. For more details, check out the rustlang book [chapter on modules](https://doc.rust-lang.org/book/ch07-02-defining-modules-to-control-scope-and-privacy.html)
+For most exercises, it is best to write all your code in the file `src/lib.rs`.
+If you would like to split your solution into several files, consult the Rust book's [chapter on modules][chapter-modules].
+
+[chapter-modules]: https://doc.rust-lang.org/book/ch07-02-defining-modules-to-control-scope-and-privacy.html
 
 ## Running Tests
 
@@ -12,8 +16,17 @@ To run the tests, all you need to do is run the following command:
 $ cargo test
 ```
 
-Only the first test is enabled by default.  After you are ready to pass the next test, remove the ignore flag from the next test (`#[ignore]`).  You can also remove the flag from all the tests at once if you prefer.
+Only the first test is enabled by default.
+After you are ready to pass the next test, remove the ignore flag from the next test (`#[ignore]`).
+You can also remove the flag from all the tests at once if you prefer.
 
-You should try to write as little code possible to get the tests to pass.  Let the test failures guide you to what should be written next.
+Feel free to write as little code as possible to get the tests to pass.
+The test failures will guide you to what should be written next.
 
-Because Rust checks all code at compile time you may find that your tests won't compile until you write the required code. Even `ignore`d tests are checked at compile time. You can [comment out](https://doc.rust-lang.org/book/ch03-04-comments.html) tests that won't compile by starting each line with a `//`. Then, when you're ready to work on that test, you can un-comment it.
+Because Rust checks all code at compile time, you may find that your tests won't compile until you write the required code.
+Even `ignore`d tests are checked at compile time.
+You can [comment out][comments] tests that won't compile by starting each line with a `//`.
+Then, when you're ready to work on that test, you can un-comment it.
+Rust also has a special macro called `todo!()`, which you can use on unfinished code paths to make your program compile.
+
+[comments]: https://doc.rust-lang.org/book/ch03-04-comments.html

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -30,3 +30,13 @@ Then, when you're ready to work on that test, you can un-comment it.
 Rust also has a special macro called `todo!()`, which you can use on unfinished code paths to make your program compile.
 
 [comments]: https://doc.rust-lang.org/book/ch03-04-comments.html
+
+## Using libraries
+
+You should be able to solve most exercises without using any external libraries.
+Nevertheless, you can add libraries (the Rust community calls them **crates**) by running `cargo add crate-name` in the directory of an exercise.
+
+The automatic tests on the website only support a predefined set of crates, which can be found [here][local-registry] under the section `[dependencies]`.
+Feel free to open an issue or pull request if you would like support for a specific crate to be added.
+
+[local-registry]: https://github.com/exercism/rust-test-runner/blob/main/local-registry/Cargo.toml


### PR DESCRIPTION
closes #1365

I'm not sure if the `docs/TESTS.md` file is the correct place to add this, but the [building documentation](https://exercism.org/docs/building/tracks/docs) has an example where that is the case.

I slightly updated the rest of that file as well.