### PR TITLE
Add test group description to single test cases

### DIFF
--- a/rust-tooling/generate/src/exercise_generation.rs
+++ b/rust-tooling/generate/src/exercise_generation.rs
@@ -78,11 +78,26 @@ fn generate_example_rs(fn_name: &str) -> String {
 
 static TEST_TEMPLATE: &str = include_str!("../templates/default_test_template.tera");
 
+fn with_group_description(mut cases: Vec<TestCase>, group_description: &str) -> Vec<TestCase> {
+    for case in cases.iter_mut() {
+        if let TestCase::Single { case } = case {
+            case.group_description = Some(group_description.to_string());
+        }
+        // Deeper nesting of groups is ignored at this point.
+        // As such, single test cases will only have the group description of
+        // their immediate parent group.
+        // It's highly unlikely that more information will be needed in practice.
+    }
+    cases
+}
+
 fn extend_single_cases(single_cases: &mut Vec<SingleTestCase>, cases: Vec<TestCase>) {
     for case in cases {
         match case {
             TestCase::Single { case } => single_cases.push(case),
-            TestCase::Group { cases, .. } => extend_single_cases(single_cases, cases),
+            TestCase::Group {
+                cases, description, ..
+            } => extend_single_cases(single_cases, with_group_description(cases, &description)),
         }
     }
 }

--- a/rust-tooling/models/src/problem_spec.rs
+++ b/rust-tooling/models/src/problem_spec.rs
@@ -31,6 +31,14 @@ pub struct SingleTestCase {
     pub uuid: String,
     pub reimplements: Option<String>,
     pub description: String,
+    /// This is technically not part of the spec.
+    /// Just by deserializing the canonical data, this will always be `None`.
+    /// However, groups aren't usually nested beyond one level.
+    /// So it's convenient to just add the group description here.
+    /// The nesting of groups can then be flattened to an array of test cases.
+    /// This field then identifies which group a test case belongs to.
+    /// This transformation is done in the test case generator.
+    pub group_description: Option<String>,
     pub comments: Option<Vec<String>>,
     pub scenarios: Option<Vec<String>>,
     pub property: String,


### PR DESCRIPTION
This is intended to help identify which group a single test case belongs to, in order to enable group-specific logic in the test template.