### PR TITLE
Sync leap with problem-specifications

### DIFF
--- a/exercises/practice/leap/.docs/instructions.md
+++ b/exercises/practice/leap/.docs/instructions.md
@@ -1,22 +1,3 @@
 # Instructions
 
-Given a year, report if it is a leap year.
-
-The tricky thing here is that a leap year in the Gregorian calendar occurs:
-
-```text
-on every year that is evenly divisible by 4
-  except every year that is evenly divisible by 100
-    unless the year is also evenly divisible by 400
-```
-
-For example, 1997 is not a leap year, but 1996 is.
-1900 is not a leap year, but 2000 is.
-
-## Notes
-
-Though our exercise adopts some very simple rules, there is more to learn!
-
-For a delightful, four minute explanation of the whole leap year phenomenon, go watch [this youtube video][video].
-
-[video]: https://www.youtube.com/watch?v=xX96xng7sAE
+Your task is to determine whether a given year is a leap year.

--- a/exercises/practice/leap/.docs/introduction.md
+++ b/exercises/practice/leap/.docs/introduction.md
@@ -1,0 +1,16 @@
+# Introduction
+
+A leap year (in the Gregorian calendar) occurs:
+
+- In every year that is evenly divisible by 4
+- Unless the year is evenly divisible by 100, in which case it's only a leap year if the year is also evenly divisible by 400.
+
+Some examples:
+
+- 1997 was not a leap year as it's not divisible by 4.
+- 1900 was not a leap year as it's not divisible by 400
+- 2000 was a leap year!
+
+~~~~exercism/note
+For a delightful, four minute explanation of the whole phenomenon of leap years, check out [this youtube video](https://www.youtube.com/watch?v=xX96xng7sAE).
+~~~~

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -44,7 +44,7 @@
       ".meta/example.rs"
     ]
   },
-  "blurb": "Given a year, report if it is a leap year.",
+  "blurb": "Determine whether a given year is a leap year.",
   "source": "CodeRanch Cattle Drive, Assignment 3",
   "source_url": "https://coderanch.com/t/718816/Leap"
 }

