### PR TITLE
Update instructions append for anagram

### DIFF
--- a/exercises/practice/anagram/.docs/hints.md
+++ b/exercises/practice/anagram/.docs/hints.md
@@ -1,0 +1,4 @@
+## General
+
+The solution is case insensitive, which means `"WOrd"` is the same as `"word"` or `"woRd"`.
+It may help to take a peek at the [std library](https://doc.rust-lang.org/std/primitive.char.html) for functions that can convert between them.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,7 +1,4 @@
-# Hints
+# Instructions append
 
 You are going to have to adjust the function signature provided in the stub in order for the lifetimes to work out properly.
 This is intentional: what's there demonstrates the basics of lifetime syntax, and what's missing teaches how to interpret lifetime-related compiler errors.
-
-The solution is case insensitive, which means `"WOrd"` is the same as `"word"` or `"woRd"`.
-It may help to take a peek at the [std library](https://doc.rust-lang.org/std/primitive.char.html) for functions that can convert between them.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,11 +1,7 @@
 # Hints
 
-The solution is case insensitive, which means `"WOrd"` is the same as `"word"` or `"woRd"`. It may help to take a peek at the [std library](https://doc.rust-lang.org/std/primitive.char.html) for functions that can convert between them.
+You are going to have to adjust the function signature provided in the stub in order for the lifetimes to work out properly.
+This is intentional: what's there demonstrates the basics of lifetime syntax, and what's missing teaches how to interpret lifetime-related compiler errors.
 
-The solution cannot contain the input word. A word is always an anagram of itself, which means it is not an interesting result. Given `"hello"` and the list `["hello", "olleh"]` the answer is `["olleh"]`.
-
-You are going to have to adjust the function signature provided in the stub in order for the lifetimes to work out properly. This is intentional: what's there demonstrates the basics of lifetime syntax, and what's missing teaches how to interpret lifetime-related compiler errors.
-
-Try to limit case changes. Case changes are expensive in terms of time, so it's faster to minimize them.
-
-If sorting, consider [sort_unstable](https://doc.rust-lang.org/std/primitive.slice.html#method.sort_unstable) which is typically faster than stable sorting. When applicable, unstable sorting is preferred because it is generally faster than stable sorting and it doesn't allocate auxiliary memory.
+The solution is case insensitive, which means `"WOrd"` is the same as `"word"` or `"woRd"`.
+It may help to take a peek at the [std library](https://doc.rust-lang.org/std/primitive.char.html) for functions that can convert between them.


### PR DESCRIPTION
- Remove some performance considerations. These are basically giving away the implementation. Also, not every student might want to focus on performance. Such considerations may be better suited for approaches articles.

- Remove non-Rust-related hints. These are pretty much covered by the instructions. I guess these were lacking at some point, but updated in the meantime.

- Move the most important hint about lifetimes to the top.