### PR TITLE
series: fix outdated instructions

### DIFF
--- a/exercises/practice/series/.docs/instructions.append.md
+++ b/exercises/practice/series/.docs/instructions.append.md
@@ -7,4 +7,4 @@ Consider the advantages and disadvantages of the following possibilities:
 - Crash the program with `panic!`.
 - Return a `Result::Err`. (not possible here, because the function signature is given)
 - Return an empty vector.
-- Return a vector containing `len + 1` empty strings. (this has some nice mathematical properties!)
+- Return a vector containing as many empty strings as the lenght of the string "digits" **plus one**. (this has some nice mathematical properties!)

--- a/exercises/practice/series/.docs/instructions.append.md
+++ b/exercises/practice/series/.docs/instructions.append.md
@@ -1,4 +1,10 @@
 # Instructions append
 
 Different languages on Exercism have different expectations about what the result should be if the length of the substrings is zero.
-For Rust, we expect you to output a number of empty strings, which will be one greater than the length of the input string.
+On the Rust track, we don't have a test for that case, so you are free to do what you feel is most appropriate.
+
+Consider the advantages and disadvantages of the following possibilities:
+- Crash the program with `panic!`.
+- Return a `Result::Err`. (not possible here, because the function signature is given)
+- Return an empty vector.
+- Return a vector containing `len + 1` empty strings. (this has some nice mathematical properties!)


### PR DESCRIPTION
The controversial test case was previously removed without updating the exercise instructions. This change brings the instructions in line with the tests.

- [PR removing the test][1]
- [forum discussion about removing the test][2]
- [report of outdated documentation][3]

[1]: https://github.com/exercism/rust/pull/1822
[2]: https://forum.exercism.org/t/feedback-wanted-removing-controversial-test-from-series-exercise/8659
[3]: https://forum.exercism.org/t/add-test-for-zero-length-case-on-exercise-series/11070