### PR TITLE
macros: fix invalid file paths

### DIFF
--- a/exercises/practice/macros/tests/invalid/Cargo.toml
+++ b/exercises/practice/macros/tests/invalid/Cargo.toml
@@ -15,41 +15,41 @@ path = "../../"
 default-features = false
 
 [[bin]]
-name = "comma-sep-rs"
-path = "comma-sep.rs"
+name = "comma_sep"
+path = "comma_sep.rs"
 
 [[bin]]
-name = "double-commas-rs"
-path = "double-commas.rs"
+name = "double_commas"
+path = "double_commas.rs"
 
 [[bin]]
-name = "only-arrow-rs"
-path = "only-arrow.rs"
+name = "only_arrow"
+path = "only_arrow.rs"
 
 [[bin]]
-name = "only-comma-rs"
-path = "only-comma.rs"
+name = "only_comma"
+path = "only_comma.rs"
 
 [[bin]]
-name = "single-argument-rs"
-path = "single-argument.rs"
+name = "single_argument"
+path = "single_argument.rs"
 
 [[bin]]
-name = "triple-arguments-rs"
-path = "triple-arguments.rs"
+name = "triple_arguments"
+path = "triple_arguments.rs"
 
 [[bin]]
-name = "two-arrows-rs"
-path = "two-arrows.rs"
+name = "two_arrows"
+path = "two_arrows.rs"
 
 [[bin]]
-name = "leading-comma-rs"
-path = "leading-comma.rs"
+name = "leading_comma"
+path = "leading_comma.rs"
 
 [[bin]]
-name = "no-comma-rs"
-path = "no-comma.rs"
+name = "no_comma"
+path = "no_comma.rs"
 
 [[bin]]
-name = "missing-argument-rs"
-path = "missing-argument.rs"
+name = "missing_argument"
+path = "missing_argument.rs"

--- a/exercises/practice/macros/tests/macros.rs
+++ b/exercises/practice/macros/tests/macros.rs
@@ -117,61 +117,61 @@ fn type_override() {
 #[test]
 #[ignore]
 fn compile_fails_comma_sep() {
-    simple_trybuild::compile_fail("comma-sep.rs");
+    simple_trybuild::compile_fail("comma_sep.rs");
 }
 
 #[test]
 #[ignore]
 fn compile_fails_double_commas() {
-    simple_trybuild::compile_fail("double-commas.rs");
+    simple_trybuild::compile_fail("double_commas.rs");
 }
 
 #[test]
 #[ignore]
 fn compile_fails_only_comma() {
-    simple_trybuild::compile_fail("only-comma.rs");
+    simple_trybuild::compile_fail("only_comma.rs");
 }
 
 #[test]
 #[ignore]
 fn compile_fails_single_argument() {
-    simple_trybuild::compile_fail("single-argument.rs");
+    simple_trybuild::compile_fail("single_argument.rs");
 }
 
 #[test]
 #[ignore]
 fn compile_fails_triple_arguments() {
-    simple_trybuild::compile_fail("triple-arguments.rs");
+    simple_trybuild::compile_fail("triple_arguments.rs");
 }
 
 #[test]
 #[ignore]
 fn compile_fails_only_arrow() {
-    simple_trybuild::compile_fail("only-arrow.rs");
+    simple_trybuild::compile_fail("only_arrow.rs");
 }
 
 #[test]
 #[ignore]
 fn compile_fails_two_arrows() {
-    simple_trybuild::compile_fail("two-arrows.rs");
+    simple_trybuild::compile_fail("two_arrows.rs");
 }
 
 #[test]
 #[ignore]
 fn compile_fails_leading_comma() {
-    simple_trybuild::compile_fail("leading-comma.rs");
+    simple_trybuild::compile_fail("leading_comma.rs");
 }
 
 #[test]
 #[ignore]
 fn compile_fails_no_comma() {
-    simple_trybuild::compile_fail("no-comma.rs");
+    simple_trybuild::compile_fail("no_comma.rs");
 }
 
 #[test]
 #[ignore]
 fn compile_fails_missing_argument() {
-    simple_trybuild::compile_fail("missing-argument.rs");
+    simple_trybuild::compile_fail("missing_argument.rs");
 }
 
 mod simple_trybuild {
@@ -189,7 +189,7 @@ mod simple_trybuild {
             file_path.into_os_string()
         );
 
-        let test_name = file_name.replace('.', "-");
+        let test_name = file_name.strip_suffix(".rs").unwrap();
         let macros_dir = ["..", "..", "target", "tests", "macros"]
             .iter()
             .collect::<PathBuf>();


### PR DESCRIPTION
This regression was introduced in:
88c13fb21eacd6d4101b98f900e525fe1be3d1ca

[no important files changed]

Co-authored-by: yjhtry <860622588@qq.com>