### PR TITLE
generator: remove redundant flag

### DIFF
--- a/rust-tooling/ci-tests/tests/stubs_are_warning_free.rs
+++ b/rust-tooling/ci-tests/tests/stubs_are_warning_free.rs
@@ -14,7 +14,7 @@ fn stubs_are_warning_free() {
         .unwrap()
         .map(Result::unwrap)
     {
-        if std::fs::read_to_string(&manifest.parent().unwrap().join(".meta").join("config.json"))
+        if std::fs::read_to_string(manifest.parent().unwrap().join(".meta").join("config.json"))
             .unwrap()
             .contains("allowed-to-not-compile")
         {

--- a/rust-tooling/generate/src/cli.rs
+++ b/rust-tooling/generate/src/cli.rs
@@ -37,17 +37,12 @@ pub struct AddArgs {
 
     #[arg(short, long)]
     difficulty: Option<Difficulty>,
-
-    /// do not update problem-specifications cache
-    #[arg(long)]
-    offline: bool,
 }
 
 pub struct FullAddArgs {
     pub slug: String,
     pub name: String,
     pub difficulty: track_config::Difficulty,
-    pub offline: bool,
 }
 
 impl AddArgs {
@@ -69,7 +64,6 @@ impl AddArgs {
             slug,
             name,
             difficulty,
-            offline: self.offline,
         })
     }
 }
@@ -79,10 +73,6 @@ pub struct UpdateArgs {
     /// slug of the exercise to update
     #[arg(short, long)]
     slug: Option<String>,
-
-    /// do not update problem-specifications cache
-    #[arg(long)]
-    pub offline: bool,
 }
 
 impl UpdateArgs {

--- a/rust-tooling/generate/src/main.rs
+++ b/rust-tooling/generate/src/main.rs
@@ -23,7 +23,6 @@ fn add_exercise(args: AddArgs) -> Result<()> {
         slug,
         name,
         difficulty,
-        offline,
     } = args.unwrap_args_or_prompt()?;
 
     let config = track_config::PracticeExercise::new(slug.clone(), name, difficulty);
@@ -42,40 +41,35 @@ Added your exercise to config.json.
 You can add practices, prerequisites and topics if you like."
     );
 
-    make_configlet_generate_what_it_can(&slug, offline)?;
+    make_configlet_generate_what_it_can(&slug)?;
 
     let is_update = false;
     generate_exercise_files(&slug, is_update)
 }
 
 fn update_exercise(args: UpdateArgs) -> Result<()> {
-    let offline = args.offline;
     let slug = args.unwrap_slug_or_prompt()?;
 
-    make_configlet_generate_what_it_can(&slug, offline)?;
+    make_configlet_generate_what_it_can(&slug)?;
 
     let is_update = true;
     generate_exercise_files(&slug, is_update)
 }
 
-fn make_configlet_generate_what_it_can(slug: &str, offline: bool) -> Result<()> {
+fn make_configlet_generate_what_it_can(slug: &str) -> Result<()> {
     let status = std::process::Command::new("just")
-        .args(
-            [
-                "configlet",
-                "sync",
-                "--update",
-                "--yes",
-                "--docs",
-                "--metadata",
-                "--tests",
-                "include",
-                "--exercise",
-                slug,
-            ]
-            .into_iter()
-            .chain(offline.then_some("--offline")),
-        )
+        .args([
+            "configlet",
+            "sync",
+            "--update",
+            "--yes",
+            "--docs",
+            "--metadata",
+            "--tests",
+            "include",
+            "--exercise",
+            slug,
+        ])
         .status()
         .context("failed to run configlet sync")?;
     if !status.success() {


### PR DESCRIPTION
With the configlet wrapper added in https://github.com/exercism/rust/pull/1950, the `--offline` flag is now always set.