### PR TITLE
collatz-conjecture: sync

### DIFF
--- a/exercises/practice/collatz-conjecture/.meta/test_template.tera
+++ b/exercises/practice/collatz-conjecture/.meta/test_template.tera
@@ -1,0 +1,16 @@
+use collatz_conjecture::*;
+
+{% for test in cases %}
+#[test]
+#[ignore]
+fn {{ test.description | snake_case }}() {
+    let output = collatz({{ test.input.number | json_encode() }});
+    
+    let expected = {% if test.expected is object %}
+        None
+    {% else %}
+        Some({{ test.expected | json_encode() }})
+    {% endif %};
+    assert_eq!(output, expected);
+}
+{% endfor -%}

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -1,3 +1,40 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
+description = "zero steps for one"
+
+[3d76a0a6-ea84-444a-821a-f7857c2c1859]
+description = "divide if even"
+
+[754dea81-123c-429e-b8bc-db20b05a87b9]
+description = "even and odd steps"
+
+[ecfd0210-6f85-44f6-8280-f65534892ff6]
+description = "large number of even and odd steps"
+
+[7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
+description = "zero is an error"
+include = false
+
+[2187673d-77d6-4543-975e-66df6c50e2da]
+description = "zero is an error"
+reimplements = "7d4750e6-def9-4b86-aec7-9f7eb44f95a3"
+
+[c6c795bf-a288-45e9-86a1-841359ad426d]
+description = "negative value is an error"
+include = false
+
+[ec11f479-56bc-47fd-a434-bcd7a31a7a2e]
+description = "negative value is an error"
+reimplements = "c6c795bf-a288-45e9-86a1-841359ad426d"
+include = false
+comment = "The exercise uses u64, which doesn't allow negative numbers."

--- a/exercises/practice/collatz-conjecture/tests/collatz-conjecture.rs
+++ b/exercises/practice/collatz-conjecture/tests/collatz-conjecture.rs
@@ -1,51 +1,45 @@
 use collatz_conjecture::*;
 
 #[test]
-fn one() {
-    assert_eq!(Some(0), collatz(1));
+fn zero_steps_for_one() {
+    let output = collatz(1);
+
+    let expected = Some(0);
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
-fn sixteen() {
-    assert_eq!(Some(4), collatz(16));
+fn divide_if_even() {
+    let output = collatz(16);
+
+    let expected = Some(4);
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
-fn twelve() {
-    assert_eq!(Some(9), collatz(12));
+fn even_and_odd_steps() {
+    let output = collatz(12);
+
+    let expected = Some(9);
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
-fn one_million() {
-    assert_eq!(Some(152), collatz(1_000_000));
+fn large_number_of_even_and_odd_steps() {
+    let output = collatz(1000000);
+
+    let expected = Some(152);
+    assert_eq!(output, expected);
 }
 
 #[test]
 #[ignore]
-fn zero() {
-    assert_eq!(None, collatz(0));
-}
+fn zero_is_an_error() {
+    let output = collatz(0);
 
-#[test]
-#[ignore]
-fn test_110243094271() {
-    let val = 110243094271;
-    assert_eq!(None, collatz(val));
-}
-
-#[test]
-#[ignore]
-fn max_div_3() {
-    let max = u64::MAX / 3;
-    assert_eq!(None, collatz(max));
-}
-
-#[test]
-#[ignore]
-fn max_minus_1() {
-    let max = u64::MAX - 1;
-    assert_eq!(None, collatz(max));
+    let expected = None;
+    assert_eq!(output, expected);
 }

--- a/rust-tooling/generate/src/lib.rs
+++ b/rust-tooling/generate/src/lib.rs
@@ -91,8 +91,10 @@ fn generate_tests(slug: &str) -> Result<String> {
     };
     let excluded_tests = get_excluded_tests(slug);
     let mut template = get_test_template(slug).context("failed to get test template")?;
-    if template.get_template_names().next() != Some("test_template.tera") {
-        anyhow::bail!("'test_template.tera' not found");
+    if template.get_template_names().next().is_none() {
+        template
+            .add_raw_template("test_template.tera", TEST_TEMPLATE)
+            .context("failed to add default template")?;
     }
     for (name, filter) in CUSTOM_FILTERS {
         template.register_filter(name, filter);

--- a/rust-tooling/generate/templates/default_test_template.tera
+++ b/rust-tooling/generate/templates/default_test_template.tera
@@ -3,7 +3,7 @@ use crate_name::*;
 {% for test in cases %}
 #[test]
 #[ignore]
-fn {{ test.description | slugify | replace(from="-", to="_") }}() {
+fn {{ test.description | snake_case }}() {
     let input = {{ test.input | json_encode() }};
     let output = function_name(input);
     let expected = {{ test.expected | json_encode() }};


### PR DESCRIPTION
The additional test cases for overflow are incorrect even with u64 in the API. u128 can be used as needed to calculate the intermediate values without overflow.

[no important files changed]