### PR TITLE
Don't run beta clippy in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,10 +121,6 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        rust: ["stable", "beta"]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
@@ -132,7 +128,7 @@ jobs:
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           components: clippy
 
       - name: Clippy tests


### PR DESCRIPTION
Running the beta version of clippy in CI creates unnecessary churn.
This time, a lint was renamed and it is not easy to satisfy *both* the stable and beta version.
Within six weeks, our CI would probably be broken again.
I also vaguely remember changing a bunch of stuff because of a beta lint, which didn't end up being stabilized after all.