### PR TITLE
Sublist: use args in todo! instead of naming with _

### DIFF
--- a/exercises/practice/sublist/src/lib.rs
+++ b/exercises/practice/sublist/src/lib.rs
@@ -6,6 +6,6 @@ pub enum Comparison {
     Unequal,
 }
 
-pub fn sublist<T: PartialEq>(_first_list: &[T], _second_list: &[T]) -> Comparison {
-    todo!("Determine if the first list is equal to, sublist of, superlist of or unequal to the second list.");
+pub fn sublist(first_list: &[i32], second_list: &[i32]) -> Comparison {
+    todo!("Determine if the {first_list:?} is equal to, sublist of, superlist of or unequal to {second_list:?}.");
 }


### PR DESCRIPTION
This necessitated adding `std::fmt::Debug` as a constraint to `T`. All of the types in the tests are `i32` so this does not cause the tests to break.

Corresponding forum post: https://forum.exercism.org/t/warn-explain-or-remove-variables/15285