### PR TITLE
Add Exercise Matrix

### DIFF
--- a/config.json
+++ b/config.json
@@ -1533,6 +1533,15 @@
         "prerequisites": [],
         "difficulty": 4,
         "topics": []
+      },
+      {
+        "slug": "matrix",
+        "name": "Matrix",
+        "uuid": "9fceeb8b-0154-45f0-93a5-7117d4d81449",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4,
+        "topics": []
       }
     ],
     "foregone": [

--- a/exercises/practice/matrix/.docs/instructions.append.md
+++ b/exercises/practice/matrix/.docs/instructions.append.md
@@ -2,7 +2,7 @@
 
 ## Challenges
 
-- Can you implement this solution with using **ANY** `for` loops? (ie using [iterators][iterators] instead)
+- Can you implement this solution without using any `for` loops? (i.e. using [iterators][iterators] instead)
 - Although it would be relatively straight-forward to have two data structures in `Matrix` (one representing rows and another for columns), can you implement this solution without having to hold two separate copies of the input in your struct?
 
 ## Helpful Methods

--- a/exercises/practice/matrix/.docs/instructions.append.md
+++ b/exercises/practice/matrix/.docs/instructions.append.md
@@ -1,0 +1,20 @@
+# Instructions append
+
+## Challenges
+
+- Can you implement this solution with using **ANY** `for` loops? (ie using [iterators][iterators] instead)
+- Although it would be relatively straight-forward to have two data structures in `Matrix` (one representing rows and another for columns), can you implement this solution without having to hold two separate copies of the input in your struct?
+
+## Helpful Methods
+- [`map()`][map]
+- [`filter()`][filter]
+- [`lines()`][lines]
+- [`split()`][split]
+- [`parse()`][parse]
+
+[iterators]: https://doc.rust-lang.org/book/ch13-02-iterators.html
+[map]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.map
+[filter]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.filter
+[lines]: https://doc.rust-lang.org/std/primitive.str.html#method.lines
+[split]: https://doc.rust-lang.org/std/primitive.str.html#method.split
+[parse]: https://doc.rust-lang.org/std/primitive.str.html#method.parse

--- a/exercises/practice/matrix/.docs/instructions.md
+++ b/exercises/practice/matrix/.docs/instructions.md
@@ -1,0 +1,38 @@
+# Instructions
+
+Given a string representing a matrix of numbers, return the rows and columns of that matrix.
+
+So given a string with embedded newlines like:
+
+```text
+9 8 7
+5 3 2
+6 6 7
+```
+
+representing this matrix:
+
+```text
+    1  2  3
+  |---------
+1 | 9  8  7
+2 | 5  3  2
+3 | 6  6  7
+```
+
+your code should be able to spit out:
+
+- A list of the rows, reading each row left-to-right while moving top-to-bottom across the rows,
+- A list of the columns, reading each column top-to-bottom while moving from left-to-right.
+
+The rows for our example matrix:
+
+- 9, 8, 7
+- 5, 3, 2
+- 6, 6, 7
+
+And its columns:
+
+- 9, 5, 6
+- 8, 3, 6
+- 7, 2, 7

--- a/exercises/practice/matrix/.gitignore
+++ b/exercises/practice/matrix/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/exercises/practice/matrix/.meta/additional-tests.json
+++ b/exercises/practice/matrix/.meta/additional-tests.json
@@ -7,7 +7,10 @@
             "string": "1 2 3\n4 5 6\n7 8 9",
             "index": 4
         },
-        "expected": null
+        "expected": null,
+        "comments": [
+            "Additional test to ensure the method can handle invalid input"
+        ]
     },
     {
         "uuid": "304d71d4-cf26-41d4-9b74-cc04441fec8c",
@@ -17,6 +20,9 @@
             "string": "1 2 3\n4 5 6\n7 8 9",
             "index": 4
         },
-        "expected": null
+        "expected": null,
+        "comments": [
+            "Additional test to ensure the method can handle invalid input"
+        ]
     }
 ]

