### PR TITLE
Fix clippy warnings

### DIFF
--- a/exercises/practice/binary-search/tests/binary-search.rs
+++ b/exercises/practice/binary-search/tests/binary-search.rs
@@ -4,6 +4,7 @@
 // without clippy warnings for both people who take on the
 // additional challenge and people who don't, we disable this lint.
 #![allow(clippy::needless_borrow)]
+#![allow(clippy::needless_borrows_for_generic_args)]
 
 use binary_search::find;
 


### PR DESCRIPTION
[no important files changed]

Seems like clippy::needless_borrow was renamed, or maybe these are separate lints where the other one now takes precedence. Either way, we want to ignore it for this exercise as already documented.