### PR TITLE
Fix stub generation for new exercises

### DIFF
--- a/rust-tooling/generate/src/custom_filters.rs
+++ b/rust-tooling/generate/src/custom_filters.rs
@@ -8,6 +8,7 @@ pub static CUSTOM_FILTERS: &[(&str, Filter)] = &[
     ("to_hex", to_hex),
     ("make_ident", make_ident),
     ("fmt_num", fmt_num),
+    ("recursive_flat_map", recursive_flat_map),
 ];
 
 pub fn to_hex(value: &Value, _args: &HashMap<String, Value>) -> Result<Value> {
@@ -55,4 +56,44 @@ pub fn fmt_num(value: &Value, _args: &HashMap<String, Value>) -> Result<Value> {
     pretty_digits.reverse();
     let pretty_num = String::from_utf8(pretty_digits).unwrap_or_default();
     Ok(Value::String(pretty_num))
+}
+
+pub fn recursive_flat_map(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
+    let Some(attribute) = args.get("attribute") else {
+        return Err(tera::Error::msg(
+            "The `recursive_flat_map` filter has to have an `attribute` argument",
+        ));
+    };
+
+    let Some(attribute) = attribute.as_str() else {
+        return Err(tera::Error::call_filter(
+            "recursive_flat_map filter attribute argument expects a String",
+            "serde_json::value::Value::as_str",
+        ));
+    };
+
+    let Some(list) = value.as_array() else {
+        return Err(tera::Error::call_filter(
+            "recursive_flat_map filter expects an array",
+            "serde_json::value::Value::as_array",
+        ));
+    };
+
+    Ok(Value::Array(flattener(list, attribute)))
+}
+
+fn flattener(list: &Vec<Value>, attribute: &str) -> Vec<Value> {
+    list.into_iter()
+        .flat_map(|item| {
+            if let Some(sublist) = item
+                .as_object()
+                .and_then(|obj| obj.get(attribute))
+                .and_then(|subitem| subitem.as_array())
+            {
+                flattener(sublist, attribute).into_iter()
+            } else {
+                vec![item.clone()].into_iter()
+            }
+        })
+        .collect()
 }

--- a/rust-tooling/generate/templates/default_test_template.tera
+++ b/rust-tooling/generate/templates/default_test_template.tera
@@ -1,6 +1,7 @@
 use crate_name::*;
 
-{% for test in cases %}
+{%- for test in cases | recursive_flat_map(attribute="cases") %}
+
 #[test]
 #[ignore]
 fn {{ test.description | make_ident }}() {
@@ -9,4 +10,4 @@ fn {{ test.description | make_ident }}() {
     let expected = {{ test.expected | json_encode() }};
     assert_eq!(output, expected);
 }
-{% endfor -%}
+{%- endfor -%}


### PR DESCRIPTION
Previously, exercises where the canonical_data was grouped were causing Tera to crash, which meant that GeneratedExercises could not be generated. This prevented basically every file from being generated.

Reproduce the error:
`just add-exercise -s list-ops`

With canonical_data cases nested two levels deep :face_holding_back_tears: :
`just add-exercise -s bottle-song`