### PR TITLE
Remove empty dependency tables

### DIFF
--- a/exercises/concept/semi-structured-logs/Cargo.toml
+++ b/exercises/concept/semi-structured-logs/Cargo.toml
@@ -5,5 +5,3 @@ edition = "2021"
 
 [features]
 add-a-variant = []
-
-[dependencies]

--- a/exercises/practice/accumulate/Cargo.toml
+++ b/exercises/practice/accumulate/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "accumulate"
 version = "0.0.0"
-
-[dependencies]

--- a/exercises/practice/acronym/Cargo.toml
+++ b/exercises/practice/acronym/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "acronym"
 version = "1.7.0"
-
-[dependencies]

--- a/exercises/practice/binary-search/Cargo.toml
+++ b/exercises/practice/binary-search/Cargo.toml
@@ -3,8 +3,6 @@ edition = "2021"
 name = "binary-search"
 version = "1.3.0"
 
-[dependencies]
-
 [features]
 generic = []
 

--- a/exercises/practice/book-store/.meta/Cargo-example.toml
+++ b/exercises/practice/book-store/.meta/Cargo-example.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "book_store"
 version = "1.3.0"
-
-[dependencies]

--- a/exercises/practice/book-store/Cargo.toml
+++ b/exercises/practice/book-store/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "book_store"
 version = "1.3.0"
-
-[dependencies]

--- a/exercises/practice/clock/Cargo.toml
+++ b/exercises/practice/clock/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "clock"
 version = "2.4.0"
-
-[dependencies]

--- a/exercises/practice/crypto-square/Cargo.toml
+++ b/exercises/practice/crypto-square/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "crypto-square"
 version = "0.1.0"
-
-[dependencies]

--- a/exercises/practice/decimal/Cargo.toml
+++ b/exercises/practice/decimal/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "decimal"
 version = "0.1.0"
-
-[dependencies]

--- a/exercises/practice/diamond/Cargo.toml
+++ b/exercises/practice/diamond/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "diamond"
 version = "1.1.0"
-
-[dependencies]

--- a/exercises/practice/diffie-hellman/Cargo.toml
+++ b/exercises/practice/diffie-hellman/Cargo.toml
@@ -3,7 +3,5 @@ edition = "2021"
 name = "diffie-hellman"
 version = "0.1.0"
 
-[dependencies]
-
 [features]
 big-primes = []

--- a/exercises/practice/eliuds-eggs/Cargo.toml
+++ b/exercises/practice/eliuds-eggs/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "eliuds_eggs"
 version = "1.0.0"
-
-[dependencies]

--- a/exercises/practice/high-scores/Cargo.toml
+++ b/exercises/practice/high-scores/Cargo.toml
@@ -1,5 +1,3 @@
-[dependencies]
-
 [package]
 edition = "2021"
 name = "high-scores"

--- a/exercises/practice/kindergarten-garden/Cargo.toml
+++ b/exercises/practice/kindergarten-garden/Cargo.toml
@@ -2,7 +2,3 @@
 name = "kindergarten_garden"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/exercises/practice/knapsack/Cargo.toml
+++ b/exercises/practice/knapsack/Cargo.toml
@@ -2,7 +2,3 @@
 name = "knapsack"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/exercises/practice/macros/Cargo.toml
+++ b/exercises/practice/macros/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "macros"
 version = "0.1.0"
-
-[dependencies]

--- a/exercises/practice/matrix/Cargo.toml
+++ b/exercises/practice/matrix/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "matrix"
 version = "1.0.0"
-
-[dependencies]

--- a/exercises/practice/nth-prime/Cargo.toml
+++ b/exercises/practice/nth-prime/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "nth_prime"
 version = "2.1.0"
-
-[dependencies]

--- a/exercises/practice/palindrome-products/Cargo.toml
+++ b/exercises/practice/palindrome-products/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "palindrome-products"
 version = "1.2.0"
