### PR TITLE
all-your-base: Update outdated comment

### DIFF
--- a/exercises/practice/all-your-base/src/lib.rs
+++ b/exercises/practice/all-your-base/src/lib.rs
@@ -12,8 +12,7 @@ pub enum Error {
 /// A digit is any unsigned integer (e.g. u8, u16, u32, u64, or usize).
 /// Bases are specified as unsigned integers.
 ///
-/// Return an `Err(.)` if the conversion is impossible.
-/// The tests do not test for specific values inside the `Err(.)`.
+/// Return the corresponding Error enum if the conversion is impossible.
 ///
 ///
 /// You are allowed to change the function signature as long as all test still pass.


### PR DESCRIPTION
This exercise was revised to use domain specific errors. However, a  leftover comment still suggests, that the specific value in Err(.) won't be checked.