### PR TITLE
Sync rna-transcription with problem-specifications

### DIFF
--- a/exercises/practice/rna-transcription/.meta/additional-tests.json
+++ b/exercises/practice/rna-transcription/.meta/additional-tests.json
@@ -1,0 +1,38 @@
+[
+  {
+    "uuid": "6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7",
+    "description": "Invalid DNA input",
+    "property": "invalidDna",
+    "input": {
+      "dna": "U"
+    },
+    "expected": 0
+  },
+  {
+    "uuid": "6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7",
+    "description": "Invalid DNA input at offset",
+    "property": "invalidDna",
+    "input": {
+      "dna": "ACGTUXXCTTAA"
+    },
+    "expected": 4
+  },
+  {
+    "uuid": "6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7",
+    "description": "Invalid RNA input",
+    "property": "invalidRna",
+    "input": {
+      "dna": "T"
+    },
+    "expected": 0
+  },
+  {
+    "uuid": "6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7",
+    "description": "Invalid RNA input at offset",
+    "property": "invalidRna",
+    "input": {
+      "dna": "ACGTUXXCTTAA"
+    },
+    "expected": 3
+  }
+]

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -43,5 +43,5 @@
   },
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "source": "Hyperphysics",
-  "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"
+  "source_url": "https://web.archive.org/web/20220408112140/http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"
 }

