### PR TITLE
Fixed tests that disallowed correct answers

### DIFF
--- a/exercises/practice/collatz-conjecture/tests/collatz-conjecture.rs
+++ b/exercises/practice/collatz-conjecture/tests/collatz-conjecture.rs
@@ -33,19 +33,29 @@ fn zero() {
 #[ignore]
 fn test_110243094271() {
     let val = 110243094271;
-    assert_eq!(None, collatz(val));
+    let collatz_length = collatz(val);
+    if collatz_length.is_some() {
+        assert_eq!(Some(572), collatz_length);
+    }
 }
 
 #[test]
 #[ignore]
 fn max_div_3() {
     let max = u64::MAX / 3;
-    assert_eq!(None, collatz(max));
+    let collatz_length = collatz(max);
+    dbg!(max, collatz_length);
+    if collatz_length.is_some() {
+        assert_eq!(Some(65), collatz_length);
+    }
 }
 
 #[test]
 #[ignore]
 fn max_minus_1() {
     let max = u64::MAX - 1;
-    assert_eq!(None, collatz(max));
+    let collatz_length = collatz(max);
+    if collatz_length.is_some() {
+        assert_eq!(Some(863), collatz_length);
+    }
 }


### PR DESCRIPTION
The tests assume that there can be only one way to solve the problem: if the number is even, divide it by 2 and if the number is odd, multiply it by 3 and add 1.

Multiplying by 3 and adding 1 can cause an overflow, which the tests accommodate by allowing `None` as a correct response whenever `u64` overflows occur.

The problem is that `None` is considered to be ***the only*** correct response in that case, when every nonzero `u64` has a correct answer that can be put into `Some`. For example, overflow can be avoided by converting the input `u64` into a `u128` and then getting the result using `u128` arithmetic.

This commit corrects the tests so that either `None` or the correct answer is allowed when `u64` overflow can occur.