### PR TITLE
acronym: Reintroduce camel case test

### DIFF
--- a/exercises/practice/acronym/.docs/instructions.md
+++ b/exercises/practice/acronym/.docs/instructions.md
@@ -10,8 +10,8 @@ Punctuation is handled as follows: hyphens are word separators (like whitespace)
 
 For example:
 
-|Input|Output|
-|-|-|
-|As Soon As Possible|ASAP|
-|Liquid-crystal display|LCD|
-|Thank George It's Friday!|TGIF|
+| Input                     | Output |
+| ------------------------- | ------ |
+| As Soon As Possible       | ASAP   |
+| Liquid-crystal display    | LCD    |
+| Thank George It's Friday! | TGIF   |

--- a/exercises/practice/acronym/.meta/test_template.tera
+++ b/exercises/practice/acronym/.meta/test_template.tera
@@ -10,3 +10,20 @@ fn {{ test.description | slugify | replace(from="-", to="_") }}() {
     assert_eq!(output, expected);
 }
 {% endfor -%}
+
+{# 
+    This test makes the exercise noticeably harder.
+
+    Upstreaming this test is not a good option,
+    as most other languages would exclude it due to the added difficulty.
+    Removing the test from the Rust track is also not a good option,
+    because it creates confusion regarding existing community solutions.
+
+    While deviations from problem-specifications should generally be avoided,
+    it seems like the best choice to stick with it in this case.
+#}
+#[test]
+#[ignore]
+fn camelcase() {
+    assert_eq!(acronym::abbreviate("HyperText Markup Language"), "HTML");
+}

--- a/exercises/practice/acronym/tests/acronym.rs
+++ b/exercises/practice/acronym/tests/acronym.rs
@@ -77,3 +77,9 @@ fn underscore_emphasis() {
     let expected = "TRNT";
     assert_eq!(output, expected);
 }
+
+#[test]
+#[ignore]
+fn camelcase() {
+    assert_eq!(acronym::abbreviate("HyperText Markup Language"), "HTML");
+}


### PR DESCRIPTION
motivated by [this forum post](https://forum.exercism.org/t/camelcase-test-unintentionally-removed-from-rust-acronym-exercise/7393/3).

(piggybacking the nicely formatted markdown table from upstream.)