### PR TITLE
Fix already-solved lifetime challenge in anagram

### DIFF
--- a/exercises/practice/anagram/src/lib.rs
+++ b/exercises/practice/anagram/src/lib.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
 
-pub fn anagrams_for<'a>(word: &str, possible_anagrams: &[&'a str]) -> HashSet<&'a str> {
+pub fn anagrams_for<'a>(word: &str, possible_anagrams: &[&str]) -> HashSet<&'a str> {
     todo!("For the '{word}' word find anagrams among the following words: {possible_anagrams:?}");
 }


### PR DESCRIPTION
This is basically a revert of #1755.

The original "fix" was a reaction to this forum post: https://forum.exercism.org/t/the-function-signature-for-anagrams-in-rust-is-missing-a-lifetime/7677

It seems the exercise instructions, which explicitly mention that this missing lifetime annotation is intentional, went unnoticed.