### PR TITLE
Deleting unnecessary to_string() calls in the test file

### DIFF
--- a/exercises/practice/dot-dsl/tests/dot-dsl.rs
+++ b/exercises/practice/dot-dsl/tests/dot-dsl.rs
@@ -82,7 +82,7 @@ fn graph_with_one_edge_with_keywords() {
 fn graph_with_one_attribute() {
     let graph = Graph::new().with_attrs(&[("foo", "1")]);
 
-    let expected_attrs = HashMap::from([("foo".to_string(), "1".to_string())]);
+    let expected_attrs = HashMap::from([("foo", "1")]);
 
     assert!(graph.nodes.is_empty());
 
@@ -108,9 +108,9 @@ fn graph_with_attributes() {
     let attrs = vec![("foo", "1"), ("title", "Testing Attrs"), ("bar", "true")];
 
     let expected_attrs = HashMap::from([
-        ("foo".to_string(), "1".to_string()),
-        ("title".to_string(), "Testing Attrs".to_string()),
-        ("bar".to_string(), "true".to_string()),
+        ("foo", "1"),
+        ("title", "Testing Attrs"),
+        ("bar", "true"),
     ]);
 
     let graph = Graph::new()


### PR DESCRIPTION
This allow the implementation to use &str in place of String. Making both the implementations and the test code cleaner, and serve a good exercise to work out the lifetimes.

The change in the test file will affect existing passing solutions since they had to make attrs field of type HashMap<String, String>.