### PR TITLE
Sync rotational-cipher with problem-specifications

### DIFF
--- a/exercises/practice/rotational-cipher/.docs/instructions.md
+++ b/exercises/practice/rotational-cipher/.docs/instructions.md
@@ -2,11 +2,9 @@
 
 Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.
 
-The Caesar cipher is a simple shift cipher that relies on
-transposing all the letters in the alphabet using an integer key
-between `0` and `26`. Using a key of `0` or `26` will always yield
-the same output due to modular arithmetic. The letter is shifted
-for as many values as the value of the key.
+The Caesar cipher is a simple shift cipher that relies on transposing all the letters in the alphabet using an integer key between `0` and `26`.
+Using a key of `0` or `26` will always yield the same output due to modular arithmetic.
+The letter is shifted for as many values as the value of the key.
 
 The general notation for rotational ciphers is `ROT + <key>`.
 The most commonly used rotational cipher is `ROT13`.
@@ -24,8 +22,8 @@ Ciphertext is written out in the same formatting as the input including spaces a
 
 ## Examples
 
-- ROT5  `omg` gives `trl`
-- ROT0  `c` gives `c`
+- ROT5 `omg` gives `trl`
+- ROT0 `c` gives `c`
 - ROT26 `Cool` gives `Cool`
 - ROT13 `The quick brown fox jumps over the lazy dog.` gives `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.`
 - ROT13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`

--- a/exercises/practice/rotational-cipher/.meta/example.rs
+++ b/exercises/practice/rotational-cipher/.meta/example.rs
@@ -1,6 +1,4 @@
-pub fn rotate(text: &str, key: i8) -> String {
-    let key = if key < 0 { (26 + key) as u8 } else { key as u8 };
-
+pub fn rotate(text: &str, key: u8) -> String {
     text.chars()
         .map(|c| {
             if c.is_alphabetic() {

--- a/exercises/practice/rotational-cipher/.meta/test_template.tera
+++ b/exercises/practice/rotational-cipher/.meta/test_template.tera
@@ -1,0 +1,14 @@
+use rotational_cipher as cipher;
+{% for test in cases %}
+#[test]
+{% if loop.index != 1 -%}
+#[ignore]
+{% endif -%}
+fn {{ test.description | slugify | replace(from="-", to="_") }}() {
+    let text = {{ test.input.text | json_encode() }};
+    let shift_key = {{ test.input.shiftKey | json_encode() }};
+    let output = cipher::{{ fn_names[0] }}(text, shift_key);
+    let expected = {{ test.expected | json_encode() }};
+    assert_eq!(output, expected);
+}
+{% endfor -%}

--- a/exercises/practice/rotational-cipher/.meta/tests.toml
+++ b/exercises/practice/rotational-cipher/.meta/tests.toml
@@ -1,6 +1,31 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[74e58a38-e484-43f1-9466-877a7515e10f]
+description = "rotate a by 0, same output as input"
+
+[7ee352c6-e6b0-4930-b903-d09943ecb8f5]
+description = "rotate a by 1"
+
+[edf0a733-4231-4594-a5ee-46a4009ad764]
+description = "rotate a by 26, same output as input"
+
+[e3e82cb9-2a5b-403f-9931-e43213879300]
+description = "rotate m by 13"
+
+[19f9eb78-e2ad-4da4-8fe3-9291d47c1709]
+description = "rotate n by 13 with wrap around alphabet"
+
+[a116aef4-225b-4da9-884f-e8023ca6408a]
+description = "rotate capital letters"
 
 [71b541bb-819c-4dc6-a9c3-132ef9bb737b]
 description = "rotate spaces"
@@ -10,3 +35,6 @@ description = "rotate numbers"
 
 [32dd74f6-db2b-41a6-b02c-82eb4f93e549]
 description = "rotate punctuation"
+
+[9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9]
+description = "rotate all letters"

--- a/exercises/practice/rotational-cipher/src/lib.rs
+++ b/exercises/practice/rotational-cipher/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn rotate(input: &str, key: i8) -> String {
+pub fn rotate(input: &str, key: u8) -> String {
     todo!(
         "How would input text '{input}' transform when every letter is shifted using key '{key}'?"
     );

--- a/exercises/practice/rotational-cipher/tests/rotational-cipher.rs
+++ b/exercises/practice/rotational-cipher/tests/rotational-cipher.rs
@@ -1,81 +1,100 @@
 use rotational_cipher as cipher;
 
 #[test]
-fn rotate_a_1() {
-    assert_eq!("b", cipher::rotate("a", 1));
+fn rotate_a_by_0_same_output_as_input() {
+    let text = "a";
+    let shift_key = 0;
+    let output = cipher::rotate(text, shift_key);
+    let expected = "a";
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
-fn rotate_a_26() {
-    assert_eq!("a", cipher::rotate("a", 26));
+fn rotate_a_by_1() {
+    let text = "a";
+    let shift_key = 1;
+    let output = cipher::rotate(text, shift_key);
+    let expected = "b";
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
-fn rotate_a_0() {
-    assert_eq!("a", cipher::rotate("a", 0));
+fn rotate_a_by_26_same_output_as_input() {
+    let text = "a";
+    let shift_key = 26;
+    let output = cipher::rotate(text, shift_key);
+    let expected = "a";
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
-fn rotate_m_13() {
-    assert_eq!("z", cipher::rotate("m", 13));
+fn rotate_m_by_13() {
+    let text = "m";
+    let shift_key = 13;
+    let output = cipher::rotate(text, shift_key);
+    let expected = "z";
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
-fn rotate_n_13_with_wrap() {
-    assert_eq!("a", cipher::rotate("n", 13));
+fn rotate_n_by_13_with_wrap_around_alphabet() {
+    let text = "n";
+    let shift_key = 13;
+    let output = cipher::rotate(text, shift_key);
+    let expected = "a";
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
-fn rotate_caps() {
-    assert_eq!("TRL", cipher::rotate("OMG", 5));
+fn rotate_capital_letters() {
+    let text = "OMG";
+    let shift_key = 5;
+    let output = cipher::rotate(text, shift_key);
+    let expected = "TRL";
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
 fn rotate_spaces() {
-    assert_eq!("T R L", cipher::rotate("O M G", 5));
+    let text = "O M G";
+    let shift_key = 5;
+    let output = cipher::rotate(text, shift_key);
+    let expected = "T R L";
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
 fn rotate_numbers() {
-    assert_eq!(
-        "Xiwxmrk 1 2 3 xiwxmrk",
-        cipher::rotate("Testing 1 2 3 testing", 4)
-    );
+    let text = "Testing 1 2 3 testing";
+    let shift_key = 4;
+    let output = cipher::rotate(text, shift_key);
+    let expected = "Xiwxmrk 1 2 3 xiwxmrk";
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
 fn rotate_punctuation() {
-    assert_eq!(
-        "Gzo\'n zvo, Bmviyhv!",
-        cipher::rotate("Let\'s eat, Grandma!", 21)
-    );
+    let text = "Let's eat, Grandma!";
+    let shift_key = 21;
+    let output = cipher::rotate(text, shift_key);
+    let expected = "Gzo'n zvo, Bmviyhv!";
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
-fn rotate_all_the_letters() {
-    assert_eq!(
-        "Gur dhvpx oebja sbk whzcf bire gur ynml qbt.",
-        cipher::rotate("The quick brown fox jumps over the lazy dog.", 13)
-    );
-}
-
-#[test]
-#[ignore]
-fn rotate_m_negative_1() {
-    assert_eq!("l", cipher::rotate("m", -1));
-}
-
-#[test]
-#[ignore]
-fn rotate_letters_negative_26() {
-    assert_eq!("omg", cipher::rotate("omg", -26));
+fn rotate_all_letters() {
+    let text = "The quick brown fox jumps over the lazy dog.";
+    let shift_key = 13;
+    let output = cipher::rotate(text, shift_key);
+    let expected = "Gur dhvpx oebja sbk whzcf bire gur ynml qbt.";
+    assert_eq!(output, expected);
 }


### PR DESCRIPTION
The two tests with negative keys as input were removed.
The exercise instructions specify a range of 0 to 26.
The function signature of the skeleton was adjusted accordingly,
using `u8` instead of `i8` to make negative numbers impossible.

The removal of these tests was discussed on the forum:
https://forum.exercism.org/t/rotational-cipher-negative-keys/8273