--- a/exercises/practice/leap/.meta/test_template.tera
+++ b/exercises/practice/leap/.meta/test_template.tera
@@ -1,0 +1,15 @@
+use {{ crate_name }}::*;
+
+{% for test in cases %}
+#[test]
+{% if loop.index != 1 -%}
+#[ignore]
+{% endif -%}
+fn {{ test.description | slugify | replace(from="-", to="_") }}() {
+{%- if test.expected %}
+    assert!(is_leap_year({{ test.input.year }}));
+{% else %}
+    assert!(!is_leap_year({{ test.input.year }}));
+{% endif -%}
+}
+{% endfor -%}

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -1,3 +1,37 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[6466b30d-519c-438e-935d-388224ab5223]
+description = "year not divisible by 4 in common year"
+
+[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
+description = "year divisible by 2, not divisible by 4 in common year"
+
+[4fe9b84c-8e65-489e-970b-856d60b8b78e]
+description = "year divisible by 4, not divisible by 100 in leap year"
+
+[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
+description = "year divisible by 4 and 5 is still a leap year"
+
+[78a7848f-9667-4192-ae53-87b30c9a02dd]
+description = "year divisible by 100, not divisible by 400 in common year"
+
+[9d70f938-537c-40a6-ba19-f50739ce8bac]
+description = "year divisible by 100 but not by 3 is still not a leap year"
+
+[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
+description = "year divisible by 400 is leap year"
+
+[57902c77-6fe9-40de-8302-587b5c27121e]
+description = "year divisible by 400 but not by 125 is still a leap year"
+
+[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
+description = "year divisible by 200, not divisible by 400 in common year"

--- a/exercises/practice/leap/tests/leap.rs
+++ b/exercises/practice/leap/tests/leap.rs
@@ -1,100 +1,54 @@
-fn process_leapyear_case(year: u64, expected: bool) {
-    assert_eq!(leap::is_leap_year(year), expected);
-}
+use leap::*;
 
 #[test]
-fn year_not_divisible_by_4_common_year() {
-    process_leapyear_case(2015, false);
+fn year_not_divisible_by_4_in_common_year() {
+    assert!(!is_leap_year(2015));
 }
 
 #[test]
 #[ignore]
 fn year_divisible_by_2_not_divisible_by_4_in_common_year() {
-    process_leapyear_case(1970, false);
+    assert!(!is_leap_year(1970));
 }
 
 #[test]
 #[ignore]
-fn year_divisible_by_4_not_divisible_by_100_leap_year() {
-    process_leapyear_case(1996, true);
+fn year_divisible_by_4_not_divisible_by_100_in_leap_year() {
+    assert!(is_leap_year(1996));
 }
 
 #[test]
 #[ignore]
 fn year_divisible_by_4_and_5_is_still_a_leap_year() {
-    process_leapyear_case(1960, true);
+    assert!(is_leap_year(1960));
 }
 
 #[test]
 #[ignore]
-fn year_divisible_by_100_not_divisible_by_400_common_year() {
-    process_leapyear_case(2100, false);
+fn year_divisible_by_100_not_divisible_by_400_in_common_year() {
+    assert!(!is_leap_year(2100));
 }
 
 #[test]
 #[ignore]
 fn year_divisible_by_100_but_not_by_3_is_still_not_a_leap_year() {
-    process_leapyear_case(1900, false);
+    assert!(!is_leap_year(1900));
 }
 
 #[test]
 #[ignore]
-fn year_divisible_by_400_leap_year() {
-    process_leapyear_case(2000, true);
+fn year_divisible_by_400_is_leap_year() {
+    assert!(is_leap_year(2000));
 }
 
 #[test]
 #[ignore]
 fn year_divisible_by_400_but_not_by_125_is_still_a_leap_year() {
-    process_leapyear_case(2400, true);
+    assert!(is_leap_year(2400));
 }
 
 #[test]
 #[ignore]
-fn year_divisible_by_200_not_divisible_by_400_common_year() {
-    process_leapyear_case(1800, false);
-}
-
-#[test]
-#[ignore]
-fn any_old_year() {
-    process_leapyear_case(1997, false);
-}
-
-#[test]
-#[ignore]
-fn early_years() {
-    process_leapyear_case(1, false);
-    process_leapyear_case(4, true);
-    process_leapyear_case(100, false);
-    process_leapyear_case(400, true);
-    process_leapyear_case(900, false);
-}
-
-#[test]
-#[ignore]
-fn century() {
-    process_leapyear_case(1700, false);
-    process_leapyear_case(1800, false);
-    process_leapyear_case(1900, false);
-}
-
-#[test]
-#[ignore]
-fn exceptional_centuries() {
-    process_leapyear_case(1600, true);
-    process_leapyear_case(2000, true);
-    process_leapyear_case(2400, true);
-}
-
-#[test]
-#[ignore]
-fn years_1600_to_1699() {
-    let incorrect_years = (1600..1700)
-        .filter(|&year| leap::is_leap_year(year) != (year % 4 == 0))
-        .collect::<Vec<_>>();
-
-    if !incorrect_years.is_empty() {
-        panic!("incorrect result for years: {incorrect_years:?}");
-    }
+fn year_divisible_by_200_not_divisible_by_400_in_common_year() {
+    assert!(!is_leap_year(1800));
 }


### PR DESCRIPTION
A bunch of test cases not part of problem-specifications were deleted. Looking through the git history, it seems the manual cases were added first and the ones from problem-specfications later. Some cases are even duplicated because of this. I checked if there are some interesting edge cases worth upstreaming. The most likely ones would be:

```
process_leapyear_case(1, false);
process_leapyear_case(4, true);
```

problem-specifications doesn't yet have any test cases close to the year zero. That being said, I can't think of a concrete solution that would fail these test cases. So it might not be worth upstreaming after all.