### PR TITLE
matrix: add tests for zero indexes

### DIFF
--- a/exercises/practice/matrix/.meta/additional-tests.json
+++ b/exercises/practice/matrix/.meta/additional-tests.json
@@ -16,6 +16,22 @@
         ]
     },
     {
+        "uuid": "83a3ade8-b44b-4e08-9092-89f5ff859050",
+        "description": "cannot extract row with index zero",
+        "property": "row",
+        "input": {
+            "string": "1 2 3\n4 5 6\n7 8 9",
+            "index": 0
+        },
+        "expected": null,
+        "comments": [ 
+            "Additional test to ensure the method can handle zero indexes without panicking.", 
+            "Upstream does not want to add this test to avoid every exercise being about input validation.", 
+            "A naive solution may handle the 1-based indexing using index - 1.", 
+            "This panics in debug mode when index == 0 due to integer underflow."
+        ]
+    },
+    {
         "uuid": "304d71d4-cf26-41d4-9b74-cc04441fec8c",
         "description": "cannot extract column with no corresponding column in matrix",
         "property": "column",
@@ -29,6 +45,22 @@
             "Upstream does not want to add this test to avoid every exercise being about input validation.", 
             "Rust puts a lot of emphasis on error handling, hence the idiomatic Option return type.", 
             "With Option in the API, it makes sense to test for None at least once." 
+        ]
+    },
+    {
+        "uuid": "39366889-ccd9-4142-954d-28f76e6036e9",
+        "description": "cannot extract column with index zero",
+        "property": "column",
+        "input": {
+            "string": "1 2 3\n4 5 6\n7 8 9",
+            "index": 0
+        },
+        "expected": null,
+        "comments": [ 
+            "Additional test to ensure the method can handle zero indexes without panicking.", 
+            "Upstream does not want to add this test to avoid every exercise being about input validation.", 
+            "A naive solution may handle the 1-based indexing using index - 1.", 
+            "This panics in debug mode when index == 0 due to integer underflow."
         ]
     }
 ]

--- a/exercises/practice/matrix/.meta/example.rs
+++ b/exercises/practice/matrix/.meta/example.rs
@@ -13,14 +13,10 @@ impl Matrix {
     }
 
     pub fn row(&self, row_no: usize) -> Option<Vec<u32>> {
-        self.grid.get(row_no - 1).map(|row| row.to_owned())
+        self.grid.get(row_no.checked_sub(1)?).cloned()
     }
 
     pub fn column(&self, col_no: usize) -> Option<Vec<u32>> {
-        if col_no > self.grid[0].len() {
-            return None;
-        };
-
-        Some(self.grid.iter().map(|row| row[col_no - 1]).collect())
+        self.grid.iter().map(|row| row.get(col_no.checked_sub(1)?).copied()).collect()
     }
 }

--- a/exercises/practice/matrix/tests/matrix.rs
+++ b/exercises/practice/matrix/tests/matrix.rs
@@ -64,7 +64,21 @@ fn cannot_extract_row_with_no_corresponding_row_in_matrix() {
 
 #[test]
 #[ignore]
+fn cannot_extract_row_with_index_zero() {
+    let matrix = Matrix::new("1 2 3\n4 5 6\n7 8 9");
+    assert_eq!(matrix.row(0), None);
+}
+
+#[test]
+#[ignore]
 fn cannot_extract_column_with_no_corresponding_column_in_matrix() {
     let matrix = Matrix::new("1 2 3\n4 5 6\n7 8 9");
     assert_eq!(matrix.column(4), None);
+}
+
+#[test]
+#[ignore]
+fn cannot_extract_column_with_index_zero() {
+    let matrix = Matrix::new("1 2 3\n4 5 6\n7 8 9");
+    assert_eq!(matrix.column(0), None);
 }


### PR DESCRIPTION
I noticed that it's very easy to accidentally write a solution to "Matrix" that panics when given an index of 0, since unchecked subtraction can panic in debug builds, and posted about it [on the forum](https://forum.exercism.org/t/matrix-doesnt-test-that-index-zero-is-handled-correctly/12182).

I realise that this change ~~may~~ will affect old solutions, and I'm happy to discuss further on the forum if needed, but I figured I'd prepare this simple PR anyway.