### PR TITLE
Use usize for counts in word-count

### DIFF
--- a/exercises/practice/word-count/.meta/example.rs
+++ b/exercises/practice/word-count/.meta/example.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-pub fn word_count(input: &str) -> HashMap<String, u32> {
-    let mut map: HashMap<String, u32> = HashMap::new();
+pub fn word_count(input: &str) -> HashMap<String, usize> {
+    let mut map = HashMap::new();
     let lower = input.to_lowercase();
     let slice: &str = lower.as_ref();
     for word in slice

--- a/exercises/practice/word-count/.meta/test_template.tera
+++ b/exercises/practice/word-count/.meta/test_template.tera
@@ -1,16 +1,5 @@
-use std::collections::HashMap;
+use word_count::*;
 
-fn check_word_count(mut output: HashMap<String, u32>, pairs: &[(&str, u32)]) {
-    // The reason for the awkward code in here is to ensure that the failure
-    // message for assert_eq! is as informative as possible. A simpler
-    // solution would simply check the length of the map, and then
-    // check for the presence and value of each key in the given pairs vector.
-    for &(k, v) in pairs.iter() {
-        assert_eq!((k, output.remove(&k.to_string()).unwrap_or(0)), (k, v));
-    }
-    // may fail with a message that clearly shows all extra pairs in the map
-    assert_eq!(output.iter().collect::<Vec<(&String, &u32)>>(), vec![]);
-}
 {% for test in cases %}
 #[test]
 {% if loop.index != 1 -%}
@@ -18,10 +7,20 @@ fn check_word_count(mut output: HashMap<String, u32>, pairs: &[(&str, u32)]) {
 {% endif -%}
 fn {{ test.description | slugify | replace(from="-", to="_") }}() {
     let input = {{ test.input.sentence | json_encode() }};
-    let output = {{ crate_name }}::{{ fn_names[0] }}(input);
-    let expected = &[{% for key, value in test.expected -%}
+    let mut output = word_count(input);
+    let expected = [{% for key, value in test.expected -%}
         ({{ key | json_encode() }}, {{ value }}),
     {%- endfor %}];
-    check_word_count(output, expected);
+    {#-
+        The reason for the awkward code in here is to ensure that the failure
+        message for assert_eq! is as informative as possible. A simpler
+        solution would simply check the length of the map, and then
+        check for the presence and value of each key in the given pairs vector.
+    #}
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    {#- may fail with a message that clearly shows all extra pairs in the map #}
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 {% endfor -%}

--- a/exercises/practice/word-count/tests/word-count.rs
+++ b/exercises/practice/word-count/tests/word-count.rs
@@ -1,100 +1,112 @@
-use std::collections::HashMap;
-
-fn check_word_count(mut output: HashMap<String, u32>, pairs: &[(&str, u32)]) {
-    // The reason for the awkward code in here is to ensure that the failure
-    // message for assert_eq! is as informative as possible. A simpler
-    // solution would simply check the length of the map, and then
-    // check for the presence and value of each key in the given pairs vector.
-    for &(k, v) in pairs.iter() {
-        assert_eq!((k, output.remove(&k.to_string()).unwrap_or(0)), (k, v));
-    }
-    // may fail with a message that clearly shows all extra pairs in the map
-    assert_eq!(output.iter().collect::<Vec<(&String, &u32)>>(), vec![]);
-}
+use word_count::*;
 
 #[test]
 fn count_one_word() {
     let input = "word";
-    let output = word_count::word_count(input);
-    let expected = &[("word", 1)];
-    check_word_count(output, expected);
+    let mut output = word_count(input);
+    let expected = [("word", 1)];
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn count_one_of_each_word() {
     let input = "one of each";
-    let output = word_count::word_count(input);
-    let expected = &[("one", 1), ("of", 1), ("each", 1)];
-    check_word_count(output, expected);
+    let mut output = word_count(input);
+    let expected = [("one", 1), ("of", 1), ("each", 1)];
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn multiple_occurrences_of_a_word() {
     let input = "one fish two fish red fish blue fish";
-    let output = word_count::word_count(input);
-    let expected = &[("one", 1), ("fish", 4), ("two", 1), ("red", 1), ("blue", 1)];
-    check_word_count(output, expected);
+    let mut output = word_count(input);
+    let expected = [("one", 1), ("fish", 4), ("two", 1), ("red", 1), ("blue", 1)];
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn handles_cramped_lists() {
     let input = "one,two,three";
-    let output = word_count::word_count(input);
-    let expected = &[("one", 1), ("two", 1), ("three", 1)];
-    check_word_count(output, expected);
+    let mut output = word_count(input);
+    let expected = [("one", 1), ("two", 1), ("three", 1)];
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn handles_expanded_lists() {
     let input = "one,\ntwo,\nthree";
-    let output = word_count::word_count(input);
-    let expected = &[("one", 1), ("two", 1), ("three", 1)];
-    check_word_count(output, expected);
+    let mut output = word_count(input);
+    let expected = [("one", 1), ("two", 1), ("three", 1)];
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn ignore_punctuation() {
     let input = "car: carpet as java: javascript!!&@$%^&";
-    let output = word_count::word_count(input);
-    let expected = &[
+    let mut output = word_count(input);
+    let expected = [
         ("car", 1),
         ("carpet", 1),
         ("as", 1),
         ("java", 1),
         ("javascript", 1),
     ];
-    check_word_count(output, expected);
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn include_numbers() {
     let input = "testing, 1, 2 testing";
-    let output = word_count::word_count(input);
-    let expected = &[("testing", 2), ("1", 1), ("2", 1)];
-    check_word_count(output, expected);
+    let mut output = word_count(input);
+    let expected = [("testing", 2), ("1", 1), ("2", 1)];
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn normalize_case() {
     let input = "go Go GO Stop stop";
-    let output = word_count::word_count(input);
-    let expected = &[("go", 3), ("stop", 2)];
-    check_word_count(output, expected);
+    let mut output = word_count(input);
+    let expected = [("go", 3), ("stop", 2)];
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn with_apostrophes() {
     let input = "'First: don't laugh. Then: don't cry. You're getting it.'";
-    let output = word_count::word_count(input);
-    let expected = &[
+    let mut output = word_count(input);
+    let expected = [
         ("first", 1),
         ("don't", 2),
         ("laugh", 1),
@@ -104,15 +116,18 @@ fn with_apostrophes() {
         ("getting", 1),
         ("it", 1),
     ];
-    check_word_count(output, expected);
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn with_quotations() {
     let input = "Joe can't tell between 'large' and large.";
-    let output = word_count::word_count(input);
-    let expected = &[
+    let mut output = word_count(input);
+    let expected = [
         ("joe", 1),
         ("can't", 1),
         ("tell", 1),
@@ -120,15 +135,18 @@ fn with_quotations() {
         ("large", 2),
         ("and", 1),
     ];
-    check_word_count(output, expected);
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn substrings_from_the_beginning() {
     let input = "Joe can't tell between app, apple and a.";
-    let output = word_count::word_count(input);
-    let expected = &[
+    let mut output = word_count(input);
+    let expected = [
         ("joe", 1),
         ("can't", 1),
         ("tell", 1),
@@ -138,32 +156,44 @@ fn substrings_from_the_beginning() {
         ("and", 1),
         ("a", 1),
     ];
-    check_word_count(output, expected);
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn multiple_spaces_not_detected_as_a_word() {
     let input = " multiple   whitespaces";
-    let output = word_count::word_count(input);
-    let expected = &[("multiple", 1), ("whitespaces", 1)];
-    check_word_count(output, expected);
+    let mut output = word_count(input);
+    let expected = [("multiple", 1), ("whitespaces", 1)];
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn alternating_word_separators_not_detected_as_a_word() {
     let input = ",\n,one,\n ,two \n 'three'";
-    let output = word_count::word_count(input);
-    let expected = &[("one", 1), ("two", 1), ("three", 1)];
-    check_word_count(output, expected);
+    let mut output = word_count(input);
+    let expected = [("one", 1), ("two", 1), ("three", 1)];
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
 #[ignore]
 fn quotation_for_word_with_apostrophe() {
     let input = "can, can't, 'can't'";
-    let output = word_count::word_count(input);
-    let expected = &[("can", 1), ("can't", 2)];
-    check_word_count(output, expected);
+    let mut output = word_count(input);
+    let expected = [("can", 1), ("can't", 2)];
+    for (word, count) in expected {
+        assert_eq!((word, output.remove(word).unwrap_or(0)), (word, count));
+    }
+    assert_eq!(output.into_iter().collect::<Vec<_>>(), vec![]);
 }


### PR DESCRIPTION
closes #1845

Due to type inference, this is not a breaking change. I tested with the old function signature using `u32` as well, it still works.