### PR TITLE
gigasecond: sync

### DIFF
--- a/exercises/practice/gigasecond/.meta/test_template.tera
+++ b/exercises/practice/gigasecond/.meta/test_template.tera
@@ -1,0 +1,53 @@
+{% for test in cases %}
+
+{#
+    Parsing datetime strings in a templating language
+    really makes you question your life choices.
+#}
+{% set date_and_time = test.input.moment | split(pat="T") %}
+{% set date = date_and_time.0 | split(pat="-") %}
+{% set year  = date.0 | int %}
+{% set month = date.1 | int %}
+{% set day   = date.2 | int %}
+{% if date_and_time | length >= 2 %}
+    {% set time = date_and_time.1 | split(pat=":") %}
+    {% set hour   = time.0 | int %}
+    {% set minute = time.1 | int %}
+    {% set second = time.2 | int %}
+{% else %}
+    {% set hour   = 0 %}
+    {% set minute = 0 %}
+    {% set second = 0 %}
+{% endif %}
+
+{#
+    again for the expected datetime
+#}
+{% set date_and_time = test.expected | split(pat="T") %}
+{% set date = date_and_time.0 | split(pat="-") %}
+{% set e_year  = date.0 | int %}
+{% set e_month = date.1 | int %}
+{% set e_day   = date.2 | int %}
+{% set time = date_and_time.1 | split(pat=":") %}
+{% set e_hour   = time.0 | int %}
+{% set e_minute = time.1 | int %}
+{% set e_second = time.2 | int %}
+
+#[test]
+#[ignore]
+fn {{ test.description | make_ident }}() {
+    let start = datetime({{ year }},{{ month }},{{ day }},{{ hour }},{{ minute }},{{ second }});
+    let actual = gigasecond::after(start);
+    let expected = datetime({{ e_year }},{{ e_month }},{{ e_day }},{{ e_hour }},{{ e_minute }},{{ e_second }});
+    assert_eq!(actual, expected);
+}
+{% endfor %}
+
+fn datetime(year: i32, month: u8, day: u8, hour: u8, minute: u8, second: u8) -> time::PrimitiveDateTime {
+    use time::{Date, PrimitiveDateTime, Time};
+
+    PrimitiveDateTime::new(
+        Date::from_calendar_date(year, month.try_into().unwrap(), day).unwrap(),
+        Time::from_hms(hour, minute, second).unwrap(),
+    )
+}

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -1,3 +1,30 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[92fbe71c-ea52-4fac-bd77-be38023cacf7]
+description = "date only specification of time"
+
+[6d86dd16-6f7a-47be-9e58-bb9fb2ae1433]
+description = "second test for date only specification of time"
+
+[77eb8502-2bca-4d92-89d9-7b39ace28dd5]
+description = "third test for date only specification of time"
+
+[c9d89a7d-06f8-4e28-a305-64f1b2abc693]
+description = "full time specified"
+
+[09d4e30e-728a-4b52-9005-be44a58d9eba]
+description = "full time with day roll-over"
+
+[fcec307c-7529-49ab-b0fe-20309197618a]
+description = "does not mutate the input"
+include = false
+comments = "Rust has immutability by default"

--- a/exercises/practice/gigasecond/tests/gigasecond.rs
+++ b/exercises/practice/gigasecond/tests/gigasecond.rs
@@ -1,52 +1,59 @@
-use time::PrimitiveDateTime as DateTime;
+#[test]
+fn date_only_specification_of_time() {
+    let start = datetime(2011, 4, 25, 0, 0, 0);
+    let actual = gigasecond::after(start);
+    let expected = datetime(2043, 1, 1, 1, 46, 40);
+    assert_eq!(actual, expected);
+}
 
-/// Create a datetime from the given numeric point in time.
-///
-/// Panics if any field is invalid.
-fn dt(year: i32, month: u8, day: u8, hour: u8, minute: u8, second: u8) -> DateTime {
-    use time::{Date, Time};
+#[test]
+#[ignore]
+fn second_test_for_date_only_specification_of_time() {
+    let start = datetime(1977, 6, 13, 0, 0, 0);
+    let actual = gigasecond::after(start);
+    let expected = datetime(2009, 2, 19, 1, 46, 40);
+    assert_eq!(actual, expected);
+}
 
-    DateTime::new(
+#[test]
+#[ignore]
+fn third_test_for_date_only_specification_of_time() {
+    let start = datetime(1959, 7, 19, 0, 0, 0);
+    let actual = gigasecond::after(start);
+    let expected = datetime(1991, 3, 27, 1, 46, 40);
+    assert_eq!(actual, expected);
+}
+
+#[test]
+#[ignore]
+fn full_time_specified() {
+    let start = datetime(2015, 1, 24, 22, 0, 0);
+    let actual = gigasecond::after(start);
+    let expected = datetime(2046, 10, 2, 23, 46, 40);
+    assert_eq!(actual, expected);
+}
+
+#[test]
+#[ignore]
+fn full_time_with_day_roll_over() {
+    let start = datetime(2015, 1, 24, 23, 59, 59);
+    let actual = gigasecond::after(start);
+    let expected = datetime(2046, 10, 3, 1, 46, 39);
+    assert_eq!(actual, expected);
+}
+
+fn datetime(
+    year: i32,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+) -> time::PrimitiveDateTime {
+    use time::{Date, PrimitiveDateTime, Time};
+
+    PrimitiveDateTime::new(
         Date::from_calendar_date(year, month.try_into().unwrap(), day).unwrap(),
         Time::from_hms(hour, minute, second).unwrap(),
     )
-}
-
-#[test]
-fn date() {
-    let start_date = dt(2011, 4, 25, 0, 0, 0);
-
-    assert_eq!(gigasecond::after(start_date), dt(2043, 1, 1, 1, 46, 40));
-}
-
-#[test]
-#[ignore]
-fn another_date() {
-    let start_date = dt(1977, 6, 13, 0, 0, 0);
-
-    assert_eq!(gigasecond::after(start_date), dt(2009, 2, 19, 1, 46, 40));
-}
-
-#[test]
-#[ignore]
-fn third_date() {
-    let start_date = dt(1959, 7, 19, 0, 0, 0);
-
-    assert_eq!(gigasecond::after(start_date), dt(1991, 3, 27, 1, 46, 40));
-}
-
-#[test]
-#[ignore]
-fn datetime() {
-    let start_date = dt(2015, 1, 24, 22, 0, 0);
-
-    assert_eq!(gigasecond::after(start_date), dt(2046, 10, 2, 23, 46, 40));
-}
-
-#[test]
-#[ignore]
-fn another_datetime() {
-    let start_date = dt(2015, 1, 24, 23, 59, 59);
-
-    assert_eq!(gigasecond::after(start_date), dt(2046, 10, 3, 1, 46, 39));
 }


### PR DESCRIPTION
[no important files changed]

part of https://github.com/exercism/rust/issues/1824

The small util function for constructing a `DateTime` value was left as is because it's only noise and not necessary to understand what's going on in the test case.