### PR TITLE
Apply additional tests consistently

### DIFF
--- a/exercises/practice/acronym/.meta/additional-tests.json
+++ b/exercises/practice/acronym/.meta/additional-tests.json
@@ -1,0 +1,22 @@
+[
+  {
+    "uuid": "d9f6e6d2-79c3-4e53-a22d-66325e8614c6",
+    "description": "camelcase",
+    "comments": [
+      "This test makes the exercise noticeably harder.",
+      "",
+      "Upstreaming this test is not a good option,",
+      "as most other languages would exclude it due to the added difficulty.",
+      "Removing the test from the Rust track is also not a good option,",
+      "because it creates confusion regarding existing community solutions.",
+      "",
+      "While deviations from problem-specifications should generally be avoided,",
+      "it seems like the best choice to stick with it in this case."
+    ],
+    "property": "abbreviate",
+    "input": {
+      "phrase": "HyperText Markup Language"
+    },
+    "expected": "HTML"
+  }
+]

--- a/exercises/practice/acronym/.meta/test_template.tera
+++ b/exercises/practice/acronym/.meta/test_template.tera
@@ -10,20 +10,3 @@ fn {{ test.description | slugify | replace(from="-", to="_") }}() {
     assert_eq!(output, expected);
 }
 {% endfor -%}
-
-{# 
-    This test makes the exercise noticeably harder.
-
-    Upstreaming this test is not a good option,
-    as most other languages would exclude it due to the added difficulty.
-    Removing the test from the Rust track is also not a good option,
-    because it creates confusion regarding existing community solutions.
-
-    While deviations from problem-specifications should generally be avoided,
-    it seems like the best choice to stick with it in this case.
-#}
-#[test]
-#[ignore]
-fn camelcase() {
-    assert_eq!(acronym::abbreviate("HyperText Markup Language"), "HTML");
-}

--- a/exercises/practice/acronym/tests/acronym.rs
+++ b/exercises/practice/acronym/tests/acronym.rs
@@ -81,5 +81,8 @@ fn underscore_emphasis() {
 #[test]
 #[ignore]
 fn camelcase() {
-    assert_eq!(acronym::abbreviate("HyperText Markup Language"), "HTML");
+    let input = "HyperText Markup Language";
+    let output = acronym::abbreviate(input);
+    let expected = "HTML";
+    assert_eq!(output, expected);
 }

--- a/justfile
+++ b/justfile
@@ -6,6 +6,10 @@ configlet *args="":
     @[ -f bin/configlet ] || bin/fetch-configlet
     ./bin/configlet  {{ args }}
 
+# generate a new uuid straight to your clipboard
+uuid:
+    ./bin/configlet uuid | tr -d '[:space:]' | wl-copy
+
 # simulate CI locally (WIP)
 test:
     just configlet lint


### PR DESCRIPTION
The mechanism of the `additional-tests.json` file did not exist at the time I wrote this test template. This makes everything consistent.

[no important files changed]