### PR TITLE
Add a test to the CircularBuffer exercise to check if elements in the buffer are dropped when the buffer is dropped

### DIFF
--- a/exercises/practice/circular-buffer/tests/circular-buffer.rs
+++ b/exercises/practice/circular-buffer/tests/circular-buffer.rs
@@ -143,6 +143,18 @@ fn overwrite_replaces_the_oldest_item_remaining_in_buffer_following_a_read() {
 
 #[test]
 #[ignore]
+fn dropping_the_buffer_drops_its_elements() {
+    let element = Rc::new(());
+    {
+        let mut buffer = CircularBuffer::new(1);
+        assert!(buffer.write(Rc::clone(&element)).is_ok());
+        assert_eq!(Rc::strong_count(&element), 2);
+    }
+    assert_eq!(Rc::strong_count(&element), 1);
+}
+
+#[test]
+#[ignore]
 fn integer_buffer() {
     let mut buffer = CircularBuffer::new(2);
     assert!(buffer.write(1).is_ok());


### PR DESCRIPTION
A common solution to this exercise is to use `MaybeUninit<T>` in the buffer. However, `MaybeUninit<T>` explicitly never calls `T`s drop code.

A sound solution should drop elements in the buffer when it is dropped. This test checks for that.