### PR TITLE
Fix clippy warnings

### DIFF
--- a/exercises/practice/custom-set/.meta/example.rs
+++ b/exercises/practice/custom-set/.meta/example.rs
@@ -49,8 +49,8 @@ impl<T: Ord + Clone> CustomSet<T> {
             &self
                 .collection
                 .iter()
-                .cloned()
                 .filter(|c| other.contains(c))
+                .cloned()
                 .collect::<Vec<_>>(),
         )
     }
@@ -61,8 +61,8 @@ impl<T: Ord + Clone> CustomSet<T> {
             &self
                 .collection
                 .iter()
+                .chain(other.collection.iter())
                 .cloned()
-                .chain(other.collection.iter().cloned())
                 .collect::<Vec<_>>(),
         )
     }
@@ -73,8 +73,8 @@ impl<T: Ord + Clone> CustomSet<T> {
             &self
                 .collection
                 .iter()
-                .cloned()
                 .filter(|c| !other.contains(c))
+                .cloned()
                 .collect::<Vec<_>>(),
         )
     }

--- a/justfile
+++ b/justfile
@@ -12,6 +12,7 @@ test:
     ./bin/lint_markdown.sh
     # TODO shellcheck
     ./bin/check_exercises.sh
+    CLIPPY=true ./bin/check_exercises.sh
     ./bin/ensure_stubs_compile.sh
     cd rust-tooling && cargo test
     # TODO format exercises


### PR DESCRIPTION
Also, `just test` now runs clippy over all exercises, making it easier to simulate CI locally.