### PR TITLE
Remove unused ignore-count-ignores

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -81,16 +81,6 @@ If there is a justified reason why this is not possible,
 include a `.custom."allowed-to-not-compile"` key
 in the exercise's `.meta/config.json` containing the reason.
 
-If your exercise implements macro-based testing
-(e.g. [`xorcism`](/exercises/practice/xorcism/tests/xorcism.rs)),
-you will likely run afoul of a CI check which counts the `#[ignore]` lines
-and compares the result to the number of `#[test]` lines.
-To fix this, add a marker to the exercise's `.meta/config.json`:
-`.custom."ignore-count-ignores"` should be `true`
-to disable that check for your exercise.
-However, tera templates should generally be preferred to generate many similar test cases.
-See [issue #1824](https://github.com/exercism/rust/issues/1824) for the reasoning.
-
 ## Updating an exercise
 
 Many exercises are derived from [`problem-specifications`].

--- a/exercises/practice/paasio/.meta/config.json
+++ b/exercises/practice/paasio/.meta/config.json
@@ -29,8 +29,5 @@
   },
   "blurb": "Report network IO statistics.",
   "source": "Brian Matsuo",
-  "source_url": "https://github.com/bmatsuo",
-  "custom": {
-    "ignore-count-ignores": true
-  }
+  "source_url": "https://github.com/bmatsuo"
 }

--- a/exercises/practice/xorcism/.meta/config.json
+++ b/exercises/practice/xorcism/.meta/config.json
@@ -24,7 +24,6 @@
   "blurb": "Implement zero-copy streaming adaptors",
   "source": "Peter Goodspeed-Niklaus",
   "custom": {
-    "allowed-to-not-compile": "The point of this exercise is for students to figure out the appropriate function signatures and generic bounds for their implementations, so we cannot provide those.",
-    "ignore-count-ignores": true
+    "allowed-to-not-compile": "The point of this exercise is for students to figure out the appropriate function signatures and generic bounds for their implementations, so we cannot provide those."
   }
 }

--- a/rust-tooling/ci-tests/tests/count_ignores.rs
+++ b/rust-tooling/ci-tests/tests/count_ignores.rs
@@ -1,34 +1,17 @@
-use models::exercise_config::{
-    get_all_concept_exercise_paths, get_all_practice_exercise_paths, PracticeExercise,
-};
-
-fn assert_one_less_ignore_than_tests(path: &str) {
-    let slug = path.split('/').last().unwrap();
-    let test_path = format!("{path}/tests/{slug}.rs");
-    let test_contents = std::fs::read_to_string(test_path).unwrap();
-    let num_tests = test_contents.matches("#[test]").count();
-    let num_ignores = test_contents.matches("#[ignore]").count();
-    assert_eq!(
-        num_tests,
-        num_ignores + 1,
-        "should have one more test than ignore in {slug}"
-    )
-}
+use models::exercise_config::get_all_exercise_paths;
 
 #[test]
 fn count_ignores() {
-    for path in get_all_concept_exercise_paths() {
-        assert_one_less_ignore_than_tests(&path);
-    }
-    for path in get_all_practice_exercise_paths() {
-        let config_path = format!("{path}/.meta/config.json");
-        let config_contents = std::fs::read_to_string(config_path).unwrap();
-        let config: PracticeExercise = serde_json::from_str(config_contents.as_str()).unwrap();
-        if let Some(custom) = config.custom {
-            if custom.ignore_count_ignores.unwrap_or_default() {
-                continue;
-            }
-        }
-        assert_one_less_ignore_than_tests(&path);
+    for path in get_all_exercise_paths() {
+        let slug = path.split('/').last().unwrap();
+        let test_path = format!("{path}/tests/{slug}.rs");
+        let test_contents = std::fs::read_to_string(test_path).unwrap();
+        let num_tests = test_contents.matches("#[test]").count();
+        let num_ignores = test_contents.matches("#[ignore]").count();
+        assert_eq!(
+            num_tests,
+            num_ignores + 1,
+            "should have one more test than ignore in {slug}"
+        )
     }
 }

--- a/rust-tooling/models/src/exercise_config.rs
+++ b/rust-tooling/models/src/exercise_config.rs
@@ -56,8 +56,6 @@ pub struct Custom {
     pub allowed_to_not_compile: Option<String>,
     #[serde(rename = "test-in-release-mode")]
     pub test_in_release_mode: Option<bool>,
-    #[serde(rename = "ignore-count-ignores")]
-    pub ignore_count_ignores: Option<bool>,
 }
 
 pub fn get_all_concept_exercise_paths() -> impl Iterator<Item = String> {


### PR DESCRIPTION
After having removed all macro-based testing, this is no longer needed.