### PR TITLE
Update test for anagram.rs

### DIFF
--- a/exercises/practice/anagram/tests/anagram.rs
+++ b/exercises/practice/anagram/tests/anagram.rs
@@ -173,7 +173,7 @@ fn handles_case_of_greek_letters() {
     let word = "ΑΒΓ";
     let inputs = &["ΒΓΑ", "ΒΓΔ", "γβα", "αβγ"];
     let output = anagrams_for(word, inputs);
-    let expected = HashSet::from_iter(["ΒΓΑ", "γβα"]);
+    let expected = HashSet::from_iter(["ΒΓΑ", "γβα", "αβγ"]);
     assert_eq!(output, expected);
 }
 


### PR DESCRIPTION
the "αβγ" should be in the right output of the test because it's the same a the precedent with a different order