### PR TITLE
Saddle-points: fix formatting of instructions

### DIFF
--- a/exercises/practice/saddle-points/.docs/instructions.md
+++ b/exercises/practice/saddle-points/.docs/instructions.md
@@ -12,11 +12,13 @@ Or it might have one, or even several.
 
 Here is a grid that has exactly one candidate tree.
 
+```
     1  2  3  4
   |-----------
 1 | 9  8  7  8
 2 | 5  3  2  4  <--- potential tree house at row 2, column 1, for tree with height 5
 3 | 6  6  7  1
+```
 
 - Row 2 has values 5, 3, and 1. The largest value is 5.
 - Column 1 has values 9, 5, and 6. The smallest value is 5.


### PR DESCRIPTION
First line of demo grid is interpreted as a code block and the rest as paragraph text. Wrapping the whole thing in code tags forces it to be shown in fixed-width text instead.