### PR TITLE
Fix clippy warnings in example solutions

### DIFF
--- a/docs/archived/exercise-concepts/luhn.md
+++ b/docs/archived/exercise-concepts/luhn.md
@@ -47,8 +47,8 @@ Canonical
 
 ```rust
 pub fn is_valid(candidate: &str) -> bool {
-    if candidate.chars().filter(|c| c.is_digit(10)).take(2).count() <= 1
-        || candidate.chars().any(|c| !c.is_digit(10) && c != ' ')
+    if candidate.chars().filter(|c| c.is_ascii_digit()).take(2).count() <= 1
+        || candidate.chars().any(|c| !c.is_ascii_digit() && c != ' ')
     {
         return false;
     }

--- a/exercises/concept/csv-builder/.meta/exemplar.rs
+++ b/exercises/concept/csv-builder/.meta/exemplar.rs
@@ -16,9 +16,9 @@ impl CsvRecordBuilder {
             self.content.push(',');
         }
 
-        if val.contains(",") || val.contains(r#"""#) || val.contains("\n") {
+        if val.contains(',') || val.contains('"') || val.contains('\n') {
             self.content.push('"');
-            self.content.push_str(&val.replace(r#"""#, r#""""#));
+            self.content.push_str(&val.replace('"', r#""""#));
             self.content.push('"');
         } else {
             self.content.push_str(val);
@@ -28,5 +28,11 @@ impl CsvRecordBuilder {
     /// Consumes the builder and returns the CSV record.
     pub fn build(self) -> String {
         self.content
+    }
+}
+
+impl Default for CsvRecordBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/exercises/practice/acronym/.meta/example.rs
+++ b/exercises/practice/acronym/.meta/example.rs
@@ -1,7 +1,7 @@
 pub fn abbreviate(phrase: &str) -> String {
     phrase
         .split(|c: char| c.is_whitespace() || (c != '\'' && !c.is_alphanumeric()))
-        .flat_map(|word| split_camel(word))
+        .flat_map(split_camel)
         .filter_map(|word| word.chars().next())
         .collect::<String>()
         .to_uppercase()

--- a/exercises/practice/affine-cipher/.meta/example.rs
+++ b/exercises/practice/affine-cipher/.meta/example.rs
@@ -43,7 +43,7 @@ pub fn decode(ciphertext: &str, a: i32, b: i32) -> Result<String, AffineCipherEr
 /// Encodes a single char with the key (`a`, `b`). The key is assumed to be valid (i.e. `a` should
 /// be coprime to 26).
 fn encode_char(ch: char, a: i32, b: i32) -> char {
-    if ch.is_digit(10) {
+    if ch.is_ascii_digit() {
         ch
     } else {
         let index = (ch as i32) - ('a' as i32);
@@ -54,7 +54,7 @@ fn encode_char(ch: char, a: i32, b: i32) -> char {
 
 /// Decodes a single char using `inv` (the modular multiplicative inverse of `a`) and `b`.
 fn decode_char(ch: char, inv: i32, b: i32) -> char {
-    if ch.is_digit(10) {
+    if ch.is_ascii_digit() {
         ch
     } else {
         let index = (ch as i32) - ('a' as i32);
@@ -82,7 +82,7 @@ fn modular_multiplicative_inverse(a: i32) -> Option<i32> {
     if rs.0 == 1 {
         // ts.0 gives a number such that (s * 26 + t * a) % 26 == 1. Since (s * 26) % 26 == 0,
         // we can further reduce this to (t * a) % 26 == 1. In other words, t is the MMI of a.
-        Some(ts.0 as i32)
+        Some(ts.0)
     } else {
         None
     }

--- a/exercises/practice/atbash-cipher/.meta/example.rs
+++ b/exercises/practice/atbash-cipher/.meta/example.rs
@@ -3,7 +3,7 @@ fn ascii(ch: char) -> u8 {
 }
 
 fn get_transpose(ch: char) -> char {
-    if ch.is_digit(10) {
+    if ch.is_ascii_digit() {
         ch
     } else {
         (ascii('z') - ascii(ch) + ascii('a')) as char

--- a/exercises/practice/book-store/.meta/example.rs
+++ b/exercises/practice/book-store/.meta/example.rs
@@ -3,7 +3,6 @@ use std::cmp::Ordering;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeSet, HashSet};
 use std::hash::{Hash, Hasher};
-use std::mem;
 
 type Book = u32;
 type Price = u32;
@@ -125,7 +124,7 @@ impl Iterator for DecomposeGroups {
         //    then move the last item from the most populous group into a new group, alone,
         //    and return
         let return_value = self.next.clone();
-        if let Some(groups) = mem::replace(&mut self.next, None) {
+        if let Some(groups) = self.next.take() {
             if !(groups.is_empty() || groups.iter().all(|g| g.0.borrow().len() == 1)) {
                 let mut hypothetical;
                 for mpg_book in groups[0].0.borrow().iter() {
@@ -169,7 +168,7 @@ impl DecomposeGroups {
         let mut book_groups = Vec::new();
         'nextbook: for book in books {
             for Group(book_group) in book_groups.iter() {
-                if !book_group.borrow().contains(&book) {
+                if !book_group.borrow().contains(book) {
                     book_group.borrow_mut().insert(*book);
                     continue 'nextbook;
                 }

--- a/exercises/practice/bowling/.meta/example.rs
+++ b/exercises/practice/bowling/.meta/example.rs
@@ -43,7 +43,7 @@ impl Frame {
             return self.bonus_score() <= 10;
         }
 
-        if let Some(first) = self.bonus.get(0) {
+        if let Some(first) = self.bonus.first() {
             if *first == 10 {
                 self.bonus_score() <= 20
             } else {
@@ -137,5 +137,11 @@ impl BowlingGame {
 
     fn is_done(&self) -> bool {
         self.frames.len() == 10 && self.frames.iter().all(|f| f.is_complete())
+    }
+}
+
+impl Default for BowlingGame {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/exercises/practice/custom-set/.meta/example.rs
+++ b/exercises/practice/custom-set/.meta/example.rs
@@ -5,8 +5,8 @@ pub struct CustomSet<T> {
 
 impl<T: Ord + Clone> PartialEq for CustomSet<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.collection.iter().all(|x| other.contains(&x))
-            && other.collection.iter().all(|x| self.contains(&x))
+        self.collection.iter().all(|x| other.contains(x))
+            && other.collection.iter().all(|x| self.contains(x))
     }
 }
 

--- a/exercises/practice/decimal/.meta/Cargo-example.toml
+++ b/exercises/practice/decimal/.meta/Cargo-example.toml
@@ -4,5 +4,5 @@ name = "decimal"
 version = "0.1.0"
 
 [dependencies]
-num-bigint = "0.1.40"
-num-traits = "0.1.40"
+num-bigint = "0.4.4"
+num-traits = "0.2.16"

--- a/exercises/practice/decimal/.meta/example.rs
+++ b/exercises/practice/decimal/.meta/example.rs
@@ -63,7 +63,7 @@ impl Decimal {
     fn equalize_precision(one: &mut Decimal, two: &mut Decimal) {
         fn expand(lower_precision: &mut Decimal, higher_precision: &Decimal) {
             let precision_difference =
-                (higher_precision.decimal_index - lower_precision.decimal_index) as usize;
+                higher_precision.decimal_index - lower_precision.decimal_index;
 
             lower_precision.digits =
                 &lower_precision.digits * pow(BigInt::from(10_usize), precision_difference);
@@ -102,7 +102,9 @@ macro_rules! auto_impl_decimal_ops {
             fn $func_name(mut self, mut rhs: Self) -> Self {
                 Decimal::equalize_precision(&mut self, &mut rhs);
                 Decimal::new(
+                    #[allow(clippy::redundant_closure_call)]
                     $digits_operation(self.digits, rhs.digits),
+                    #[allow(clippy::redundant_closure_call)]
                     $index_operation(self.decimal_index, rhs.decimal_index),
                 )
             }
@@ -125,6 +127,7 @@ macro_rules! auto_impl_decimal_cow {
         impl $trait for Decimal {
             fn $func_name(&self, other: &Self) -> $return_type {
                 if self.decimal_index == other.decimal_index {
+                    #[allow(clippy::redundant_closure_call)]
                     $digits_operation(&self.digits, &other.digits)
                 } else {
                     // if we're here, the decimal indexes are unmatched.

--- a/exercises/practice/dot-dsl/.meta/example.rs
+++ b/exercises/practice/dot-dsl/.meta/example.rs
@@ -44,6 +44,12 @@ pub mod graph {
         }
     }
 
+    impl Default for Graph {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     pub mod graph_items {
         pub mod edge {
             use std::collections::HashMap;

--- a/exercises/practice/doubly-linked-list/.meta/example.rs
+++ b/exercises/practice/doubly-linked-list/.meta/example.rs
@@ -67,6 +67,12 @@ impl<T> Node<T> {
     }
 }
 
+impl<T> Default for LinkedList<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> LinkedList<T> {
     pub fn new() -> Self {
         LinkedList {
@@ -253,7 +259,7 @@ impl<T> Cursor<'_, T> {
             }
         };
         link_new_node(cursor_node, new_node);
-        let end_node = end_node(&mut self.list);
+        let end_node = end_node(self.list);
         if *end_node == Some(cursor_node) {
             *end_node = Some(new_node);
         }

--- a/exercises/practice/forth/.meta/example.rs
+++ b/exercises/practice/forth/.meta/example.rs
@@ -67,7 +67,6 @@ impl Forth {
                         eval_op(
                             parse_op(token, &self.words)?,
                             &mut self.stack,
-                            &self.words,
                             &self.definitions,
                         )?;
                     }
@@ -96,7 +95,7 @@ impl Forth {
         }
 
         (mode == Mode::Execution)
-            .then(|| ())
+            .then_some(())
             .ok_or(Error::InvalidWord)
     }
 }
@@ -119,12 +118,7 @@ fn parse_op(token: &str, words: &HashMap<String, Id>) -> Result<Op, Error> {
     })
 }
 
-fn eval_op(
-    op: Op,
-    stack: &mut Vec<Value>,
-    words: &HashMap<String, Id>,
-    definitions: &Vec<Vec<Op>>,
-) -> ForthResult {
+fn eval_op(op: Op, stack: &mut Vec<Value>, definitions: &Vec<Vec<Op>>) -> ForthResult {
     let mut pop = || stack.pop().ok_or(Error::StackUnderflow);
     match op {
         Op::Add => {
@@ -165,7 +159,7 @@ fn eval_op(
         }
         Op::Call(fn_id) => {
             for op in &definitions[fn_id as usize] {
-                eval_op(*op, stack, words, definitions)?;
+                eval_op(*op, stack, definitions)?;
             }
         }
     }

--- a/exercises/practice/grade-school/.meta/example.rs
+++ b/exercises/practice/grade-school/.meta/example.rs
@@ -12,7 +12,7 @@ impl School {
     }
 
     pub fn add(&mut self, grade: u32, student: &str) {
-        let entry = self.grades.entry(grade).or_insert_with(Vec::new);
+        let entry = self.grades.entry(grade).or_default();
         entry.push(student.to_string());
         entry.sort_unstable();
     }
@@ -28,5 +28,11 @@ impl School {
             .get(&grade)
             .map(|v| v.to_vec())
             .unwrap_or_default()
+    }
+}
+
+impl Default for School {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/exercises/practice/hexadecimal/.meta/example.rs
+++ b/exercises/practice/hexadecimal/.meta/example.rs
@@ -27,7 +27,7 @@ pub fn hex_to_int(string: &str) -> Option<i64> {
         .chars()
         .rev()
         .enumerate()
-        .fold(Some(0), |acc, (pos, c)| {
-            parse_hex_digit(c).and_then(|n| acc.map(|acc| acc + n * base.pow(pos as u32)))
+        .try_fold(0, |acc, (pos, c)| {
+            parse_hex_digit(c).map(|n| acc + n * base.pow(pos as u32))
         })
 }

--- a/exercises/practice/high-scores/.meta/example.rs
+++ b/exercises/practice/high-scores/.meta/example.rs
@@ -9,7 +9,7 @@ impl<'a> HighScores<'a> {
     }
 
     pub fn scores(&self) -> &'a [u32] {
-        &self.scores
+        self.scores
     }
 
     pub fn latest(&self) -> Option<u32> {

--- a/exercises/practice/largest-series-product/.meta/example.rs
+++ b/exercises/practice/largest-series-product/.meta/example.rs
@@ -9,7 +9,7 @@ pub fn lsp(string_digits: &str, span: usize) -> Result<u64, Error> {
         return Ok(1);
     }
 
-    if let Some(invalid) = string_digits.chars().find(|c| !c.is_digit(10)) {
+    if let Some(invalid) = string_digits.chars().find(|c| !c.is_ascii_digit()) {
         return Err(Error::InvalidDigit(invalid));
     }
 

--- a/exercises/practice/luhn-from/.meta/example.rs
+++ b/exercises/practice/luhn-from/.meta/example.rs
@@ -4,7 +4,7 @@ pub struct Luhn {
 
 impl Luhn {
     pub fn is_valid(&self) -> bool {
-        if self.digits.iter().any(|c| c.is_alphabetic()) || self.digits.iter().count() == 1 {
+        if self.digits.iter().any(|c| c.is_alphabetic()) || self.digits.len() == 1 {
             return false;
         }
 

--- a/exercises/practice/luhn/.meta/example.rs
+++ b/exercises/practice/luhn/.meta/example.rs
@@ -1,6 +1,11 @@
 pub fn is_valid(candidate: &str) -> bool {
-    if candidate.chars().filter(|c| c.is_digit(10)).take(2).count() <= 1
-        || candidate.chars().any(|c| !c.is_digit(10) && c != ' ')
+    if candidate
+        .chars()
+        .filter(|c| c.is_ascii_digit())
+        .take(2)
+        .count()
+        <= 1
+        || candidate.chars().any(|c| !c.is_ascii_digit() && c != ' ')
     {
         return false;
     }

--- a/exercises/practice/matching-brackets/.meta/example.rs
+++ b/exercises/practice/matching-brackets/.meta/example.rs
@@ -23,7 +23,7 @@ impl Brackets {
         };
 
         Brackets {
-            raw_brackets: s.chars().filter(|c| p.contains(&c)).collect::<Vec<char>>(),
+            raw_brackets: s.chars().filter(|c| p.contains(c)).collect::<Vec<char>>(),
             pairs: p,
         }
     }

--- a/exercises/practice/palindrome-products/.meta/example.rs
+++ b/exercises/practice/palindrome-products/.meta/example.rs
@@ -8,7 +8,7 @@ pub struct Palindrome(u64);
 impl Palindrome {
     /// Create a `Palindrome` only if `value` is in fact a palindrome when represented in base ten. Otherwise, `None`.
     pub fn new(value: u64) -> Option<Palindrome> {
-        is_palindrome(value).then(move || Palindrome(value))
+        is_palindrome(value).then_some(Palindrome(value))
     }
 
     /// Get the value of this palindrome.

--- a/exercises/practice/phone-number/.meta/example.rs
+++ b/exercises/practice/phone-number/.meta/example.rs
@@ -1,5 +1,8 @@
 pub fn number(user_number: &str) -> Option<String> {
-    let mut filtered_number: String = user_number.chars().filter(|ch| ch.is_digit(10)).collect();
+    let mut filtered_number: String = user_number
+        .chars()
+        .filter(|ch| ch.is_ascii_digit())
+        .collect();
 
     let number_len = filtered_number.len();
 

--- a/exercises/practice/pig-latin/.meta/example.rs
+++ b/exercises/practice/pig-latin/.meta/example.rs
@@ -26,7 +26,7 @@ pub fn translate_word(word: &str) -> String {
 
 pub fn translate(text: &str) -> String {
     text.split(' ')
-        .map(|w| translate_word(w))
+        .map(translate_word)
         .collect::<Vec<_>>()
         .join(" ")
 }

--- a/exercises/practice/queen-attack/.meta/example.rs
+++ b/exercises/practice/queen-attack/.meta/example.rs
@@ -14,9 +14,9 @@ impl ChessPiece for Queen {
     }
 
     fn can_attack<T: ChessPiece>(&self, piece: &T) -> bool {
-        self.position.horizontal_from(&piece.position())
-            || self.position.vertical_from(&piece.position())
-            || self.position.diagonal_from(&piece.position())
+        self.position.horizontal_from(piece.position())
+            || self.position.vertical_from(piece.position())
+            || self.position.diagonal_from(piece.position())
     }
 }
 

--- a/exercises/practice/react/.meta/example.rs
+++ b/exercises/practice/react/.meta/example.rs
@@ -44,6 +44,7 @@ struct ComputeCell<'a, T: Copy> {
     cell: Cell<T>,
 
     dependencies: Vec<CellId>,
+    #[allow(clippy::type_complexity)]
     f: Box<dyn 'a + Fn(&[T]) -> T>,
     callbacks_issued: usize,
     callbacks: HashMap<CallbackId, Box<dyn 'a + FnMut(T)>>,
@@ -245,5 +246,11 @@ impl<'a, T: Copy + PartialEq> Reactor<'a, T> {
         for d in dependents {
             self.fire_callbacks(d);
         }
+    }
+}
+
+impl<'a, T: Copy + PartialEq> Default for Reactor<'a, T> {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/exercises/practice/rectangles/.meta/example.rs
+++ b/exercises/practice/rectangles/.meta/example.rs
@@ -71,9 +71,11 @@ struct TransposedArea<'a>(&'a RealArea);
 
 // For vertical scanning
 impl<'a> Area for TransposedArea<'a> {
+    #[allow(clippy::misnamed_getters)]
     fn width(&self) -> usize {
         self.0.height
     }
+    #[allow(clippy::misnamed_getters)]
     fn height(&self) -> usize {
         self.0.width
     }

--- a/exercises/practice/robot-name/.meta/example.rs
+++ b/exercises/practice/robot-name/.meta/example.rs
@@ -44,3 +44,9 @@ impl Robot {
         self.name = generate_name();
     }
 }
+
+impl Default for Robot {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/exercises/practice/scale-generator/.meta/example.rs
+++ b/exercises/practice/scale-generator/.meta/example.rs
@@ -96,26 +96,6 @@ pub mod interval {
             &self.0
         }
     }
-
-    #[cfg(test)]
-    mod test {
-        use super::*;
-
-        #[test]
-        fn parse_chromatic() {
-            assert!("mmmmmmmmmmmm".parse::<Intervals>().is_ok());
-        }
-
-        #[test]
-        fn parse_major() {
-            assert!("MMmMMMm".parse::<Intervals>().is_ok());
-        }
-
-        #[test]
-        fn parse_minor() {
-            assert!("MmMMmMM".parse::<Intervals>().is_ok());
-        }
-    }
 }
 
 pub mod note {
@@ -167,8 +147,8 @@ pub mod note {
     }
 
     impl Accidental {
-        fn to_i8(&self) -> i8 {
-            match *self {
+        fn to_i8(self) -> i8 {
+            match self {
                 Accidental::Sharp => 1,
                 Accidental::Flat => -1,
             }
@@ -353,5 +333,25 @@ impl Scale {
         }
 
         out
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::interval::*;
+
+    #[test]
+    fn parse_chromatic() {
+        assert!("mmmmmmmmmmmm".parse::<Intervals>().is_ok());
+    }
+
+    #[test]
+    fn parse_major() {
+        assert!("MMmMMMm".parse::<Intervals>().is_ok());
+    }
+
+    #[test]
+    fn parse_minor() {
+        assert!("MmMMmMM".parse::<Intervals>().is_ok());
     }
 }

--- a/exercises/practice/simple-linked-list/.meta/example.rs
+++ b/exercises/practice/simple-linked-list/.meta/example.rs
@@ -10,6 +10,12 @@ struct Node<T> {
     next: Option<Box<Node<T>>>,
 }
 
+impl<T> Default for SimpleLinkedList<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> SimpleLinkedList<T> {
     pub fn new() -> Self {
         SimpleLinkedList { head: None, len: 0 }

--- a/exercises/practice/tournament/.meta/example.rs
+++ b/exercises/practice/tournament/.meta/example.rs
@@ -70,7 +70,7 @@ fn write_tally(results: &HashMap<String, TeamResult>) -> String {
         .collect();
     // Sort by points descending, then name A-Z.
     v.sort_by(|a, b| match a.3.cmp(&(b.3)).reverse() {
-        Equal => a.0.cmp(&(b.0)),
+        Equal => a.0.cmp(b.0),
         other => other,
     });
     let mut lines = vec![format!("{:30} | MP |  W |  D |  L |  P", "Team")];


### PR DESCRIPTION
CI errors are now surfacing because of [this semi-conscious change](https://github.com/exercism/rust/pull/1746/files#diff-c97b02ca592b9137046a9842fd1d13e04f1baaba1085b41aee9856bea0cfcf6dL97-L100).

Previously, clippy was only run over the test files. Now it is run over the example solutions as well. I like it this way and applied the relevant fixes.