### PR TITLE
Fix operand order in leaked bytes check in step_4_leak_test_2.rs of doubly-linked-list exercise

### DIFF
--- a/exercises/practice/doubly-linked-list/tests/step_4_leak_test_2.rs
+++ b/exercises/practice/doubly-linked-list/tests/step_4_leak_test_2.rs
@@ -19,7 +19,7 @@ fn drop_no_leaks() {
     drop(list);
 
     let allocated_after = ALLOCATED.load(SeqCst);
-    let leaked_bytes = allocated_before - allocated_after;
+    let leaked_bytes = allocated_after - allocated_before;
     assert!(leaked_bytes == 0);
 }
 


### PR DESCRIPTION


Update step_4_leak_test_2.rs to fix the order of operands in the leaked bytes check. Previously, this would fail when expected, but by an underflow error from subtracting a larger unsigned number rather than the assertion for the value being zero.