### PR TITLE
accumulate: deprecate

### DIFF
--- a/config.json
+++ b/config.json
@@ -333,7 +333,8 @@
         "topics": [
           "case",
           "vectors"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "difference-of-squares",
@@ -495,7 +496,8 @@
         "difficulty": 1,
         "topics": [
           "math"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "series",
@@ -1079,7 +1081,8 @@
           "generics",
           "higher_order_functions",
           "move_semantics"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "affine-cipher",

--- a/config.json
+++ b/config.json
@@ -324,10 +324,7 @@
         "slug": "beer-song",
         "name": "Beer Song",
         "uuid": "bb42bc3a-139d-4cab-8b3a-2eac2e1b77b6",
-        "practices": [
-          "loops",
-          "strings"
-        ],
+        "practices": [],
         "prerequisites": [],
         "difficulty": 1,
         "topics": [

--- a/config.json
+++ b/config.json
@@ -324,14 +324,16 @@
         "slug": "beer-song",
         "name": "Beer Song",
         "uuid": "bb42bc3a-139d-4cab-8b3a-2eac2e1b77b6",
-        "practices": [],
+        "practices": [
+          "loops",
+          "strings"
+        ],
         "prerequisites": [],
         "difficulty": 1,
         "topics": [
           "case",
           "vectors"
-        ],
-        "status": "deprecated"
+        ]
       },
       {
         "slug": "difference-of-squares",
@@ -493,8 +495,7 @@
         "difficulty": 1,
         "topics": [
           "math"
-        ],
-        "status": "deprecated"
+        ]
       },
       {
         "slug": "series",


### PR DESCRIPTION
Should add
- list-ops which replaces accumulate
- bottle-song which replaces beer-song
- diffie-hellman is deprecated without a replacement

accumulate and bottle-song seem pretty clear-cut to me, however an argument could be made for keeping diffie-hellman since the discussion around its deprecation explicitly mentions that track maintainers may choose to keep it:
- [diffie-hellman PR](https://github.com/exercism/problem-specifications/pull/2149)
  - [elixir](https://github.com/exercism/elixir/pull/1356) deprecated it while [the JS track](https://github.com/exercism/problem-specifications/pull/2149) seem to be planning to continue supporting it
- [beer-song PR](https://github.com/exercism/problem-specifications/pull/2097)
- [accumulate PR](https://github.com/exercism/problem-specifications/pull/1918)

I only noticed this because I was planning to make a PR adding a missing test in diffie-hellman and changing its kind of ridiculous difficulty of `1`, so I thought I'd check if we want to keep it before doing that work.