### PR TITLE
simple-cipher: Sync tests.toml

### DIFF
--- a/exercises/practice/simple-cipher/.meta/tests.toml
+++ b/exercises/practice/simple-cipher/.meta/tests.toml
@@ -1,3 +1,46 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[b8bdfbe1-bea3-41bb-a999-b41403f2b15d]
+description = "Random key cipher -> Can encode"
+
+[3dff7f36-75db-46b4-ab70-644b3f38b81c]
+description = "Random key cipher -> Can decode"
+
+[8143c684-6df6-46ba-bd1f-dea8fcb5d265]
+description = "Random key cipher -> Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method"
+
+[defc0050-e87d-4840-85e4-51a1ab9dd6aa]
+description = "Random key cipher -> Key is made only of lowercase letters"
+
+[565e5158-5b3b-41dd-b99d-33b9f413c39f]
+description = "Substitution cipher -> Can encode"
+
+[d44e4f6a-b8af-4e90-9d08-fd407e31e67b]
+description = "Substitution cipher -> Can decode"
+
+[70a16473-7339-43df-902d-93408c69e9d1]
+description = "Substitution cipher -> Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method"
+
+[69a1458b-92a6-433a-a02d-7beac3ea91f9]
+description = "Substitution cipher -> Can double shift encode"
+
+[21d207c1-98de-40aa-994f-86197ae230fb]
+description = "Substitution cipher -> Can wrap on encode"
+
+[a3d7a4d7-24a9-4de6-bdc4-a6614ced0cb3]
+description = "Substitution cipher -> Can wrap on decode"
+
+[e31c9b8c-8eb6-45c9-a4b5-8344a36b9641]
+description = "Substitution cipher -> Can encode messages longer than the key"
+
+[93cfaae0-17da-4627-9a04-d6d1e1be52e3]
+description = "Substitution cipher -> Can decode messages longer than the key"


### PR DESCRIPTION
Confirmed that all tests are defined, creating a Tera template is not really possible since canonical_data has some fields that are expressions rather than values. Besides many of the test cases have hilariously long descriptions which would not look good as function names.

Link to canonical_data.json for convenience: https://github.com/exercism/problem-specifications/blob/47b3bb2a1c88bf93d540916477a3b71ff94e9964/exercises/simple-cipher/canonical-data.json

[no important files changed]