### PR TITLE
add test for zero-length case

### DIFF
--- a/exercises/practice/series/tests/series.rs
+++ b/exercises/practice/series/tests/series.rs
@@ -90,3 +90,13 @@ fn empty_series_is_invalid() {
     let expected: &[&str] = &[];
     assert_eq!(output, expected);
 }
+
+#[test]
+#[ignore]
+fn zero_length_series_returns_empty_strings() {
+    let input = "12345";
+    let length = 0;
+    let output = series(input, length);
+    let expected: &[&str] = &[""; 6];
+    assert_eq!(output, expected)
+}


### PR DESCRIPTION
I noticed that the exercise was missing a test for the zero-length case that is described in this paragraph:

> Different languages on Exercism have different expectations about what the result should be if the length of the substrings is zero.
>For Rust, we expect you to output a number of empty strings, which will be one greater than the length of the input string.

This PR adds that test.

Hopefully this is okay, it's my first time making a PR. Sorry for any mistakes!