### PR TITLE
anagram: Bring back unicode tests

### DIFF
--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -78,3 +78,9 @@ include = false
 [33d3f67e-fbb9-49d3-a90e-0beb00861da7]
 description = "words other than themselves can be anagrams"
 reimplements = "a0705568-628c-4b55-9798-82e4acde51ca"
+
+[a6854f66-eec1-4afd-a137-62ef2870c051]
+description = "handles case of greek letters"
+
+[fd3509e5-e3ba-409d-ac3d-a9ac84d13296]
+description = "different characters may have the same bytes"

--- a/exercises/practice/anagram/tests/anagram.rs
+++ b/exercises/practice/anagram/tests/anagram.rs
@@ -166,3 +166,23 @@ fn words_other_than_themselves_can_be_anagrams() {
     let expected = HashSet::from_iter(["Silent"]);
     assert_eq!(output, expected);
 }
+
+#[test]
+#[ignore]
+fn handles_case_of_greek_letters() {
+    let word = "ΑΒΓ";
+    let inputs = &["ΒΓΑ", "ΒΓΔ", "γβα", "αβγ"];
+    let output = anagrams_for(word, inputs);
+    let expected = HashSet::from_iter(["ΒΓΑ", "γβα"]);
+    assert_eq!(output, expected);
+}
+
+#[test]
+#[ignore]
+fn different_characters_may_have_the_same_bytes() {
+    let word = "a⬂";
+    let inputs = &["€a"];
+    let output = anagrams_for(word, inputs);
+    let expected = HashSet::from_iter([]);
+    assert_eq!(output, expected);
+}


### PR DESCRIPTION
I accidentally removed some unicode related tests in PR #1844. These are now upstreamed to problem-specifications.