### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/exercises/practice/bob/.approaches/answer-array/content.md
+++ b/exercises/practice/bob/.approaches/answer-array/content.md
@@ -61,11 +61,11 @@ If the input is a yell, then `is_yelling` is given the value `2`, otherwise it i
 
 The final expression returns the value in the `ANSWERS` array at the index of the combined values for `is_questioning` and `is_yelling`.
 
-```exercism/note
+~~~~exercism/note
 Note that the final line is just `ANSWERS[is_questioning + is_yelling]`
 This is because the [last expression can be returned](https://doc.rust-lang.org/rust-by-example/fn.html)
 from a function without using `return` and a semicolon.
-```
+~~~~
 
 | is_yelling | is_questioning | Index     | Answer                                |
 | ---------- | -------------- | --------- | ------------------------------------- |

--- a/exercises/practice/bob/.approaches/if-statements/content.md
+++ b/exercises/practice/bob/.approaches/if-statements/content.md
@@ -48,11 +48,11 @@ The uppercasing is done by using the `str` method [`to_uppercase`][to-uppercase]
 - If the input is a question, then the function returns the response for that.
 - Finally, if the function has not returned by the end, the response for neither a yell nor a question is returned.
 
-```exercism/note
+~~~~exercism/note
 Note that the final line is just `"Whatever."`
 This is because the [last expression can be returned](https://doc.rust-lang.org/rust-by-example/fn.html)
 from a function without using `return` and a semicolon.
-```
+~~~~
 
 [str]: https://doc.rust-lang.org/std/primitive.str.html
 [trim-end]: https://doc.rust-lang.org/std/primitive.str.html#method.trim_end

--- a/exercises/practice/bob/.approaches/match-on-tuple/content.md
+++ b/exercises/practice/bob/.approaches/match-on-tuple/content.md
@@ -43,12 +43,12 @@ Since those values are booleans, each arm of the `match` tests a pattern of bool
 - If both the yell value in the tuple is `true` and the question part of the tuple is `true`,
 then the response is returned for a yelled question.
 
-```exercism/note
+~~~~exercism/note
 Note that each arm of the `match` is a single-line expression, so `return` is not needed in the responses returned by the `match` arms.
 And, since the `match` is the last expression in the function, `return` is not used before `match`.
 The [last expression can be returned](https://doc.rust-lang.org/rust-by-example/fn.html)
 from a function without using `return` and a semicolon.
-```
+~~~~
 
 - If the tuple is not `(true, true)`, then the next arm of the `match` tests if the yell value in the tuple is `true`.
 It uses the [wildcard pattern][wildcard] of `_` to disregard the value for the question part of the tuple.
@@ -59,14 +59,14 @@ If the pattern matches, in other words, if the yell value in the tuple is `true`
 This is similar to `default` used in `switch` statements in other languages.
 It returns "Whatever." no matter what the values in the tuple are.
 
-```exercism/note
+~~~~exercism/note
 Note that a `match` in Rust must be exhaustive.
 This means it must match all conceivable patterns of the value being tested or the code will not compile.
 For a boolean value, you can have one arm to match `true` and another to match `false`,
 and the compiler will know that the `match` has checked all conceivable patterns for a boolean.
 For a value with many possible patterns, such as a `u32`, you can have each arm match whatever patterns you care about,
 such as `1` and `2`, and then have one final arm using the wildcard pattern to match on everything else.
-```
+~~~~
 
 [match]: https://doc.rust-lang.org/rust-by-example/flow_control/match.html
 [str]: https://doc.rust-lang.org/std/primitive.str.html

