### PR TITLE
Enforce idiomatic error handling in bash

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 
+      - name: Fetch origin/main
+        run: git fetch --depth=1 origin main
+
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e
         with:
@@ -130,6 +133,7 @@ jobs:
         uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e
         with:
           toolchain: ${{ matrix.rust }}
+          components: clippy
 
       - name: Clippy tests
         env:

--- a/bin/check_exercises.sh
+++ b/bin/check_exercises.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
-
-# In DENYWARNINGS or CLIPPY mode, do not set -e so that we run all tests.
-# This allows us to see all warnings.
-# If we are in neither DENYWARNINGS nor CLIPPY mode, do set -e.
-if [ -z "$DENYWARNINGS" ] && [ -z "$CLIPPY" ]; then
-    set -e
-fi
+set -eo pipefail
 
 # can't benchmark with a stable compiler; to bench, use
 # $ BENCHMARK=1 rustup run nightly bin/check_exercises.sh

--- a/bin/check_exercises.sh
+++ b/bin/check_exercises.sh
@@ -12,13 +12,14 @@ fi
 repo=$(git rev-parse --show-toplevel)
 
 if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-   files="$(
-      git diff --diff-filter=d --name-only remotes/origin/main |
-      grep "exercises/" |
-      cut -d '/' -f -3 |
-      sort -u |
-      awk -v repo="$repo" '{print repo"/"$1}'
-   )"
+    git fetch --depth=1 origin main
+    files="$(
+        git diff --diff-filter=d --name-only remotes/origin/main |
+        grep "exercises/" || true |
+        cut -d '/' -f -3 |
+        sort -u |
+        awk -v repo="$repo" '{print repo"/"$1}'
+    )"
 else
     files="$repo/exercises/*/*"
 fi
@@ -27,39 +28,39 @@ return_code=0
 # An exercise worth testing is defined here as any top level directory with
 # a 'tests' directory and a .meta/config.json.
 for exercise in $files; do
-   exercise="$exercise/$target_dir"
+    exercise="$exercise/$target_dir"
 
-   # This assumes that exercises are only one directory deep
-   # and that the primary module is named the same as the directory
-   directory=$(dirname "${exercise}")
+    # This assumes that exercises are only one directory deep
+    # and that the primary module is named the same as the directory
+    directory=$(dirname "${exercise}")
 
-   # An exercise must have a .meta/config.json
-   metaconf="$directory/.meta/config.json"
-   if [ ! -f "$metaconf" ]; then
-      continue
-   fi
+    # An exercise must have a .meta/config.json
+    metaconf="$directory/.meta/config.json"
+    if [ ! -f "$metaconf" ]; then
+        continue
+    fi
 
-   release=""
-   if [ -z "$BENCHMARK" ] && jq --exit-status '.custom?."test-in-release-mode"?' "$metaconf"; then
-      # release mode is enabled if not benchmarking and the appropriate key is neither `false` nor `null`.
-      release="--release"
-   fi
+    release=""
+    if [ -z "$BENCHMARK" ] && jq --exit-status '.custom?."test-in-release-mode"?' "$metaconf"; then
+        # release mode is enabled if not benchmarking and the appropriate key is neither `false` nor `null`.
+        release="--release"
+    fi
 
-   if [ -n "$DENYWARNINGS" ]; then
-      # Output a progress dot, because we may not otherwise produce output in > 10 mins.
-      echo -n '.'
-      # No-run mode so we see no test output.
-      # Quiet mode so we see no compile output
-      # (such as "Compiling"/"Downloading").
-      # Compiler errors will still be shown though.
-      # Both flags are necessary to keep things quiet.
-      ./bin/test_exercise.sh "$directory" --quiet --no-run
-      return_code=$((return_code | $?))
-   else
-      # Run the test and get the status
-      ./bin/test_exercise.sh "$directory" $release
-      return_code=$((return_code | $?))
-   fi
+    if [ -n "$DENYWARNINGS" ]; then
+        # Output a progress dot, because we may not otherwise produce output in > 10 mins.
+        echo -n '.'
+        # No-run mode so we see no test output.
+        # Quiet mode so we see no compile output
+        # (such as "Compiling"/"Downloading").
+        # Compiler errors will still be shown though.
+        # Both flags are necessary to keep things quiet.
+        ./bin/test_exercise.sh "$directory" --quiet --no-run
+        return_code=$((return_code | $?))
+    else
+        # Run the test and get the status
+        ./bin/test_exercise.sh "$directory" $release
+        return_code=$((return_code | $?))
+    fi
 done
 
 exit $return_code

--- a/bin/ensure_stubs_compile.sh
+++ b/bin/ensure_stubs_compile.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 repo="$(git rev-parse --show-toplevel)"
 

