### PR TITLE
Remove undefined offset variable from `tracks/rust/exercises/binary-search/dig_deeper`

### DIFF
--- a/exercises/practice/binary-search/.approaches/introduction.md
+++ b/exercises/practice/binary-search/.approaches/introduction.md
@@ -50,7 +50,7 @@ fn find<U: AsRef<[T]>, T: Ord>(array: U, key: T) -> Option<usize> {
     let mid = array.len() / 2;
 
     match array[mid].cmp(&key) {
-        Ordering::Equal => Some(offset + mid),
+        Ordering::Equal => Some(mid),
         Ordering::Greater => find(&array[..mid], key),
         Ordering::Less => find(&array[mid + 1..], key).map(|p| p + mid + 1),
     }


### PR DESCRIPTION
In the recursion section, `offset` is not defined. I updated it to match https://exercism.org/tracks/rust/exercises/binary-search/approaches/recursion.