### PR TITLE
Use glob import in default test template

### DIFF
--- a/rust-tooling/generate/templates/default_test_template.tera
+++ b/rust-tooling/generate/templates/default_test_template.tera
@@ -1,3 +1,5 @@
+use {{ crate_name }}::*;
+
 {% for test in cases %}
 #[test]
 {% if loop.index != 1 -%}
@@ -5,7 +7,7 @@
 {% endif -%}
 fn {{ test.description | slugify | replace(from="-", to="_") }}() {
     let input = {{ test.input | json_encode() }};
-    let output = {{ crate_name }}::{{ fn_names[0] }}(input);
+    let output = {{ fn_names[0] }}(input);
     let expected = {{ test.expected | json_encode() }};
     assert_eq!(output, expected);
 }


### PR DESCRIPTION
Glob imports are a better default for the test template. Some exercises may require the student to implement a method. If the test file doesn't have a glob import, the students will be forced to implement an inherent method on a struct. On the other hand, if a glob import is used, the students may choose to implement it as a method on a trait.
Traits are a powerful feature of Rust, so we want to enable students to experiment with them whenever possible.