--- a/bin/ensure_stubs_compile.sh
+++ b/bin/ensure_stubs_compile.sh
@@ -4,13 +4,14 @@ set -eo pipefail
 repo="$(git rev-parse --show-toplevel)"
 
 if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-  changed_exercises="$(
-    git diff --diff-filter=d --name-only remotes/origin/main |
-    grep "exercises/" |
-    cut -d '/' -f -3 |
-    sort -u |
-    awk -v repo="$repo" '{print repo"/"$1}'
-  )"
+    git fetch --depth=1 origin main
+    changed_exercises="$(
+        git diff --diff-filter=d --name-only remotes/origin/main |
+        grep "exercises/" || true |
+        cut -d '/' -f -3 |
+        sort -u |
+        awk -v repo="$repo" '{print repo"/"$1}'
+    )"
 else
     # we want globbing and it does not actually assign locally
     # shellcheck disable=SC2125
@@ -32,47 +33,47 @@ for dir in $changed_exercises; do
 
     # An exercise must have a .meta/config.json
     if [ ! -f "$config_file" ]; then
-       continue
+        continue
     fi
 
     if jq --exit-status '.custom?."allowed-to-not-compile"?' "$config_file"; then
-      echo "$exercise's stub is allowed to not compile"
-      continue
+        echo "$exercise's stub is allowed to not compile"
+        continue
     fi
 
     # Backup tests and stub; this script will modify them.
     cp -r "$dir/tests" "$dir/tests.orig"
     cp "$dir/src/lib.rs" "$dir/lib.rs.orig"
 
