### PR TITLE
Fix typo in the example

### DIFF
--- a/exercises/practice/binary-search/.docs/instructions.md
+++ b/exercises/practice/binary-search/.docs/instructions.md
@@ -25,5 +25,5 @@ Let's say we're looking for the number 23 in the following sorted list: `[4, 8, 
 - We start by comparing 23 with the middle element, 16.
 - Since 23 is greater than 16, we can eliminate the left half of the list, leaving us with `[23, 28, 32]`.
 - We then compare 23 with the new middle element, 28.
-- Since 23 is less than 28, we can eliminate the right half of the list: `[23]`.
+- Since 23 is less than 28, we can eliminate the right half of the list, leaving us with `[23]`.
 - We've found our item.


### PR DESCRIPTION
It looked like `[23]` was the deleted part, while it is the one leaved intact instead