### PR TITLE
matching-brackets: Sync tests and add test template

### DIFF
--- a/exercises/practice/matching-brackets/.meta/test_template.tera
+++ b/exercises/practice/matching-brackets/.meta/test_template.tera
@@ -1,0 +1,12 @@
+use matching_brackets::brackets_are_balanced;
+
+{% for test in cases %}
+#[test]
+#[ignore]
+fn {{ test.description | make_ident }}() {
+    assert!(
+      {% if test.expected == false %}!{% endif %}
+      brackets_are_balanced("{{ test.input.value | replace(from="\", to="\\") }}")
+    );
+}
+{% endfor -%}

--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [81ec11da-38dd-442a-bcf9-3de7754609a5]
 description = "paired square brackets"
@@ -41,11 +48,20 @@ description = "unpaired and nested brackets"
 [a0205e34-c2ac-49e6-a88a-899508d7d68e]
 description = "paired and wrong nested brackets"
 
+[1d5c093f-fc84-41fb-8c2a-e052f9581602]
+description = "paired and wrong nested brackets but innermost are correct"
+
 [ef47c21b-bcfd-4998-844c-7ad5daad90a8]
 description = "paired and incomplete brackets"
 
 [a4675a40-a8be-4fc2-bc47-2a282ce6edbe]
 description = "too many closing brackets"
+
+[a345a753-d889-4b7e-99ae-34ac85910d1a]
+description = "early unexpected brackets"
+
+[21f81d61-1608-465a-b850-baa44c5def83]
+description = "early mismatched brackets"
 
 [99255f93-261b-4435-a352-02bdecc9bdf2]
 description = "math expression"

--- a/exercises/practice/matching-brackets/tests/matching_brackets.rs
+++ b/exercises/practice/matching-brackets/tests/matching_brackets.rs
@@ -79,6 +79,12 @@ fn paired_and_wrong_nested_brackets() {
 
 #[test]
 #[ignore]
+fn paired_and_wrong_nested_brackets_but_innermost_are_correct() {
+    assert!(!brackets_are_balanced("[({}])"));
+}
+
+#[test]
+#[ignore]
 fn paired_and_incomplete_brackets() {
     assert!(!brackets_are_balanced("{}["));
 }
@@ -91,7 +97,7 @@ fn too_many_closing_brackets() {
 
 #[test]
 #[ignore]
-fn early_incomplete_brackets() {
+fn early_unexpected_brackets() {
     assert!(!brackets_are_balanced(")()"));
 }
 
@@ -110,7 +116,7 @@ fn math_expression() {
 #[test]
 #[ignore]
 fn complex_latex_expression() {
-    let input = "\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ \\mathrm{e}^{x} &... x^2 \
-                 \\end{array}\\right)";
-    assert!(brackets_are_balanced(input));
+    assert!(brackets_are_balanced(
+        "\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ \\mathrm{e}^{x} &... x^2 \\end{array}\\right)"
+    ));
 }


### PR DESCRIPTION
Some shenanigans was going on where tests were missing in `tests.toml` but were actually implemented in the test file. With this everything is consistent.

Specifically
fn early_incomplete_brackets() {}
fn early_mismatched_brackets() {}