--- a/exercises/practice/matrix/.meta/additional-tests.json
+++ b/exercises/practice/matrix/.meta/additional-tests.json
@@ -1,22 +1,22 @@
-{
-    "cases": [
-        {
-            "description": "cannot extract row with no corresponding row in matrix",
-            "property": "row",
-            "input": {
-                "string": "1 2 3\n4 5 6\n7 8 9",
-                "index": 4
-            },
-            "expected": null
+[
+    {
+        "uuid": "9ca9c869-7220-4783-93ba-3e4f96b81732",
+        "description": "cannot extract row with no corresponding row in matrix",
+        "property": "row",
+        "input": {
+            "string": "1 2 3\n4 5 6\n7 8 9",
+            "index": 4
         },
-        {
-            "description": "cannot extract column with no corresponding column in matrix",
-            "property": "column",
-            "input": {
-                "string": "1 2 3\n4 5 6\n7 8 9",
-                "index": 4
-            },
-            "expected": null
-        }
-    ]
-}
+        "expected": null
+    },
+    {
+        "uuid": "304d71d4-cf26-41d4-9b74-cc04441fec8c",
+        "description": "cannot extract column with no corresponding column in matrix",
+        "property": "column",
+        "input": {
+            "string": "1 2 3\n4 5 6\n7 8 9",
+            "index": 4
+        },
+        "expected": null
+    }
+]

--- a/exercises/practice/matrix/.meta/additional-tests.json
+++ b/exercises/practice/matrix/.meta/additional-tests.json
@@ -8,8 +8,11 @@
             "index": 4
         },
         "expected": null,
-        "comments": [
-            "Additional test to ensure the method can handle invalid input"
+        "comments": [ 
+            "Additional test to ensure the method can handle invalid input", 
+            "Upstream does not want to add this test to avoid every exercise being about input validation.", 
+            "Rust puts a lot of emphasis on error handling, hence the idiomatic Option return type.", 
+            "With Option in the API, it makes sense to test for None at least once." 
         ]
     },
     {
@@ -21,8 +24,11 @@
             "index": 4
         },
         "expected": null,
-        "comments": [
-            "Additional test to ensure the method can handle invalid input"
+        "comments": [ 
+            "Additional test to ensure the method can handle invalid input", 
+            "Upstream does not want to add this test to avoid every exercise being about input validation.", 
+            "Rust puts a lot of emphasis on error handling, hence the idiomatic Option return type.", 
+            "With Option in the API, it makes sense to test for None at least once." 
         ]
     }
 ]

--- a/exercises/practice/matrix/.meta/additional-tests.json
+++ b/exercises/practice/matrix/.meta/additional-tests.json
@@ -1,0 +1,22 @@
+{
+    "cases": [
+        {
+            "description": "cannot extract row with no corresponding row in matrix",
+            "property": "row",
+            "input": {
+                "string": "1 2 3\n4 5 6\n7 8 9",
+                "index": 4
+            },
+            "expected": null
+        },
+        {
+            "description": "cannot extract column with no corresponding column in matrix",
+            "property": "column",
+            "input": {
+                "string": "1 2 3\n4 5 6\n7 8 9",
+                "index": 4
+            },
+            "expected": null
+        }
+    ]
+}

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -1,0 +1,11 @@
+{
+  "authors": [],
+  "files": {
+    "solution": [],
+    "test": [],
+    "example": []
+  },
+  "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
+  "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",
+  "source_url": "https://turing.edu"
+}

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -1,9 +1,16 @@
 {
-  "authors": [],
+  "authors": ["jpal91"],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "src/lib.rs",
+      "Cargo.toml"
+    ],
+    "test": [
+      "tests/matrix.rs"
+    ],
+    "example": [
+      ".meta/example.rs"
+    ]
   },
   "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
   "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",