--- a/exercises/practice/gigasecond/.docs/introduction.md
+++ b/exercises/practice/gigasecond/.docs/introduction.md
@@ -13,7 +13,7 @@ Then we can use metric system prefixes for writing large numbers of seconds in m
 - Perhaps you and your family would travel to somewhere exotic for two megaseconds (that's two million seconds).
 - And if you and your spouse were married for _a thousand million_ seconds, you would celebrate your one gigasecond anniversary.
 
-```exercism/note
+~~~~exercism/note
 If we ever colonize Mars or some other planet, measuring time is going to get even messier.
 If someone says "year" do they mean a year on Earth or a year on Mars?
 
@@ -21,4 +21,4 @@ The idea for this exercise came from the science fiction novel ["A Deepness in t
 In it the author uses the metric system as the basis for time measurements.
 
 [vinge-novel]: https://www.tor.com/2017/08/03/science-fiction-with-something-for-everyone-a-deepness-in-the-sky-by-vernor-vinge/
-```
+~~~~

--- a/exercises/practice/grains/.approaches/bit-shifting/content.md
+++ b/exercises/practice/grains/.approaches/bit-shifting/content.md
@@ -38,12 +38,12 @@ However, we can't do this with a `u64` which has only `64` bits, so we need to u
 To go back to our two-square example, if we can grow to three squares, then we can shift `1_u128` two positions to the left for binary `100`,
 which is decimal `4`.
 
-```exercism/note
+~~~~exercism/note
 Note that the type of a binding can be defined by appending it to the binding name.
 It can optionally be appended using one or more `_` separators between the value and the type.
 More info can be found in the [Literals](https://doc.rust-lang.org/rust-by-example/types/literals.html) section of
 [Rust by Example](https://doc.rust-lang.org/rust-by-example/index.html)
-```
+~~~~
 By subtracting `1` we get `3`, which is the total amount of grains on the two squares.
 
 | Square  | Binary Value | Decimal Value |

--- a/exercises/practice/grains/.approaches/pow/content.md
+++ b/exercises/practice/grains/.approaches/pow/content.md
@@ -19,12 +19,12 @@ Rust does not have an exponential operator, but uses the [`pow`][pow-u64] method
 `pow` is nicely suited to the problem, since we start with one grain and keep doubling the number of grains on each successive square.
 `1` grain is `2u64.pow(0)`, `2` grains is `2u64.pow(1)`, `4` is `2u64.pow(2)`, and so on.
 
-```exercism/note
+~~~~exercism/note
 Note that the type of a binding can be defined by appending it to the binding name.
 It can optionally be appended using one or more `_` separators between the value and the type.
 More info can be found in the [Literals](https://doc.rust-lang.org/rust-by-example/types/literals.html) section of
 [Rust by Example](https://doc.rust-lang.org/rust-by-example/index.html)
-```
+~~~~
 
 So, to get the right exponent, we subtract `1` from the square number `s`.
 

--- a/exercises/practice/leap/.approaches/date-addition-chrono/content.md
+++ b/exercises/practice/leap/.approaches/date-addition-chrono/content.md
@@ -8,9 +8,9 @@ pub fn is_leap_year(year: u64) -> bool {
 }
 ```
 
-```exercism/caution
+~~~~exercism/caution
 This approach may be considered a "cheat" for this exercise.
-```
+~~~~
 By adding a day to February 28th for the year, you can see if the new day is the 29th or the 1st.
 If it is the 29th, then the year is a leap year.
 This is done by using the [`Duration::days(1)`][day-duration] method to add a day to a [`chrono::Date`][chrono-date] `struct` and comparing it to `29` with the [`day`][day-method] method.

--- a/exercises/practice/leap/.approaches/date-addition-time/content.md
+++ b/exercises/practice/leap/.approaches/date-addition-time/content.md
@@ -9,9 +9,9 @@ pub fn is_leap_year(year: u64) -> bool {
 }
 ```
 
-```exercism/caution
+~~~~exercism/caution
 This approach may be considered a "cheat" for this exercise.
-```
+~~~~
 By adding a day to February 28th for the year, you can see if the new day is the 29th or the 1st.
 If it is the 29th, then the year is a leap year.
 This is done by adding a [`Duration::DAY`][day-duration] to a [`time::Date`][time-date] `struct` and comparing it to `29` with the [`day`][day-method] method.

--- a/exercises/practice/leap/.approaches/ternary-expression/content.md
+++ b/exercises/practice/leap/.approaches/ternary-expression/content.md
@@ -33,11 +33,11 @@ if year % 100 == 0 {
 `year` is tested to be evenly divislbe by `100` by using the [remainder operator][remainder-operator].
 If so, it returns if `year` is evenly divisible by `400`, as the last expression evaluated in the function.
 
-```exercism/note
+~~~~exercism/note
 Note that the line is just `year % 400 == 0`.
 This is because the [last expression can be returned](https://doc.rust-lang.org/rust-by-example/fn.html)
 from a function without using `return` and a semicolon.
-```
+~~~~
 
 If `year` is _not_ evenly divisible by `100`, then `else` is the last expression evaluated in the function
 

--- a/exercises/practice/pangram/.docs/introduction.md
+++ b/exercises/practice/pangram/.docs/introduction.md
@@ -7,10 +7,10 @@ To give a comprehensive sense of the font, the random sentences should use **all
 They're running a competition to get suggestions for sentences that they can use.
 You're in charge of checking the submissions to see if they are valid.
 
-```exercism/note
+~~~~exercism/note
 Pangram comes from Greek, παν γράμμα, pan gramma, which means "every letter".
 
 The best known English pangram is:
 
 > The quick brown fox jumps over the lazy dog.
-```
+~~~~

--- a/exercises/practice/sieve/.docs/instructions.md
+++ b/exercises/practice/sieve/.docs/instructions.md
@@ -18,11 +18,11 @@ Then you repeat the following steps:
 You keep repeating these steps until you've gone through every number in your list.
 At the end, all the unmarked numbers are prime.
 
-```exercism/note
+~~~~exercism/note
 [Wikipedia's Sieve of Eratosthenes article][eratosthenes] has a useful graphic that explains the algorithm.
 
 The tests don't check that you've implemented the algorithm, only that you've come up with the correct list of primes.
 A good first test is to check that you do not use division or remainder operations.
 
 [eratosthenes]: https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
-```
+~~~~


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705