### PR TITLE
Add test case for early returns in `anagram`

### DIFF
--- a/exercises/practice/anagram/tests/anagram.rs
+++ b/exercises/practice/anagram/tests/anagram.rs
@@ -184,3 +184,15 @@ fn test_different_words_but_same_ascii_sum() {
 
     process_anagram_case(word, &inputs, &outputs);
 }
+
+#[test]
+#[ignore]
+fn test_does_not_return_early_after_own_anagram() {
+    let word = "hello";
+
+    let inputs = ["nothing", "hello", "banana", "olleh", "zombies"];
+
+    let outputs = vec!["olleh"];
+
+    process_anagram_case(word, &inputs, &outputs);
+}


### PR DESCRIPTION
I've seen during mentoring an incorrect solution using `return` instead of `continue` to skip the trivial solution, which would cause the function to miss genuine anagrams coming after the trivial solution.

None of the existing tests catch that bug; here is a new test case that does.