### PR TITLE
Cleanup test scripts

### DIFF
--- a/bin/check_exercises.sh
+++ b/bin/check_exercises.sh
@@ -1,66 +1,45 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# can't benchmark with a stable compiler; to bench, use
-# $ BENCHMARK=1 rustup run nightly bin/check_exercises.sh
-if [ -n "$BENCHMARK" ]; then
-    target_dir=benches
-else
-    target_dir=tests
-fi
-
 repo=$(git rev-parse --show-toplevel)
 
 if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
     git fetch --depth=1 origin main
     files="$(
         git diff --diff-filter=d --name-only remotes/origin/main |
-        grep "exercises/" || true |
-        cut -d '/' -f -3 |
-        sort -u |
-        awk -v repo="$repo" '{print repo"/"$1}'
+        grep "exercises/" |
+        cut --delimiter '/' --fields -3 |
+        sort --unique || true
     )"
 else
     files="$repo/exercises/*/*"
 fi
 
-return_code=0
 # An exercise worth testing is defined here as any top level directory with
 # a 'tests' directory and a .meta/config.json.
 for exercise in $files; do
-    exercise="$exercise/$target_dir"
-
-    # This assumes that exercises are only one directory deep
-    # and that the primary module is named the same as the directory
-    directory=$(dirname "${exercise}")
+    slug=$(basename "$exercise")
 
     # An exercise must have a .meta/config.json
-    metaconf="$directory/.meta/config.json"
+    metaconf="$exercise/.meta/config.json"
     if [ ! -f "$metaconf" ]; then
         continue
     fi
 
-    release=""
-    if [ -z "$BENCHMARK" ] && jq --exit-status '.custom?."test-in-release-mode"?' "$metaconf"; then
+    # suppress compilation output
+    cargo_args="--quiet"
+
+    if [ -z "$BENCHMARK" ] && jq --exit-status '.custom?."test-in-release-mode"?' "$metaconf" > /dev/null; then
         # release mode is enabled if not benchmarking and the appropriate key is neither `false` nor `null`.
-        release="--release"
+        cargo_args="$cargo_args --release"
     fi
 
-    if [ -n "$DENYWARNINGS" ]; then
-        # Output a progress dot, because we may not otherwise produce output in > 10 mins.
-        echo -n '.'
+    if [ -n "$DENYWARNINGS" ] && [ -z "$CLIPPY" ]; then
         # No-run mode so we see no test output.
-        # Quiet mode so we see no compile output
-        # (such as "Compiling"/"Downloading").
-        # Compiler errors will still be shown though.
-        # Both flags are necessary to keep things quiet.
-        ./bin/test_exercise.sh "$directory" --quiet --no-run
-        return_code=$((return_code | $?))
-    else
-        # Run the test and get the status
-        ./bin/test_exercise.sh "$directory" $release
-        return_code=$((return_code | $?))
+        # clippy does not understand this flag.
+        cargo_args="$cargo_args --no-run"
     fi
-done
 
-exit $return_code
+    echo "Checking $slug..."
+    ./bin/test_exercise.sh "$slug" "$cargo_args"
+done

--- a/bin/ensure_stubs_compile.sh
+++ b/bin/ensure_stubs_compile.sh
@@ -7,10 +7,9 @@ if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
     git fetch --depth=1 origin main
     changed_exercises="$(
         git diff --diff-filter=d --name-only remotes/origin/main |
-        grep "exercises/" || true |
-        cut -d '/' -f -3 |
-        sort -u |
-        awk -v repo="$repo" '{print repo"/"$1}'
+        grep "exercises/" |
+        cut --delimiter '/' --fields -3 |
+        sort --unique || true
     )"
 else
     # we want globbing and it does not actually assign locally

--- a/bin/test_exercise.sh
+++ b/bin/test_exercise.sh
@@ -1,112 +1,81 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Test an exercise
+cd "$(git rev-parse --show-toplevel)"
 
