### PR TITLE
run shellcheck in local test script

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ uuid:
 test:
     just configlet lint
     ./bin/lint_markdown.sh
-    # TODO shellcheck
+    shellcheck bin/*.sh
     ./bin/check_exercises.sh
     CLIPPY=true ./bin/check_exercises.sh
     cd rust-tooling && cargo test


### PR DESCRIPTION
`bin/` is the only directory where we have shell scripts. This will fail if shellcheck is not installed, but even the Ubuntu repos have it, so nobody should have trouble installing it.