### PR TITLE
Update dependencie rand to 0.9 on simple-cipher

### DIFF
--- a/exercises/practice/simple-cipher/.meta/example.rs
+++ b/exercises/practice/simple-cipher/.meta/example.rs
@@ -1,10 +1,10 @@
 use rand::Rng;
 
 pub fn encode_random(s: &str) -> (String, String) {
-    let mut r = rand::thread_rng();
+    let mut r = rand::rng();
     let mut key = String::new();
     for _ in 0..100 {
-        key.push(char::from(b'a' + r.gen_range(0..26)));
+        key.push(char::from(b'a' + r.random_range(0..26)));
     }
     let encoded = encode(&key, s);
     (key, encoded.unwrap())

--- a/exercises/practice/simple-cipher/Cargo.toml
+++ b/exercises/practice/simple-cipher/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 # The full list of available libraries is here:
 # https://github.com/exercism/rust-test-runner/blob/main/local-registry/Cargo.toml
 [dependencies]
-rand = "0.8"
+rand = "0.9"


### PR DESCRIPTION
On [simple-cipher](https://exercism.org/tracks/rust/exercises/simple-cipher), we can update the `rand` version to the latest version because the new version has [several function name changes](https://github.com/rust-random/rand/blob/master/CHANGELOG.md#features) that, if you don't realize that you are looking at the wrong version of the doc, give meaningless errors like `expected function, found module 'rand::rng'` or `module 'rng' is private` (and it's even worse if you are looking at the [rust-rand-book](https://rust-random.github.io/book/quick-start.html), because it doesn't say the version anywhere). 

I saw that the rust-test-runner already [updated](https://github.com/exercism/rust-test-runner/commit/dff9e549a47efb99d14f98162a310d84e3102500#diff-4c3a26ef0093cb7ed4c5ed89ef6f170551d56aff3b8a879f992a07574b659dbaR84) the `rand` to 0.9 and I checked that it works by adding a solution with that version.