--- a/exercises/practice/rna-transcription/.meta/test_template.tera
+++ b/exercises/practice/rna-transcription/.meta/test_template.tera
@@ -1,0 +1,21 @@
+use rna_transcription::{Dna, Rna};
+{% for test in cases %}
+#[test]
+{% if loop.index != 1 -%}
+#[ignore]
+{% endif -%}
+fn {{ test.description | slugify | replace(from="-", to="_") }}() {
+    let input = {{ test.input.dna | json_encode() }};
+{% if test.property == "invalidDna" -%}
+    let output = Dna::new(input);
+    let expected = Err({{ test.expected }});
+{%- elif test.property == "invalidRna" -%}
+    let output = Rna::new(input);
+    let expected = Err({{ test.expected }});
+{%- else -%}
+    let output = Dna::new(input).unwrap().into_rna();
+    let expected = Rna::new({{ test.expected | json_encode() }}).unwrap();
+{%- endif %}
+    assert_eq!(output, expected);
+}
+{% endfor -%}

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -1,3 +1,28 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
+description = "Empty RNA sequence"
+
+[a9558a3c-318c-4240-9256-5d5ed47005a6]
+description = "RNA complement of cytosine is guanine"
+
+[6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
+description = "RNA complement of guanine is cytosine"
+
+[870bd3ec-8487-471d-8d9a-a25046488d3e]
+description = "RNA complement of thymine is adenine"
+
+[aade8964-02e1-4073-872f-42d3ffd74c5f]
+description = "RNA complement of adenine is uracil"
+
+[79ed2757-f018-4f47-a1d7-34a559392dbf]
+description = "RNA complement"

--- a/exercises/practice/rna-transcription/tests/rna-transcription.rs
+++ b/exercises/practice/rna-transcription/tests/rna-transcription.rs
@@ -1,88 +1,90 @@
-use rna_transcription as dna;
+use rna_transcription::{Dna, Rna};
 
 #[test]
-fn valid_dna_input() {
-    assert!(dna::Dna::new("GCTA").is_ok());
+fn empty_rna_sequence() {
+    let input = "";
+    let output = Dna::new(input).unwrap().into_rna();
+    let expected = Rna::new("").unwrap();
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
-fn valid_rna_input() {
-    assert!(dna::Rna::new("CGAU").is_ok());
+fn rna_complement_of_cytosine_is_guanine() {
+    let input = "C";
+    let output = Dna::new(input).unwrap().into_rna();
+    let expected = Rna::new("G").unwrap();
+    assert_eq!(output, expected);
+}
+
+#[test]
+#[ignore]
+fn rna_complement_of_guanine_is_cytosine() {
+    let input = "G";
+    let output = Dna::new(input).unwrap().into_rna();
+    let expected = Rna::new("C").unwrap();
+    assert_eq!(output, expected);
+}
+
+#[test]
+#[ignore]
+fn rna_complement_of_thymine_is_adenine() {
+    let input = "T";
+    let output = Dna::new(input).unwrap().into_rna();
+    let expected = Rna::new("A").unwrap();
+    assert_eq!(output, expected);
+}
+
+#[test]
+#[ignore]
+fn rna_complement_of_adenine_is_uracil() {
+    let input = "A";
+    let output = Dna::new(input).unwrap().into_rna();
+    let expected = Rna::new("U").unwrap();
+    assert_eq!(output, expected);
+}
+
+#[test]
+#[ignore]
+fn rna_complement() {
+    let input = "ACGTGGTCTTAA";
+    let output = Dna::new(input).unwrap().into_rna();
+    let expected = Rna::new("UGCACCAGAAUU").unwrap();
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
 fn invalid_dna_input() {
-    // Invalid character
-    assert_eq!(dna::Dna::new("X").err(), Some(0));
-    // Valid nucleotide, but invalid in context
-    assert_eq!(dna::Dna::new("U").err(), Some(0));
-    // Longer string with contained errors
-    assert_eq!(dna::Dna::new("ACGTUXXCTTAA").err(), Some(4));
+    let input = "U";
+    let output = Dna::new(input);
+    let expected = Err(0);
+    assert_eq!(output, expected);
+}
+
+#[test]
+#[ignore]
+fn invalid_dna_input_at_offset() {
+    let input = "ACGTUXXCTTAA";
+    let output = Dna::new(input);
+    let expected = Err(4);
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
 fn invalid_rna_input() {
-    // Invalid character
-    assert_eq!(dna::Rna::new("X").unwrap_err(), 0);
-    // Valid nucleotide, but invalid in context
-    assert_eq!(dna::Rna::new("T").unwrap_err(), 0);
-    // Longer string with contained errors
-    assert_eq!(dna::Rna::new("ACGUTTXCUUAA").unwrap_err(), 4);
+    let input = "T";
+    let output = Rna::new(input);
+    let expected = Err(0);
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
-fn acid_equals_acid() {
-    assert_eq!(dna::Dna::new("CGA").unwrap(), dna::Dna::new("CGA").unwrap());
-    assert_ne!(dna::Dna::new("CGA").unwrap(), dna::Dna::new("AGC").unwrap());
-    assert_eq!(dna::Rna::new("CGA").unwrap(), dna::Rna::new("CGA").unwrap());
-    assert_ne!(dna::Rna::new("CGA").unwrap(), dna::Rna::new("AGC").unwrap());
-}
-
-#[test]
-#[ignore]
-fn transcribes_cytosine_guanine() {
-    assert_eq!(
-        dna::Rna::new("G").unwrap(),
-        dna::Dna::new("C").unwrap().into_rna()
-    );
-}
-
-#[test]
-#[ignore]
-fn transcribes_guanine_cytosine() {
-    assert_eq!(
-        dna::Rna::new("C").unwrap(),
-        dna::Dna::new("G").unwrap().into_rna()
-    );
-}
-
-#[test]
-#[ignore]
-fn transcribes_adenine_uracil() {
-    assert_eq!(
-        dna::Rna::new("U").unwrap(),
-        dna::Dna::new("A").unwrap().into_rna()
-    );
-}
-
-#[test]
-#[ignore]
-fn transcribes_thymine_to_adenine() {
-    assert_eq!(
-        dna::Rna::new("A").unwrap(),
-        dna::Dna::new("T").unwrap().into_rna()
-    );
-}
-
-#[test]
-#[ignore]
-fn transcribes_all_dna_to_rna() {
-    assert_eq!(
-        dna::Rna::new("UGCACCAGAAUU").unwrap(),
-        dna::Dna::new("ACGTGGTCTTAA").unwrap().into_rna()
-    )
+fn invalid_rna_input_at_offset() {
+    let input = "ACGTUXXCTTAA";
+    let output = Rna::new(input);
+    let expected = Err(3);
+    assert_eq!(output, expected);
 }


### PR DESCRIPTION
There were some additional test, and I kept some of them.
They are related to error handling, which is a big focus for Rust.
So I felt it is appropriate to keep these additional tests.

[no important files changed]