### PR TITLE
Add a test to check for duplicate data at initialization in exercise "custom-set"

### DIFF
--- a/exercises/practice/custom-set/tests/custom-set.rs
+++ b/exercises/practice/custom-set/tests/custom-set.rs
@@ -15,6 +15,14 @@ fn sets_with_elements_are_not_empty() {
 
 #[test]
 #[ignore]
+fn duplicate_input_is_ignored() {
+    let set = CustomSet::<i32>::new(&[1,1,2,3]);
+    let expected = CustomSet::<i32>::new(&[1,2,3]);
+    assert_eq!(set, expected);
+}
+
+#[test]
+#[ignore]
 fn nothing_is_contained_in_an_empty_set() {
     let set = CustomSet::<i32>::new(&[]);
     assert!(!set.contains(&1));


### PR DESCRIPTION
As per the comment in [NMeulemann's solution](https://exercism.org/tracks/rust/exercises/custom-set/solutions/NMeuleman), the tests in custom-set currently pass even if CustomSet incorrectly carries over duplicate data from input provided at initialization.

This PR adds a test to rectify that!