### PR TITLE
doubly-linked-list: check compilation in ci

### DIFF
--- a/exercises/practice/doubly-linked-list/.meta/config.json
+++ b/exercises/practice/doubly-linked-list/.meta/config.json
@@ -22,8 +22,5 @@
       ".meta/example.rs"
     ]
   },
-  "blurb": "Write a more advanced doubly linked list implementation with cursors and iteration.",
-  "custom": {
-    "allowed-to-not-compile": "Stub allowed to not compile because pre_implemented module cannot be resolved by rustfmt in exercism v3 track structure"
-  }
+  "blurb": "Write a more advanced doubly linked list implementation with cursors and iteration."
 }

--- a/exercises/practice/doubly-linked-list/Cargo.toml
+++ b/exercises/practice/doubly-linked-list/Cargo.toml
@@ -11,3 +11,7 @@ edition = "2024"
 [features]
 # check correct covariance and Send, Sync
 advanced = []
+
+[lints.clippy]
+drop_non_drop = "allow" # tests call drop before students have implemented it
+new_without_default = "allow"


### PR DESCRIPTION
The reason given for why this exercise was allowed to not compile
doesn't seem to apply anymore.