-
-[dependencies]

--- a/exercises/practice/perfect-numbers/Cargo.toml
+++ b/exercises/practice/perfect-numbers/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "perfect_numbers"
 version = "1.1.0"
-
-[dependencies]

--- a/exercises/practice/pig-latin/Cargo.toml
+++ b/exercises/practice/pig-latin/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "pig-latin"
 version = "1.0.0"
-
-[dependencies]

--- a/exercises/practice/poker/Cargo.toml
+++ b/exercises/practice/poker/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "poker"
 version = "1.1.0"
-
-[dependencies]

--- a/exercises/practice/prime-factors/Cargo.toml
+++ b/exercises/practice/prime-factors/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "prime_factors"
 version = "1.1.0"
-
-[dependencies]

--- a/exercises/practice/proverb/Cargo.toml
+++ b/exercises/practice/proverb/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "proverb"
 version = "1.1.0"
-
-[dependencies]

--- a/exercises/practice/pythagorean-triplet/Cargo.toml
+++ b/exercises/practice/pythagorean-triplet/Cargo.toml
@@ -1,5 +1,3 @@
-[dependencies]
-
 [package]
 edition = "2021"
 name = "pythagorean_triplet"

--- a/exercises/practice/reverse-string/Cargo.toml
+++ b/exercises/practice/reverse-string/Cargo.toml
@@ -1,9 +1,7 @@
-[dependencies]
-
-[features]
-grapheme = []
-
 [package]
 edition = "2021"
 name = "reverse_string"
 version = "1.2.0"
+
+[features]
+grapheme = []

--- a/exercises/practice/run-length-encoding/Cargo.toml
+++ b/exercises/practice/run-length-encoding/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "run-length-encoding"
 version = "1.1.0"
-
-[dependencies]

--- a/exercises/practice/saddle-points/Cargo.toml
+++ b/exercises/practice/saddle-points/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "saddle-points"
 version = "1.3.0"
-
-[dependencies]

--- a/exercises/practice/scale-generator/Cargo.toml
+++ b/exercises/practice/scale-generator/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "scale_generator"
 version = "2.0.0"
-
-[dependencies]

--- a/exercises/practice/series/Cargo.toml
+++ b/exercises/practice/series/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "series"
 version = "0.1.0"
-
-[dependencies]

--- a/exercises/practice/two-fer/Cargo.toml
+++ b/exercises/practice/two-fer/Cargo.toml
@@ -2,5 +2,3 @@
 edition = "2021"
 name = "twofer"
 version = "1.2.0"
-
-[dependencies]

--- a/exercises/practice/xorcism/Cargo.toml
+++ b/exercises/practice/xorcism/Cargo.toml
@@ -3,8 +3,5 @@ name = "xorcism"
 version = "0.1.0"
 edition = "2021"
 
-
-[dependencies]
-
 [features]
 io = []

--- a/exercises/practice/yacht/Cargo.toml
+++ b/exercises/practice/yacht/Cargo.toml
@@ -2,7 +2,3 @@
 name = "yacht"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/rust-tooling/generate/src/lib.rs
+++ b/rust-tooling/generate/src/lib.rs
@@ -48,8 +48,6 @@ fn generate_manifest(crate_name: &str) -> String {
             "edition = \"2021\"\n",
             "name = \"{crate_name}\"\n",
             "version = \"1.0.0\"\n",
-            "\n",
-            "[dependencies]\n",
         ),
         crate_name = crate_name
     )

--- a/rust-tooling/utils/Cargo.toml
+++ b/rust-tooling/utils/Cargo.toml
@@ -2,7 +2,3 @@
 name = "utils"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]


### PR DESCRIPTION
This is a preparation to make it easier to detect if an exercise doesn't use any dependencies. The Rust analyzer currently fails on such exercises, so we plan to disable it in those cases. Hopefully a better solution can be found later.