### PR TITLE
Update anagrams_for signature

### DIFF
--- a/exercises/practice/anagram/src/lib.rs
+++ b/exercises/practice/anagram/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-pub fn anagrams_for<'a>(word: &str, possible_anagrams: &[&str]) -> HashSet<&'a str> {
+pub fn anagrams_for<'a>(word: &str, possible_anagrams: &[&'a str]) -> HashSet<&'a str> {
     unimplemented!(
         "For the '{word}' word find anagrams among the following words: {possible_anagrams:?}"
     );


### PR DESCRIPTION
Rust suggests adding explicit lifetime `'a` to the type of `possible_anagrams`.

<details>

<summary>Details</summary>

```
exercism/rust/anagram via 🦀 v1.72.0
❯ cargo test
   Compiling anagram v0.0.0 (/Users/albert/Projects/practice/exercism/rust/anagram)
error[E0621]: explicit lifetime required in the type of `possible_anagrams`
  --> src/lib.rs:7:5
   |
3  |   pub fn anagrams_for<'a>(word: &str, possible_anagrams: &[&str]) -> HashSet<&'a str> {
   |                                                          ------- help: add explicit lifetime `'a` to the type of `possible_anagrams`: `&[&'a str]`
...
7  | /     possible_anagrams
8  | |         .iter()
9  | |         .copied()
10 | |         .filter(|&anagram| {
...  |
14 | |         })
15 | |         .collect()
   | |__________________^ lifetime `'a` required

For more information about this error, try `rustc --explain E0621`.
error: could not compile `anagram` due to previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `anagram` due to previous error

```

</details>