### PR TITLE
generate: don't crash on invalid templates

### DIFF
--- a/rust-tooling/generate/src/lib.rs
+++ b/rust-tooling/generate/src/lib.rs
@@ -75,7 +75,7 @@ static TEST_TEMPLATE: &str = include_str!("../templates/default_test_template.te
 static FALLBACK_TESTS: &str = "\
 #[test]
 fn invalid_template() {
-    panic!(\"The exercise generator failed to produce valid tests from the template.\");
+    panic!(\"The exercise generator failed to produce valid tests from the template. Fix `.meta/test_template.tera`. To write tests manually you MUST delete the template.\");
 }
 ";
 

--- a/rust-tooling/generate/src/main.rs
+++ b/rust-tooling/generate/src/main.rs
@@ -79,7 +79,7 @@ fn make_configlet_generate_what_it_can(slug: &str) -> Result<()> {
 }
 
 fn generate_exercise_files(slug: &str, is_update: bool) -> Result<()> {
-    let exercise = generate::new(slug).context("failed to generate exercise")?;
+    let exercise = generate::new(slug);
 
     let exercise_path = PathBuf::from("exercises/practice").join(slug);
 

--- a/rust-tooling/generate/tests/tera_templates_are_in_sync.rs
+++ b/rust-tooling/generate/tests/tera_templates_are_in_sync.rs
@@ -14,7 +14,7 @@ fn tera_templates_are_in_sync() {
         let exercise_dir = path.parent().unwrap().parent().unwrap();
         let slug = exercise_dir.file_name().unwrap().to_string_lossy();
 
-        let generated = generate::new(&slug).unwrap();
+        let generated = generate::new(&slug);
 
         let test_path = exercise_dir.join("tests").join(format!("{slug}.rs"));
         let on_disk = std::fs::read_to_string(test_path).unwrap();


### PR DESCRIPTION
This ensures that all other files are still written to disk as expected. There is no risk of an invalid template being merged, because the generated fallback tests will always fail in CI.