### PR TITLE
Remove lazy_static

### DIFF
--- a/exercises/practice/pig-latin/.meta/Cargo-example.toml
+++ b/exercises/practice/pig-latin/.meta/Cargo-example.toml
@@ -5,4 +5,3 @@ version = "1.0.0"
 
 [dependencies]
 regex = "0.2"
-lazy_static = "1.4.0"

--- a/exercises/practice/pig-latin/.meta/example.rs
+++ b/exercises/practice/pig-latin/.meta/example.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate lazy_static;
-extern crate regex;
+use std::sync::LazyLock;
 
 use regex::Regex;
 
@@ -9,12 +7,13 @@ use regex::Regex;
 pub fn translate_word(word: &str) -> String {
     // Prevent creation and compilation at every call.
     // These are compiled exactly once
-    lazy_static! {
-        // Detects if it starts with a vowel
-        static ref VOWEL: Regex = Regex::new(r"^([aeiou]|y[^aeiou]|xr)[a-z]*").unwrap();
-        // Detects splits for initial consonants
-        static ref CONSONANTS: Regex = Regex::new(r"^([^aeiou]?qu|[^aeiou][^aeiouy]*)([a-z]*)").unwrap();
-    }
+
+    // Detects if it starts with a vowel
+    static VOWEL: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^([aeiou]|y[^aeiou]|xr)[a-z]*").unwrap());
+    // Detects splits for initial consonants
+    static CONSONANTS: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^([^aeiou]?qu|[^aeiou][^aeiouy]*)([a-z]*)").unwrap());
 
     if VOWEL.is_match(word) {
         String::from(word) + "ay"

--- a/exercises/practice/robot-name/.meta/Cargo-example.toml
+++ b/exercises/practice/robot-name/.meta/Cargo-example.toml
@@ -4,5 +4,4 @@ name = "robot-name"
 version = "0.0.0"
 
 [dependencies]
-lazy_static = "1.4.0"
 rand = "0.3.12"

--- a/exercises/practice/robot-name/.meta/example.rs
+++ b/exercises/practice/robot-name/.meta/example.rs
@@ -1,11 +1,11 @@
-use lazy_static::lazy_static;
-use rand::{thread_rng, Rng};
-use std::collections::HashSet;
-use std::sync::Mutex;
+use std::{
+    collections::HashSet,
+    sync::{LazyLock, Mutex},
+};
 
-lazy_static! {
-    static ref NAMES: Mutex<HashSet<String>> = Mutex::new(HashSet::new());
-}
+use rand::{thread_rng, Rng};
+
+static NAMES: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 
 pub struct Robot {
     name: String,


### PR DESCRIPTION
This crate is not needed anymore since all its functionality has been merged into the standard library over time.