### PR TITLE
Symlink problem-specifications for easy reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 exercises/*/*/Cargo.lock
 exercises/*/*/clippy.log
 .vscode
+.prob-spec

--- a/bin/symlink_problem_specifications.sh
+++ b/bin/symlink_problem_specifications.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+for exercise in exercises/practice/*; do
+    name="$(basename "$exercise")"
+    if [ -d "problem-specifications/exercises/$name" ]; then
+        [ -e "$exercise/.prob-spec" ] && rm "$exercise/.prob-spec"
+        ln -s "../../../problem-specifications/exercises/$name" "$exercise/.prob-spec"
+    fi
+done

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -101,6 +101,11 @@ Find some tips about writing tera templates [in the next section](#tera-template
 The full documentation for tera templates is [here][tera-docs].
 Following are some approaches that have worked for our specific needs.
 
+You will likely want to look at the exercise's `canonical-data.json`
+to see what structure your input data has.
+You can use `bin/symlink_problem_specifications.sh` to have this data
+symlinked into the actual exercise directory. Handy!
+
 The name of the input property is different for each exercise.
 The default template will be something like this:
 


### PR DESCRIPTION
This is handy when referring to `canonical-data.json` of an exercise,
while creating / updating the test template for it.
It's all available in the same spot.