### PR TITLE
grep: remove suggestion of unavailable crates

### DIFF
--- a/exercises/practice/grep/src/lib.rs
+++ b/exercises/practice/grep/src/lib.rs
@@ -5,13 +5,7 @@ use anyhow::Error;
 /// both more convenient and more idiomatic to contain runtime configuration in
 /// a dedicated struct. Therefore, we suggest that you do so in this exercise.
 ///
-/// In the real world, it's common to use crates such as [`clap`] or
-/// [`structopt`] to handle argument parsing, and of course doing so is
-/// permitted in this exercise as well, though it may be somewhat overkill.
-///
-/// [`clap`]: https://crates.io/crates/clap
 /// [`std::env::args`]: https://doc.rust-lang.org/std/env/fn.args.html
-/// [`structopt`]: https://crates.io/crates/structopt
 #[derive(Debug)]
 pub struct Flags;
 


### PR DESCRIPTION
clap and structopt are not available in the test runner. This is because their derive-API (which is the most popular) takes too long to compile.