### PR TITLE
Replace actions-rs with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,10 +113,9 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Setup toolchain
-        uses: actions-rs/toolchain@v1.0.7
+        uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e
         with:
           toolchain: ${{ matrix.rust }}
-          default: true
 
       # run scripts as steps
       - name: Check exercises
@@ -141,10 +140,9 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Setup toolchain
-        uses: actions-rs/toolchain@v1.0.7
+        uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e
         with:
           toolchain: stable
-          default: true
 
       - name: Rust Format Version
         run: rustfmt --version
@@ -177,10 +175,9 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Setup toolchain
-        uses: actions-rs/toolchain@v1.0.7
+        uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e
         with:
           toolchain: ${{ matrix.rust }}
-          default: true
 
       # Clippy already installed on Stable, but not Beta.
       # So, we must install here.
@@ -214,10 +211,9 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Setup nightly toolchain
-        uses: actions-rs/toolchain@v1.0.7
+        uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e
         with:
           toolchain: nightly
-          default: true
 
       - name: Check exercises
         env:


### PR DESCRIPTION
actions-rs is unmaintained, the last commit is from March 2020. https://github.com/actions-rs/toolchain

The Rust community recommends dtolnay/rust-toolchain these days, e.g. https://blessed.rs/crates#section-tooling

The fact that actions-rs is unmaintained shows for example in the [deprecation warnings](https://github.com/exercism/rust/actions/runs/5633367871) we're getting in CI

Judging from the [documentation](https://github.com/dtolnay/rust-toolchain#inputs), I think the toolchain specifier remains the same.