### PR TITLE
Use `as_bytes()` instead of `chars()` for ASCII strings

### DIFF
--- a/exercises/practice/minesweeper/tests/minesweeper.rs
+++ b/exercises/practice/minesweeper/tests/minesweeper.rs
@@ -5,7 +5,8 @@ fn remove_annotations(board: &[&str]) -> Vec<String> {
 }
 
 fn remove_annotations_in_row(row: &str) -> String {
-    row.chars()
+    row.as_bytes()
+        .iter()
         .map(|ch| match ch {
             '*' => '*',
             _ => ' ',


### PR DESCRIPTION
This pull request updates the code to use `as_bytes()` instead of `chars()` for processing ASCII strings. Since all the inputs and outputs are in ASCII, using `as_bytes()` allows us to work directly with the underlying byte representation of the string as a `[u8]` (byte slice). This change improves performance by avoiding the need to check for variable-length UTF-8 characters when iterating over the ASCII data. ASCII bytes are always one byte long, making iteration over a slice of ASCII bytes more efficient.
