### PR TITLE
doubly-linked-list: improve leak check

### DIFF
--- a/exercises/practice/doubly-linked-list/tests/step_4_leak_test_2.rs
+++ b/exercises/practice/doubly-linked-list/tests/step_4_leak_test_2.rs
@@ -19,8 +19,7 @@ fn drop_no_leaks() {
     drop(list);
 
     let allocated_after = ALLOCATED.load(SeqCst);
-    let leaked_bytes = allocated_before - allocated_after;
-    assert!(leaked_bytes == 0);
+    assert_eq!(allocated_before, allocated_after);
 }
 
 // Defines a wrapper around the global allocator that counts allocations


### PR DESCRIPTION
Previously the check may fail due to an underflow in the subtraction, rather than the assert.

Forum discussion:
https://forum.exercism.org/t/fix-operand-order-in-leaked-bytes-check-in-leak-test-doubly-linked-list-rust-exercise/15884