### PR TITLE
acronym exercise: add new test case for single character

### DIFF
--- a/exercises/practice/acronym/tests/acronym.rs
+++ b/exercises/practice/acronym/tests/acronym.rs
@@ -5,6 +5,12 @@ fn empty() {
 
 #[test]
 #[ignore]
+fn one_char_string(){
+    assert_eq!(acronym::abbreviate("z", "Z");
+}
+
+#[test]
+#[ignore]
 fn basic() {
     assert_eq!(acronym::abbreviate("Portable Network Graphics"), "PNG");
 }


### PR DESCRIPTION
When I was solving this exercise, I noticed that my solution would fail for cases where the input string is one character long. This PR adds a new test case to ensure that the solution handles this edge case properly.