-# which exercise are we testing right now?
-# if we were passed an argument, that should be the
-# exercise directory. Otherwise, assume we're in
-# it currently.
-if [ $# -ge 1 ]; then
-    exercise=$1
-    # if this script is called with arguments, it will pass through
-    # any beyond the first to cargo. Note that we can only get a
-    # free default argument if no arguments at all were passed,
-    # so if you are in the exercise directory and want to pass any
-    # arguments to cargo, you need to include the local path first.
-    # I.e. to test in release mode:
-    # $ test_exercise.sh . --release
-    shift 1
-else
-    exercise='.'
+if [ $# -eq 0 ]; then
+    echo "Usage: <exercise-slug> [cargo args]"
+    exit 1
+fi
+
+slug="$1"
+cargo_args="$2"
+
+# determine the exercise path from the slug
+for p in exercises/{practice,concept}/* ; do
+    if [[ "$p" =~ $slug ]]; then
+        exercise_path=$p
+        break
+    fi
+done
+if [ -z "$exercise_path" ]; then
+    echo "Could not find exercise path for $slug"
+    exit 1
 fi
 
 # what cargo command will we use?
 if [ -n "$BENCHMARK" ]; then
-    command="bench"
+    command="+nightly bench"
+    if [ ! -e "$exercise_path/benches" ]; then
+        # no benches, nothing to do
+        exit
+    fi
 else
     command="test"
 fi
 
-declare -a preserve_files=("src/lib.rs" "Cargo.toml" "Cargo.lock")
-declare -a preserve_dirs=("tests")
+# setup temporary directory for the exercise
+tmp_dir=$(mktemp -d)
+trap 'rm -rf $tmp_dir' EXIT INT TERM
 
-# reset instructions
-reset () {
-    for file in "${preserve_files[@]}"; do
-        if [ -f "$exercise/$file.orig" ]; then
-            mv -f "$exercise/$file.orig" "$exercise/$file"
-        fi
-    done
-    for dir in "${preserve_dirs[@]}"; do
-        if [ -d "$exercise/$dir.orig" ]; then
-            rm -rf "${exercise:?}/$dir"
-            mv "$exercise/$dir.orig" "$exercise/$dir"
-        fi
-    done
-}
-
-# cause the reset to execute when the script exits normally or is killed
-trap reset EXIT INT TERM
-
-# preserve the files and directories we care about
-for file in "${preserve_files[@]}"; do
-    if [ -f "$exercise/$file" ]; then
-        cp "$exercise/$file" "$exercise/$file.orig"
+# copy the exercise to the temporary directory
+contents_to_copy=(
+    "src"
+    "tests"
+    "benches"
+    "Cargo.toml"
+)
+for c in "${contents_to_copy[@]}"; do
+    if [ ! -e "$exercise_path/$c" ]; then
+        continue
     fi
-done
-for dir in "${preserve_dirs[@]}"; do
-    if [ -d "$exercise/$dir" ]; then
-        cp -r "$exercise/$dir" "$exercise/$dir.orig"
-    fi
+    cp -r "$exercise_path/$c" "$tmp_dir"
 done
 
 # Move example files to where Cargo expects them
-if [ -f "$exercise/.meta/example.rs" ]; then
-    example="$exercise/.meta/example.rs"
-elif [ -f "$exercise/.meta/exemplar.rs" ]; then
-    example="$exercise/.meta/exemplar.rs"
+if [ -f "$exercise_path/.meta/example.rs" ]; then
+    cp -f "$exercise_path/.meta/example.rs" "$tmp_dir/src/lib.rs"
+elif [ -f "$exercise_path/.meta/exemplar.rs" ]; then
+    cp -f "$exercise_path/.meta/exemplar.rs" "$tmp_dir/src/lib.rs"
 else
-    echo "Could not locate example implementation for $exercise"
+    echo "Could not locate example implementation for $exercise_path"
     exit 1
 fi
-
-cp -f "$example" "$exercise/src/lib.rs"
-if [ -f "$exercise/.meta/Cargo-example.toml" ]; then
-    cp -f "$exercise/.meta/Cargo-example.toml" "$exercise/Cargo.toml"
+if [ -f "$exercise_path/.meta/Cargo-example.toml" ]; then
+    cp -f "$exercise_path/.meta/Cargo-example.toml" "$tmp_dir/Cargo.toml"
 fi
 
-# If deny warnings, insert a deny warnings compiler directive in the header
 if [ -n "$DENYWARNINGS" ]; then
-    sed -i -e '1i #![deny(warnings)]' "$exercise/src/lib.rs"
+    export RUSTFLAGS="$RUSTFLAGS -D warnings"
 fi
 
-# eliminate #[ignore] lines from tests
-for test in "$exercise/"tests/*.rs; do
-    sed -i -e '/#\[ignore\]/{
-        s/#\[ignore\]\s*//
-        /^\s*$/d
-    }' "$test"
-done
-
-# run tests from within exercise directory
-# (use subshell so we auto-reset to current pwd after)
-(
-cd "$exercise"
-    if [ -n "$CLIPPY" ]; then
-        # Consider any Clippy to be an error in tests only.
-        # For now, not the example solutions since they have many Clippy warnings,
-        # and are not shown to students anyway.
-        sed -i -e '1i #![deny(clippy::all)]' tests/*.rs
-        if ! cargo clippy --tests --color always "$@" 2>clippy.log; then
-            cat clippy.log
-            exit 1
-        else
-            # Just to show progress
-            echo "clippy $exercise OK"
-        fi
-    else
-        # this is the last command; its exit code is what's passed on
-        time cargo $command "$@"
-    fi
-)
+# run tests from within temporary directory
+cd "$tmp_dir"
+if [ -n "$CLIPPY" ]; then
+    export RUSTFLAGS="$RUSTFLAGS -D clippy::all"
+    # shellcheck disable=SC2086
+    cargo clippy --tests $cargo_args
+else
+    # shellcheck disable=SC2086
+    cargo $command $cargo_args -- --include-ignored
+fi


### PR DESCRIPTION
Most importantly, move all required files for testing to a tmp dir. This means the actual files in the repository are not modified anymore. Running these scripts locally does not interrupt the git workflow now.

The output is also cleaned up in various situations.

closes #1738 