-  # In CI, we may have already compiled using the example solution.
-  # So we want to touch the src/lib.rs in some way,
-  # so that we surely recompile using the stub.
-  # Since we also want to deny warnings, that will also serve as the touch.
-  sed -i -e '1i #![deny(warnings)]' "$dir/src/lib.rs"
+    # In CI, we may have already compiled using the example solution.
+    # So we want to touch the src/lib.rs in some way,
+    # so that we surely recompile using the stub.
+    # Since we also want to deny warnings, that will also serve as the touch.
+    sed -i -e '1i #![deny(warnings)]' "$dir/src/lib.rs"
 
     # Deny warnings in the tests that may result from compiling the stubs.
     # This helps avoid, for example, an overflowing literal warning
     # that could be caused by a stub with a type that is too small.
     sed -i -e '1i #![deny(warnings)]' "$dir"/tests/*.rs
 
-  if [ -n "$CLIPPY" ]; then
-    echo "clippy $exercise..."
-    # We don't find it useful in general to have students implement Default,
-    # since we're generally not going to test it.
-    if ! (
-      cd "$dir" &&
-      cargo clippy --lib --tests --color always -- --allow clippy::new_without_default 2>clippy.log
-    ); then
-      cat "$dir/clippy.log"
-      broken="$broken\n$exercise"
-    else
-      # Just to show progress
-      echo "... OK"
+    if [ -n "$CLIPPY" ]; then
+        echo "clippy $exercise..."
+        # We don't find it useful in general to have students implement Default,
+        # since we're generally not going to test it.
+        if ! (
+            cd "$dir" &&
+            cargo clippy --lib --tests --color always -- --allow clippy::new_without_default 2>clippy.log
+        ); then
+            cat "$dir/clippy.log"
+            broken="$broken\n$exercise"
+        else
+            # Just to show progress
+            echo "... OK"
+        fi
+    elif ! (cd "$dir" && cargo test --quiet --no-run); then
+        echo "$exercise's stub does not compile; please make it compile"
+        broken="$broken\n$exercise"
     fi
-  elif ! (cd "$dir" && cargo test --quiet --no-run); then
-    echo "$exercise's stub does not compile; please make it compile"
-    broken="$broken\n$exercise"
-  fi
 
     # Restore tests and stub.
     mv "$dir/lib.rs.orig" "$dir/src/lib.rs"
@@ -81,6 +82,6 @@ for dir in $changed_exercises; do
 done
 
 if [ -n "$broken" ]; then
-  echo "Exercises that don't compile:$broken"
-  exit 1
+    echo "Exercises that don't compile:$broken"
+    exit 1
 fi

--- a/bin/format_exercises.sh
+++ b/bin/format_exercises.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+set -eo pipefail
+
 # Format existing exercises using rustfmt
-set -e
 
 repo=$(git rev-parse --show-toplevel)
 

--- a/bin/test_exercise.sh
+++ b/bin/test_exercise.sh
@@ -8,24 +8,24 @@ set -eo pipefail
 # exercise directory. Otherwise, assume we're in
 # it currently.
 if [ $# -ge 1 ]; then
-   exercise=$1
-   # if this script is called with arguments, it will pass through
-   # any beyond the first to cargo. Note that we can only get a
-   # free default argument if no arguments at all were passed,
-   # so if you are in the exercise directory and want to pass any
-   # arguments to cargo, you need to include the local path first.
-   # I.e. to test in release mode:
-   # $ test_exercise.sh . --release
-   shift 1
+    exercise=$1
+    # if this script is called with arguments, it will pass through
+    # any beyond the first to cargo. Note that we can only get a
+    # free default argument if no arguments at all were passed,
+    # so if you are in the exercise directory and want to pass any
+    # arguments to cargo, you need to include the local path first.
+    # I.e. to test in release mode:
+    # $ test_exercise.sh . --release
+    shift 1
 else
-   exercise='.'
+    exercise='.'
 fi
 
 # what cargo command will we use?
 if [ -n "$BENCHMARK" ]; then
-   command="bench"
+    command="bench"
 else
-   command="test"
+    command="test"
 fi
 
 declare -a preserve_files=("src/lib.rs" "Cargo.toml" "Cargo.lock")
@@ -33,17 +33,17 @@ declare -a preserve_dirs=("tests")
 
 # reset instructions
 reset () {
-   for file in "${preserve_files[@]}"; do
-      if [ -f "$exercise/$file.orig" ]; then
-         mv -f "$exercise/$file.orig" "$exercise/$file"
-      fi
-   done
-   for dir in "${preserve_dirs[@]}"; do
-      if [ -d "$exercise/$dir.orig" ]; then
-         rm -rf "${exercise:?}/$dir"
-         mv "$exercise/$dir.orig" "$exercise/$dir"
-      fi
-   done
+    for file in "${preserve_files[@]}"; do
+        if [ -f "$exercise/$file.orig" ]; then
+            mv -f "$exercise/$file.orig" "$exercise/$file"
+        fi
+    done
+    for dir in "${preserve_dirs[@]}"; do
+        if [ -d "$exercise/$dir.orig" ]; then
+            rm -rf "${exercise:?}/$dir"
+            mv "$exercise/$dir.orig" "$exercise/$dir"
+        fi
+    done
 }
 
 # cause the reset to execute when the script exits normally or is killed
@@ -51,62 +51,62 @@ trap reset EXIT INT TERM
 
 # preserve the files and directories we care about
 for file in "${preserve_files[@]}"; do
-   if [ -f "$exercise/$file" ]; then
-      cp "$exercise/$file" "$exercise/$file.orig"
-   fi
+    if [ -f "$exercise/$file" ]; then
+        cp "$exercise/$file" "$exercise/$file.orig"
+    fi
 done
 for dir in "${preserve_dirs[@]}"; do
-   if [ -d "$exercise/$dir" ]; then
-      cp -r "$exercise/$dir" "$exercise/$dir.orig"
-   fi
+    if [ -d "$exercise/$dir" ]; then
+        cp -r "$exercise/$dir" "$exercise/$dir.orig"
+    fi
 done
 
 # Move example files to where Cargo expects them
 if [ -f "$exercise/.meta/example.rs" ]; then
-   example="$exercise/.meta/example.rs"
+    example="$exercise/.meta/example.rs"
 elif [ -f "$exercise/.meta/exemplar.rs" ]; then
-   example="$exercise/.meta/exemplar.rs"
+    example="$exercise/.meta/exemplar.rs"
 else
-   echo "Could not locate example implementation for $exercise"
-   exit 1
+    echo "Could not locate example implementation for $exercise"
+    exit 1
 fi
 
 cp -f "$example" "$exercise/src/lib.rs"
 if [ -f "$exercise/.meta/Cargo-example.toml" ]; then
-   cp -f "$exercise/.meta/Cargo-example.toml" "$exercise/Cargo.toml"
+    cp -f "$exercise/.meta/Cargo-example.toml" "$exercise/Cargo.toml"
 fi
 
 # If deny warnings, insert a deny warnings compiler directive in the header
 if [ -n "$DENYWARNINGS" ]; then
-   sed -i -e '1i #![deny(warnings)]' "$exercise/src/lib.rs"
+    sed -i -e '1i #![deny(warnings)]' "$exercise/src/lib.rs"
 fi
 
 # eliminate #[ignore] lines from tests
 for test in "$exercise/"tests/*.rs; do
-   sed -i -e '/#\[ignore\]/{
-      s/#\[ignore\]\s*//
-      /^\s*$/d
-   }' "$test"
+    sed -i -e '/#\[ignore\]/{
+        s/#\[ignore\]\s*//
+        /^\s*$/d
+    }' "$test"
 done
 
 # run tests from within exercise directory
 # (use subshell so we auto-reset to current pwd after)
 (
-   cd "$exercise"
-   if [ -n "$CLIPPY" ]; then
-     # Consider any Clippy to be an error in tests only.
-     # For now, not the example solutions since they have many Clippy warnings,
-     # and are not shown to students anyway.
-     sed -i -e '1i #![deny(clippy::all)]' tests/*.rs
-     if ! cargo clippy --tests --color always "$@" 2>clippy.log; then
-       cat clippy.log
-       exit 1
-     else
-       # Just to show progress
-       echo "clippy $exercise OK"
-     fi
-   else
-     # this is the last command; its exit code is what's passed on
-     time cargo $command "$@"
-   fi
+cd "$exercise"
+    if [ -n "$CLIPPY" ]; then
+        # Consider any Clippy to be an error in tests only.
+        # For now, not the example solutions since they have many Clippy warnings,
+        # and are not shown to students anyway.
+        sed -i -e '1i #![deny(clippy::all)]' tests/*.rs
+        if ! cargo clippy --tests --color always "$@" 2>clippy.log; then
+            cat clippy.log
+            exit 1
+        else
+            # Just to show progress
+            echo "clippy $exercise OK"
+        fi
+    else
+        # this is the last command; its exit code is what's passed on
+        time cargo $command "$@"
+    fi
 )

--- a/bin/test_exercise.sh
+++ b/bin/test_exercise.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-
 set -eo pipefail
+
 # Test an exercise
 
 # which exercise are we testing right now?

--- a/rust-tooling/tests/bash_script_conventions.rs
+++ b/rust-tooling/tests/bash_script_conventions.rs
@@ -5,24 +5,27 @@ use exercism_tooling::fs_utils;
 
 /// Runs a function for each bash script in the bin directory.
 /// The function is passed the path of the script.
-fn for_all_scripts(f: fn(PathBuf)) {
+fn for_all_scripts(f: fn(&str)) {
     fs_utils::cd_into_repo_root();
 
     for entry in std::fs::read_dir("bin").unwrap() {
-        f(entry.unwrap().path())
+        let path = entry.unwrap().path();
+        let file_name = path.file_name().unwrap().to_str().unwrap();
+
+        // exceptions:
+        // configlet is not a bash script, but it must be in `bin`.
+        // fetch-configlet comes from upstream, we don't control it.
+        if file_name == "configlet" || file_name == "fetch-configlet" {
+            continue;
+        }
+
+        f(file_name)
     }
 }
 
 #[test]
 fn test_file_extension() {
-    for_all_scripts(|path| {
-        let file_name = path.file_name().unwrap().to_str().unwrap();
-
-        // exceptions
-        if file_name == "fetch-configlet" || file_name == "configlet" {
-            return;
-        }
-
+    for_all_scripts(|file_name| {
         assert!(
             file_name.ends_with(".sh"),
             "name of '{file_name}' should end with .sh"
@@ -32,18 +35,8 @@ fn test_file_extension() {
 
 #[test]
 fn test_snake_case_name() {
-    for_all_scripts(|path| {
-        let file_name = path
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .trim_end_matches(".sh");
-
-        // fetch-configlet comes from upstream, we don't control its name
-        if file_name == "fetch-configlet" {
-            return;
-        }
+    for_all_scripts(|file_name| {
+        let file_name = file_name.trim_end_matches(".sh");
 
         assert!(
             file_name.is_case(Case::Snake),
@@ -55,18 +48,22 @@ fn test_snake_case_name() {
 /// Notably on nixOS and macOS, bash is not installed in `/bin/bash`.
 #[test]
 fn test_portable_shebang() {
-    for_all_scripts(|path| {
-        let file_name = path.file_name().unwrap().to_str().unwrap();
-
-        // not a bash script, but it must be in `bin`
-        if file_name == "configlet" {
-            return;
-        }
-
-        let contents = std::fs::read_to_string(&path).unwrap();
+    for_all_scripts(|file_name| {
+        let contents = std::fs::read_to_string(PathBuf::from("bin").join(file_name)).unwrap();
         assert!(
             contents.starts_with("#!/usr/bin/env bash"),
             "'{file_name}' should start with the shebang '#!/usr/bin/env bash'"
+        );
+    })
+}
+
+#[test]
+fn error_handling_flags() {
+    for_all_scripts(|file_name| {
+        let contents = std::fs::read_to_string(PathBuf::from("bin").join(file_name)).unwrap();
+        assert!(
+            contents.contains("set -eo pipefail"),
+            "'{file_name}' should set error handling flags 'set -eo pipefail'"
         );
     })
 }


### PR DESCRIPTION
Single commands that may error can stil be achieved with `|| true`.
With this change, we'll only see a limited number of clippy warnings
in CI. I think that's fine, the one fixing it can still remove these
flags locally while working on the fix to see all warnings.