### PR TITLE
palindrome-products: require factors in solution

### DIFF
--- a/exercises/practice/palindrome-products/.meta/example.rs
+++ b/exercises/practice/palindrome-products/.meta/example.rs
@@ -23,8 +23,8 @@ impl Palindrome {
         self.value
     }
 
-    pub fn factors(&self) -> &HashSet<(u64, u64)> {
-        &self.factors
+    pub fn into_factors(self) -> HashSet<(u64, u64)> {
+        self.factors
     }
 }
 

--- a/exercises/practice/palindrome-products/.meta/test_template.tera
+++ b/exercises/practice/palindrome-products/.meta/test_template.tera
@@ -1,42 +1,26 @@
 use palindrome_products::*;
-
-{#
-    These first two custom test cases are for the object-oriented design of the exercise.
-    They don't fit the structure of the upstream tests, so they're implemented here.
-#}
-
-#[test]
-#[ignore]
-/// test `Palindrome::new` with valid input
-fn palindrome_new_return_some() {
-    for v in [1, 11, 121, 12321, 1234321, 123454321, 543212345] {
-        assert_eq!(Palindrome::new(v).expect("is a palindrome").into_inner(), v);
-    }
-}
-
-#[test]
-#[ignore]
-/// test `Palindrome::new` with invalid input
-fn palindrome_new_return_none() {
-    for v in [12, 2322, 23443, 1233211, 8932343] {
-        assert_eq!(Palindrome::new(v), None);
-    }
-}
+use std::collections::HashSet;
 
 {% for test in cases %}
 #[test]
 #[ignore]
 fn {{ test.description | make_ident }}() {
-    {%- if test.property == "smallest" %}
-        let output = palindrome_products({{ test.input.min }}, {{ test.input.max }}).map(|(min, _)| min.into_inner());
-    {%- else %}
-        let output = palindrome_products({{ test.input.min }}, {{ test.input.max }}).map(|(_, max)| max.into_inner());
-    {%- endif%}
+    let output = palindrome_products({{ test.input.min }}, {{ test.input.max }});
+
     {%- if test.expected.error is defined or not test.expected.value %}
-        let expected = None;
+        assert!(output.is_none());
     {%- else %}
-        let expected = Some({{ test.expected.value }});
+      assert!(output.is_some());
+
+      {% if test.property == "smallest" %}
+        let (pal, _) = output.unwrap();
+      {%- else %}
+        let (_, pal) = output.unwrap();
+      {%- endif%}
+      assert_eq!(pal.value(), {{ test.expected.value }});
+      assert_eq!(pal.factors(), &HashSet::from([
+        {{- test.expected.factors | join(sep=", ") | replace(from="[", to="(") | replace(from="]", to=")") -}}
+      ]));
     {%- endif%}
-    assert_eq!(output, expected);
 }
 {% endfor -%}

--- a/exercises/practice/palindrome-products/.meta/test_template.tera
+++ b/exercises/practice/palindrome-products/.meta/test_template.tera
@@ -18,7 +18,7 @@ fn {{ test.description | make_ident }}() {
         let (_, pal) = output.unwrap();
       {%- endif%}
       assert_eq!(pal.value(), {{ test.expected.value }});
-      assert_eq!(pal.factors(), &HashSet::from([
+      assert_eq!(pal.into_factors(), HashSet::from([
         {{- test.expected.factors | join(sep=", ") | replace(from="[", to="(") | replace(from="]", to=")") -}}
       ]));
     {%- endif%}

--- a/exercises/practice/palindrome-products/src/lib.rs
+++ b/exercises/practice/palindrome-products/src/lib.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Palindrome;
+pub struct Palindrome {
+    // TODO
+}
 
 impl Palindrome {
     pub fn value(&self) -> u64 {

--- a/exercises/practice/palindrome-products/src/lib.rs
+++ b/exercises/practice/palindrome-products/src/lib.rs
@@ -1,19 +1,15 @@
-/// `Palindrome` is a newtype which only exists when the contained value is a palindrome number in base ten.
-///
-/// A struct with a single field which is used to constrain behavior like this is called a "newtype", and its use is
-/// often referred to as the "newtype pattern". This is a fairly common pattern in Rust.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Palindrome(u64);
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Palindrome;
 
 impl Palindrome {
-    /// Create a `Palindrome` only if `value` is in fact a palindrome when represented in base ten. Otherwise, `None`.
-    pub fn new(value: u64) -> Option<Palindrome> {
-        todo!("if the value {value} is a palindrome return Some, otherwise return None");
+    pub fn value(&self) -> u64 {
+        todo!("return the value of the palindrome")
     }
 
-    /// Get the value of this palindrome.
-    pub fn into_inner(self) -> u64 {
-        todo!("return inner value of a Palindrome");
+    pub fn factors(&self) -> &HashSet<(u64, u64)> {
+        todo!("return the set of factors of the palindrome")
     }
 }
 

--- a/exercises/practice/palindrome-products/src/lib.rs
+++ b/exercises/practice/palindrome-products/src/lib.rs
@@ -8,7 +8,7 @@ impl Palindrome {
         todo!("return the value of the palindrome")
     }
 
-    pub fn factors(&self) -> &HashSet<(u64, u64)> {
+    pub fn into_factors(self) -> HashSet<(u64, u64)> {
         todo!("return the set of factors of the palindrome")
     }
 }

--- a/exercises/practice/palindrome-products/tests/palindrome-products.rs
+++ b/exercises/practice/palindrome-products/tests/palindrome-products.rs
@@ -1,122 +1,128 @@
 use palindrome_products::*;
+use std::collections::HashSet;
 
 #[test]
-/// test `Palindrome::new` with valid input
-fn palindrome_new_return_some() {
-    for v in [1, 11, 121, 12321, 1234321, 123454321, 543212345] {
-        assert_eq!(Palindrome::new(v).expect("is a palindrome").into_inner(), v);
-    }
-}
-
-#[test]
-#[ignore]
-/// test `Palindrome::new` with invalid input
-fn palindrome_new_return_none() {
-    for v in [12, 2322, 23443, 1233211, 8932343] {
-        assert_eq!(Palindrome::new(v), None);
-    }
-}
-
-#[test]
-#[ignore]
 fn find_the_smallest_palindrome_from_single_digit_factors() {
-    let output = palindrome_products(1, 9).map(|(min, _)| min.into_inner());
-    let expected = Some(1);
-    assert_eq!(output, expected);
+    let output = palindrome_products(1, 9);
+    assert!(output.is_some());
+
+    let (pal, _) = output.unwrap();
+    assert_eq!(pal.value(), 1);
+    assert_eq!(pal.factors(), &HashSet::from([(1, 1)]));
 }
 
 #[test]
 #[ignore]
 fn find_the_largest_palindrome_from_single_digit_factors() {
-    let output = palindrome_products(1, 9).map(|(_, max)| max.into_inner());
-    let expected = Some(9);
-    assert_eq!(output, expected);
+    let output = palindrome_products(1, 9);
+    assert!(output.is_some());
+
+    let (_, pal) = output.unwrap();
+    assert_eq!(pal.value(), 9);
+    assert_eq!(pal.factors(), &HashSet::from([(1, 9), (3, 3)]));
 }
 
 #[test]
 #[ignore]
 fn find_the_smallest_palindrome_from_double_digit_factors() {
-    let output = palindrome_products(10, 99).map(|(min, _)| min.into_inner());
-    let expected = Some(121);
-    assert_eq!(output, expected);
+    let output = palindrome_products(10, 99);
+    assert!(output.is_some());
+
+    let (pal, _) = output.unwrap();
+    assert_eq!(pal.value(), 121);
+    assert_eq!(pal.factors(), &HashSet::from([(11, 11)]));
 }
 
 #[test]
 #[ignore]
 fn find_the_largest_palindrome_from_double_digit_factors() {
-    let output = palindrome_products(10, 99).map(|(_, max)| max.into_inner());
-    let expected = Some(9009);
-    assert_eq!(output, expected);
+    let output = palindrome_products(10, 99);
+    assert!(output.is_some());
+
+    let (_, pal) = output.unwrap();
+    assert_eq!(pal.value(), 9009);
+    assert_eq!(pal.factors(), &HashSet::from([(91, 99)]));
 }
 
 #[test]
 #[ignore]
 fn find_the_smallest_palindrome_from_triple_digit_factors() {
-    let output = palindrome_products(100, 999).map(|(min, _)| min.into_inner());
-    let expected = Some(10201);
-    assert_eq!(output, expected);
+    let output = palindrome_products(100, 999);
+    assert!(output.is_some());
+
+    let (pal, _) = output.unwrap();
+    assert_eq!(pal.value(), 10201);
+    assert_eq!(pal.factors(), &HashSet::from([(101, 101)]));
 }
 
 #[test]
 #[ignore]
 fn find_the_largest_palindrome_from_triple_digit_factors() {
-    let output = palindrome_products(100, 999).map(|(_, max)| max.into_inner());
-    let expected = Some(906609);
-    assert_eq!(output, expected);
+    let output = palindrome_products(100, 999);
+    assert!(output.is_some());
+
+    let (_, pal) = output.unwrap();
+    assert_eq!(pal.value(), 906609);
+    assert_eq!(pal.factors(), &HashSet::from([(913, 993)]));
 }
 
 #[test]
 #[ignore]
 fn find_the_smallest_palindrome_from_four_digit_factors() {
-    let output = palindrome_products(1000, 9999).map(|(min, _)| min.into_inner());
-    let expected = Some(1002001);
-    assert_eq!(output, expected);
+    let output = palindrome_products(1000, 9999);
+    assert!(output.is_some());
+
+    let (pal, _) = output.unwrap();
+    assert_eq!(pal.value(), 1002001);
+    assert_eq!(pal.factors(), &HashSet::from([(1001, 1001)]));
 }
 
 #[test]
 #[ignore]
 fn find_the_largest_palindrome_from_four_digit_factors() {
-    let output = palindrome_products(1000, 9999).map(|(_, max)| max.into_inner());
-    let expected = Some(99000099);
-    assert_eq!(output, expected);
+    let output = palindrome_products(1000, 9999);
+    assert!(output.is_some());
+
+    let (_, pal) = output.unwrap();
+    assert_eq!(pal.value(), 99000099);
+    assert_eq!(pal.factors(), &HashSet::from([(9901, 9999)]));
 }
 
 #[test]
 #[ignore]
 fn empty_result_for_smallest_if_no_palindrome_in_the_range() {
-    let output = palindrome_products(1002, 1003).map(|(min, _)| min.into_inner());
-    let expected = None;
-    assert_eq!(output, expected);
+    let output = palindrome_products(1002, 1003);
+    assert!(output.is_none());
 }
 
 #[test]
 #[ignore]
 fn empty_result_for_largest_if_no_palindrome_in_the_range() {
-    let output = palindrome_products(15, 15).map(|(_, max)| max.into_inner());
-    let expected = None;
-    assert_eq!(output, expected);
+    let output = palindrome_products(15, 15);
+    assert!(output.is_none());
 }
 
 #[test]
 #[ignore]
 fn error_result_for_smallest_if_min_is_more_than_max() {
-    let output = palindrome_products(10000, 1).map(|(min, _)| min.into_inner());
-    let expected = None;
-    assert_eq!(output, expected);
+    let output = palindrome_products(10000, 1);
+    assert!(output.is_none());
 }
 
 #[test]
 #[ignore]
 fn error_result_for_largest_if_min_is_more_than_max() {
-    let output = palindrome_products(2, 1).map(|(_, max)| max.into_inner());
-    let expected = None;
-    assert_eq!(output, expected);
+    let output = palindrome_products(2, 1);
+    assert!(output.is_none());
 }
 
 #[test]
 #[ignore]
 fn smallest_product_does_not_use_the_smallest_factor() {
-    let output = palindrome_products(3215, 4000).map(|(min, _)| min.into_inner());
-    let expected = Some(10988901);
-    assert_eq!(output, expected);
+    let output = palindrome_products(3215, 4000);
+    assert!(output.is_some());
+
+    let (pal, _) = output.unwrap();
+    assert_eq!(pal.value(), 10988901);
+    assert_eq!(pal.factors(), &HashSet::from([(3297, 3333)]));
 }

--- a/exercises/practice/palindrome-products/tests/palindrome-products.rs
+++ b/exercises/practice/palindrome-products/tests/palindrome-products.rs
@@ -8,7 +8,7 @@ fn find_the_smallest_palindrome_from_single_digit_factors() {
 
     let (pal, _) = output.unwrap();
     assert_eq!(pal.value(), 1);
-    assert_eq!(pal.factors(), &HashSet::from([(1, 1)]));
+    assert_eq!(pal.into_factors(), HashSet::from([(1, 1)]));
 }
 
 #[test]
@@ -19,7 +19,7 @@ fn find_the_largest_palindrome_from_single_digit_factors() {
 
     let (_, pal) = output.unwrap();
     assert_eq!(pal.value(), 9);
-    assert_eq!(pal.factors(), &HashSet::from([(1, 9), (3, 3)]));
+    assert_eq!(pal.into_factors(), HashSet::from([(1, 9), (3, 3)]));
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn find_the_smallest_palindrome_from_double_digit_factors() {
 
     let (pal, _) = output.unwrap();
     assert_eq!(pal.value(), 121);
-    assert_eq!(pal.factors(), &HashSet::from([(11, 11)]));
+    assert_eq!(pal.into_factors(), HashSet::from([(11, 11)]));
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn find_the_largest_palindrome_from_double_digit_factors() {
 
     let (_, pal) = output.unwrap();
     assert_eq!(pal.value(), 9009);
-    assert_eq!(pal.factors(), &HashSet::from([(91, 99)]));
+    assert_eq!(pal.into_factors(), HashSet::from([(91, 99)]));
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn find_the_smallest_palindrome_from_triple_digit_factors() {
 
     let (pal, _) = output.unwrap();
     assert_eq!(pal.value(), 10201);
-    assert_eq!(pal.factors(), &HashSet::from([(101, 101)]));
+    assert_eq!(pal.into_factors(), HashSet::from([(101, 101)]));
 }
 
 #[test]
@@ -63,7 +63,7 @@ fn find_the_largest_palindrome_from_triple_digit_factors() {
 
     let (_, pal) = output.unwrap();
     assert_eq!(pal.value(), 906609);
-    assert_eq!(pal.factors(), &HashSet::from([(913, 993)]));
+    assert_eq!(pal.into_factors(), HashSet::from([(913, 993)]));
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn find_the_smallest_palindrome_from_four_digit_factors() {
 
     let (pal, _) = output.unwrap();
     assert_eq!(pal.value(), 1002001);
-    assert_eq!(pal.factors(), &HashSet::from([(1001, 1001)]));
+    assert_eq!(pal.into_factors(), HashSet::from([(1001, 1001)]));
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn find_the_largest_palindrome_from_four_digit_factors() {
 
     let (_, pal) = output.unwrap();
     assert_eq!(pal.value(), 99000099);
-    assert_eq!(pal.factors(), &HashSet::from([(9901, 9999)]));
+    assert_eq!(pal.into_factors(), HashSet::from([(9901, 9999)]));
 }
 
 #[test]
@@ -124,5 +124,5 @@ fn smallest_product_does_not_use_the_smallest_factor() {
 
     let (pal, _) = output.unwrap();
     assert_eq!(pal.value(), 10988901);
-    assert_eq!(pal.factors(), &HashSet::from([(3297, 3333)]));
+    assert_eq!(pal.into_factors(), HashSet::from([(3297, 3333)]));
 }


### PR DESCRIPTION
Apologies if I did something wrong, struggled a little bit with the rust-tooling.

Please let me know of any mistake, miss, or decisions you disagree with, no matter how small. **No hard feelings.** 

# The HashSet

Used a `HashSet<(u64, u64)>` for factors to avoid dealing with ordering of the factors and simultaneously communicate that the order doesn't matter. I thought leaving the inner tuple sorted made sense since that's how it appears in the instructions:

> [...] The largest palindrome product is 9. Its factors are (1, 9) and (3, 3).

A sorted `Vec` would probably be fine, and the change can be made easily enough if you think it would be more appropriate.

# The extra tests

There were two extra tests on the now-defunct `Palindrome::new` function. I felt those only made sense if this exercise still contained the newtype pattern. I can add them again if appropriate.

Corresponding forum post: https://forum.exercism.org/t/palindrome-products-description-mentions-factors/