### PR TITLE
Update instructions.append.md for Triangle

### DIFF
--- a/exercises/practice/triangle/.docs/instructions.append.md
+++ b/exercises/practice/triangle/.docs/instructions.append.md
@@ -13,7 +13,7 @@ Or maybe you will come up with an approach that uses none of those!
 ## Non-integer lengths
 
 The base exercise tests identification of triangles whose sides are all
-integers. However, some triangles cannot be represented by pure integers. A simple example is a right triangle (an isosceles triangle whose equal sides are separated by 90 degrees) whose equal sides both have length of 1. Its hypotenuse is the square root of 2, which is an irrational number: no simple multiplication can represent this number as an integer.
+integers. However, some triangles cannot be represented by pure integers. A simple example is an isosceles right triangle (a right triangle is a triangle whose smaller sides form an angle of 90 degrees) whose equal sides both have length of 1. Its hypotenuse is the square root of 2, which is an irrational number: no integer type can represent this number.
 
 It would be tedious to rewrite the analysis functions to handle both integer and floating-point cases, and particularly tedious to do so for all potential integer and floating point types: given signed and unsigned variants of bitwidths 8, 16, 32, 64, and 128, that would be 10 reimplementations of fundamentally the same code even before considering floats!
 

--- a/exercises/practice/triangle/.docs/instructions.append.md
+++ b/exercises/practice/triangle/.docs/instructions.append.md
@@ -13,7 +13,7 @@ Or maybe you will come up with an approach that uses none of those!
 ## Non-integer lengths
 
 The base exercise tests identification of triangles whose sides are all
-integers. However, some triangles cannot be represented by pure integers. A simple example is an isosceles right triangle (a right triangle is a triangle whose smaller sides form an angle of 90 degrees) whose equal sides both have length of 1. Its hypotenuse is the square root of 2, which is an irrational number: no integer type can represent this number.
+integers. However, some triangles cannot be represented by pure integers. A simple example is a triangle with a 90 degree angle between two equal sides of length 1. Its third side has the length square root of 2, which is an irrational number. No integer can represent it.
 
 It would be tedious to rewrite the analysis functions to handle both integer and floating-point cases, and particularly tedious to do so for all potential integer and floating point types: given signed and unsigned variants of bitwidths 8, 16, 32, 64, and 128, that would be 10 reimplementations of fundamentally the same code even before considering floats!
 


### PR DESCRIPTION
The current version of ` instructions.append.md` gives an inaccurate definition of a right triangle:

`an isosceles triangle whose equal sides are separated by 90 degrees`

(a right triangle need not be isosceles)

This PR attempts to fix this while trying not to add too much additional text that's incidental to the exercise - hopefully the result is readable!

The PR also tries to clarify a little the phrasing about  the representation of irrationals, at the end of the same paragraph.