--- a/exercises/practice/matrix/.meta/example.rs
+++ b/exercises/practice/matrix/.meta/example.rs
@@ -1,3 +1,34 @@
-pub fn TODO(input: TODO) -> TODO {
-    TODO
+pub struct Matrix {
+    grid: Vec<Vec<u32>>,
+}
+
+impl Matrix {
+    pub fn new(input: &str) -> Self {
+        let grid = input
+            .lines()
+            .map(|l| {
+                l.split(" ")
+                    .map(|n| n.parse::<u32>().unwrap())
+                    .collect()
+            })
+            .collect();
+
+        Self { grid }
+    }
+
+    pub fn row(&self, row_no: usize) -> Option<Vec<u32>> {
+        if row_no > self.grid.len() {
+            return None;
+        };
+
+        Some(self.grid[row_no - 1].to_owned())
+    }
+
+    pub fn column(&self, col_no: usize) -> Option<Vec<u32>> {
+        if col_no > self.grid[0].len() {
+            return None;
+        };
+
+        Some(self.grid.iter().map(|row| row[col_no - 1]).collect())
+    }
 }

--- a/exercises/practice/matrix/.meta/example.rs
+++ b/exercises/practice/matrix/.meta/example.rs
@@ -6,22 +6,14 @@ impl Matrix {
     pub fn new(input: &str) -> Self {
         let grid = input
             .lines()
-            .map(|l| {
-                l.split(" ")
-                    .map(|n| n.parse::<u32>().unwrap())
-                    .collect()
-            })
+            .map(|l| l.split(' ').map(|n| n.parse::<u32>().unwrap()).collect())
             .collect();
 
         Self { grid }
     }
 
     pub fn row(&self, row_no: usize) -> Option<Vec<u32>> {
-        if row_no > self.grid.len() {
-            return None;
-        };
-
-        Some(self.grid[row_no - 1].to_owned())
+        self.grid.get(row_no - 1).map(|row| row.to_owned())
     }
 
     pub fn column(&self, col_no: usize) -> Option<Vec<u32>> {

--- a/exercises/practice/matrix/.meta/example.rs
+++ b/exercises/practice/matrix/.meta/example.rs
@@ -1,0 +1,3 @@
+pub fn TODO(input: TODO) -> TODO {
+    TODO
+}

--- a/exercises/practice/matrix/.meta/test_template.tera
+++ b/exercises/practice/matrix/.meta/test_template.tera
@@ -7,12 +7,10 @@ use {{ crate_name }}::*;
 {% endif -%}
 fn {{ test.description | slugify | replace(from="-", to="_") }}() {
     let matrix = Matrix::new({{ test.input.string | json_encode() }});
+    {% if test.expected -%}
     assert_eq!(matrix.{{ test.property }}({{ test.input.index }}), Some(vec!{{ test.expected | json_encode() }}));
-    {% if loop.index == 4 -%}
-    assert_eq!(matrix.column({{ test.input.index }}), None);
+    {% else -%}
+    assert_eq!(matrix.{{ test.property }}({{ test.input.index }}), None);
     {% endif -%}
-    {% if loop.index == 7 -%}
-    assert_eq!(matrix.row({{ test.input.index }}), None);
-    {% endif -%} 
 }
 {% endfor -%}

--- a/exercises/practice/matrix/.meta/test_template.tera
+++ b/exercises/practice/matrix/.meta/test_template.tera
@@ -6,9 +6,13 @@ use {{ crate_name }}::*;
 #[ignore]
 {% endif -%}
 fn {{ test.description | slugify | replace(from="-", to="_") }}() {
-    let input = {{ test.input | json_encode() }};
-    let output = {{ fn_names[0] }}(input);
-    let expected = {{ test.expected | json_encode() }};
-    assert_eq!(output, expected);
+    let matrix = Matrix::new({{ test.input.string | json_encode() }});
+    assert_eq!(matrix.{{ test.property }}({{ test.input.index }}), Some(vec!{{ test.expected | json_encode() }}));
+    {% if loop.index == 4 -%}
+    assert_eq!(matrix.column({{ test.input.index }}), None);
+    {% endif -%}
+    {% if loop.index == 7 -%}
+    assert_eq!(matrix.row({{ test.input.index }}), None);
+    {% endif -%} 
 }
 {% endfor -%}

--- a/exercises/practice/matrix/.meta/test_template.tera
+++ b/exercises/practice/matrix/.meta/test_template.tera
@@ -1,0 +1,14 @@
+use {{ crate_name }}::*;
+
+{% for test in cases %}
+#[test]
+{% if loop.index != 1 -%}
+#[ignore]
+{% endif -%}
+fn {{ test.description | slugify | replace(from="-", to="_") }}() {
+    let input = {{ test.input | json_encode() }};
+    let output = {{ fn_names[0] }}(input);
+    let expected = {{ test.expected | json_encode() }};
+    assert_eq!(output, expected);
+}
+{% endfor -%}

--- a/exercises/practice/matrix/.meta/tests.toml
+++ b/exercises/practice/matrix/.meta/tests.toml
@@ -1,0 +1,34 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[ca733dab-9d85-4065-9ef6-a880a951dafd]
+description = "extract row from one number matrix"
+
+[5c93ec93-80e1-4268-9fc2-63bc7d23385c]
+description = "can extract row"
+
+[2f1aad89-ad0f-4bd2-9919-99a8bff0305a]
+description = "extract row where numbers have different widths"
+
+[68f7f6ba-57e2-4e87-82d0-ad09889b5204]
+description = "can extract row from non-square matrix with no corresponding column"
+
+[e8c74391-c93b-4aed-8bfe-f3c9beb89ebb]
+description = "extract column from one number matrix"
+
+[7136bdbd-b3dc-48c4-a10c-8230976d3727]
+description = "can extract column"
+
+[ad64f8d7-bba6-4182-8adf-0c14de3d0eca]
+description = "can extract column from non-square matrix with no corresponding row"
+
+[9eddfa5c-8474-440e-ae0a-f018c2a0dd89]
+description = "extract column where numbers have different widths"

--- a/exercises/practice/matrix/Cargo.toml
+++ b/exercises/practice/matrix/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+edition = "2021"
+name = "matrix"
+version = "1.0.0"
+
+[dependencies]

--- a/exercises/practice/matrix/src/lib.rs
+++ b/exercises/practice/matrix/src/lib.rs
@@ -1,0 +1,17 @@
+pub struct Matrix {
+    // Implement your Matrix struct
+}
+
+impl Matrix {
+    pub fn new(input: &str) -> Self {
+        todo!("Create new method to store the {input}")
+    }
+
+    pub fn row(&self, row_no: usize) -> Option<Vec<u32>> {
+        todo!("Return the row at {row_no} (1-indexed) or None if the number is invalid")
+    }
+
+    pub fn column(&self, col_no: usize) -> Option<Vec<u32>> {
+        todo!("Return the column at {col_no} (1-indexed) or None if the number is invalid")
+    }
+}

--- a/exercises/practice/matrix/tests/matrix.rs
+++ b/exercises/practice/matrix/tests/matrix.rs
@@ -25,7 +25,6 @@ fn extract_row_where_numbers_have_different_widths() {
 fn can_extract_row_from_non_square_matrix_with_no_corresponding_column() {
     let matrix = Matrix::new("1 2 3\n4 5 6\n7 8 9\n8 7 6");
     assert_eq!(matrix.row(4), Some(vec![8, 7, 6]));
-    assert_eq!(matrix.column(4), None);
 }
 
 #[test]
@@ -47,7 +46,6 @@ fn can_extract_column() {
 fn can_extract_column_from_non_square_matrix_with_no_corresponding_row() {
     let matrix = Matrix::new("1 2 3 4\n5 6 7 8\n9 8 7 6");
     assert_eq!(matrix.column(4), Some(vec![4, 8, 6]));
-    assert_eq!(matrix.row(4), None);
 }
 
 #[test]
@@ -55,4 +53,18 @@ fn can_extract_column_from_non_square_matrix_with_no_corresponding_row() {
 fn extract_column_where_numbers_have_different_widths() {
     let matrix = Matrix::new("89 1903 3\n18 3 1\n9 4 800");
     assert_eq!(matrix.column(2), Some(vec![1903, 3, 4]));
+}
+
+#[test]
+#[ignore]
+fn cannot_extract_row_with_no_corresponding_row_in_matrix() {
+    let matrix = Matrix::new("1 2 3\n4 5 6\n7 8 9");
+    assert_eq!(matrix.row(4), None);
+}
+
+#[test]
+#[ignore]
+fn cannot_extract_column_with_no_corresponding_column_in_matrix() {
+    let matrix = Matrix::new("1 2 3\n4 5 6\n7 8 9");
+    assert_eq!(matrix.column(4), None);
 }

--- a/exercises/practice/matrix/tests/matrix.rs
+++ b/exercises/practice/matrix/tests/matrix.rs
@@ -1,1 +1,51 @@
 use matrix::*;
+
+#[test]
+fn test_extract_row_from_one_number_matrix() {
+    let matrix = Matrix::new("1");
+    assert_eq!(matrix.row(1), Some(vec![1]));
+}
+
+#[test]
+fn test_can_extract_row() {
+    let matrix = Matrix::new("1 2\n3 4");
+    assert_eq!(matrix.row(2), Some(vec![3, 4]));
+}
+
+#[test]
+fn test_extract_row_where_numbers_have_different_widths() {
+    let matrix = Matrix::new("1 2\n10 20");
+    assert_eq!(matrix.row(2 ), Some(vec![10, 20]));
+}
+
+#[test]
+fn test_can_extract_row_from_non_square_matrix_with_no_corresponding_column() {
+    let matrix = Matrix::new("1 2 3\n4 5 6\n7 8 9\n8 7 6");
+    assert_eq!(matrix.row(4), Some(vec![8, 7, 6]));
+    assert_eq!(matrix.column(4), None);
+}
+
+#[test]
+fn test_extract_column_from_one_number_matrix() {
+    let matrix = Matrix::new("1");
+    assert_eq!(matrix.column(1), Some(vec![1]));
+}
+
+#[test]
+fn test_extract_column() {
+    let matrix = Matrix::new("1 2 3\n4 5 6\n7 8 9");
+    assert_eq!(matrix.column(3), Some(vec![3, 6, 9]));
+}
+
+#[test]
+fn test_can_extract_column_from_non_square_matrix_with_no_corresponding_row() {
+    let matrix = Matrix::new("1 2 3 4\n5 6 7 8\n9 8 7 6");
+    assert_eq!(matrix.column(4), Some(vec![4, 8, 6]));
+    assert_eq!(matrix.row(4), None);
+}
+
+#[test]
+fn test_extract_column_where_numbers_have_different_widths() {
+    let matrix = Matrix::new("89 1903 3\n18 3 1\n9 4 800");
+    assert_eq!(matrix.column(2), Some(vec![1903, 3, 4]));
+}

--- a/exercises/practice/matrix/tests/matrix.rs
+++ b/exercises/practice/matrix/tests/matrix.rs
@@ -1,28 +1,28 @@
 use matrix::*;
 
 #[test]
-fn test_extract_row_from_one_number_matrix() {
+fn extract_row_from_one_number_matrix() {
     let matrix = Matrix::new("1");
     assert_eq!(matrix.row(1), Some(vec![1]));
 }
 
 #[test]
 #[ignore]
-fn test_can_extract_row() {
+fn can_extract_row() {
     let matrix = Matrix::new("1 2\n3 4");
     assert_eq!(matrix.row(2), Some(vec![3, 4]));
 }
 
 #[test]
 #[ignore]
-fn test_extract_row_where_numbers_have_different_widths() {
+fn extract_row_where_numbers_have_different_widths() {
     let matrix = Matrix::new("1 2\n10 20");
     assert_eq!(matrix.row(2), Some(vec![10, 20]));
 }
 
 #[test]
 #[ignore]
-fn test_can_extract_row_from_non_square_matrix_with_no_corresponding_column() {
+fn can_extract_row_from_non_square_matrix_with_no_corresponding_column() {
     let matrix = Matrix::new("1 2 3\n4 5 6\n7 8 9\n8 7 6");
     assert_eq!(matrix.row(4), Some(vec![8, 7, 6]));
     assert_eq!(matrix.column(4), None);
@@ -30,21 +30,21 @@ fn test_can_extract_row_from_non_square_matrix_with_no_corresponding_column() {
 
 #[test]
 #[ignore]
-fn test_extract_column_from_one_number_matrix() {
+fn extract_column_from_one_number_matrix() {
     let matrix = Matrix::new("1");
     assert_eq!(matrix.column(1), Some(vec![1]));
 }
 
 #[test]
 #[ignore]
-fn test_extract_column() {
+fn can_extract_column() {
     let matrix = Matrix::new("1 2 3\n4 5 6\n7 8 9");
     assert_eq!(matrix.column(3), Some(vec![3, 6, 9]));
 }
 
 #[test]
 #[ignore]
-fn test_can_extract_column_from_non_square_matrix_with_no_corresponding_row() {
+fn can_extract_column_from_non_square_matrix_with_no_corresponding_row() {
     let matrix = Matrix::new("1 2 3 4\n5 6 7 8\n9 8 7 6");
     assert_eq!(matrix.column(4), Some(vec![4, 8, 6]));
     assert_eq!(matrix.row(4), None);
@@ -52,7 +52,7 @@ fn test_can_extract_column_from_non_square_matrix_with_no_corresponding_row() {
 
 #[test]
 #[ignore]
-fn test_extract_column_where_numbers_have_different_widths() {
+fn extract_column_where_numbers_have_different_widths() {
     let matrix = Matrix::new("89 1903 3\n18 3 1\n9 4 800");
     assert_eq!(matrix.column(2), Some(vec![1903, 3, 4]));
 }

--- a/exercises/practice/matrix/tests/matrix.rs
+++ b/exercises/practice/matrix/tests/matrix.rs
@@ -15,7 +15,7 @@ fn test_can_extract_row() {
 #[test]
 fn test_extract_row_where_numbers_have_different_widths() {
     let matrix = Matrix::new("1 2\n10 20");
-    assert_eq!(matrix.row(2 ), Some(vec![10, 20]));
+    assert_eq!(matrix.row(2), Some(vec![10, 20]));
 }
 
 #[test]

--- a/exercises/practice/matrix/tests/matrix.rs
+++ b/exercises/practice/matrix/tests/matrix.rs
@@ -1,0 +1,1 @@
+use matrix::*;

--- a/exercises/practice/matrix/tests/matrix.rs
+++ b/exercises/practice/matrix/tests/matrix.rs
@@ -7,18 +7,21 @@ fn test_extract_row_from_one_number_matrix() {
 }
 
 #[test]
+#[ignore]
 fn test_can_extract_row() {
     let matrix = Matrix::new("1 2\n3 4");
     assert_eq!(matrix.row(2), Some(vec![3, 4]));
 }
 
 #[test]
+#[ignore]
 fn test_extract_row_where_numbers_have_different_widths() {
     let matrix = Matrix::new("1 2\n10 20");
     assert_eq!(matrix.row(2), Some(vec![10, 20]));
 }
 
 #[test]
+#[ignore]
 fn test_can_extract_row_from_non_square_matrix_with_no_corresponding_column() {
     let matrix = Matrix::new("1 2 3\n4 5 6\n7 8 9\n8 7 6");
     assert_eq!(matrix.row(4), Some(vec![8, 7, 6]));
@@ -26,18 +29,21 @@ fn test_can_extract_row_from_non_square_matrix_with_no_corresponding_column() {
 }
 
 #[test]
+#[ignore]
 fn test_extract_column_from_one_number_matrix() {
     let matrix = Matrix::new("1");
     assert_eq!(matrix.column(1), Some(vec![1]));
 }
 
 #[test]
+#[ignore]
 fn test_extract_column() {
     let matrix = Matrix::new("1 2 3\n4 5 6\n7 8 9");
     assert_eq!(matrix.column(3), Some(vec![3, 6, 9]));
 }
 
 #[test]
+#[ignore]
 fn test_can_extract_column_from_non_square_matrix_with_no_corresponding_row() {
     let matrix = Matrix::new("1 2 3 4\n5 6 7 8\n9 8 7 6");
     assert_eq!(matrix.column(4), Some(vec![4, 8, 6]));
@@ -45,6 +51,7 @@ fn test_can_extract_column_from_non_square_matrix_with_no_corresponding_row() {
 }
 
 #[test]
+#[ignore]
 fn test_extract_column_where_numbers_have_different_widths() {
     let matrix = Matrix::new("89 1903 3\n18 3 1\n9 4 800");
     assert_eq!(matrix.column(2), Some(vec![1903, 3, 4]));


### PR DESCRIPTION
Per forum post - [Adding Matrix to the Rust Track](http://forum.exercism.org/t/adding-matrix-to-the-rust-track/10480)

Here's what I did:

- Added Matrix exercise from problem-specifications using `rust-tooling/generate`
- Created example.rs
- Added all required tests
- Created boilerplate in lib.rs

This is my first contribution so there's a chance I probably forgot something but it looks like all cargo and CI tests are running on my end, so hopefully we should be good.

Also, I increased the difficulty to 4 as depending on the implementation you could be working with nested iterators/map/collect, but I was going back and forth on this. If you think 1 is still more appropriate, just let me know and I'll switch it back. 

Thanks!