### PR TITLE
[Sublist] fix wording issue in instructions.md

### DIFF
--- a/exercises/practice/sublist/.docs/instructions.md
+++ b/exercises/practice/sublist/.docs/instructions.md
@@ -8,8 +8,8 @@ Given any two lists `A` and `B`, determine if:
 - None of the above is true, thus lists `A` and `B` are unequal
 
 Specifically, list `A` is equal to list `B` if both lists have the same values in the same order.
-List `A` is a superlist of `B` if `A` contains a sub-sequence of values equal to `B`.
-List `A` is a sublist of `B` if `B` contains a sub-sequence of values equal to `A`.
+List `A` is a superlist of `B` if `A` contains a sublist (contiguous sub-sequence) of values equal to `B`.
+List `A` is a sublist of `B` if `B` contains a sublist of values equal to `A`.
 
 Examples:
 


### PR DESCRIPTION
The words "sublist" and "subsequence"[^1] mean different things.
They should not be used interchangeably.

[^1]: https://en.wikipedia.org/wiki/Subsequence