### PR TITLE
Fix Working with strings in Rust link

### DIFF
--- a/concepts/string-vs-str/links.json
+++ b/concepts/string-vs-str/links.json
@@ -4,7 +4,7 @@
         "description": "String types in RBE"
     },
     {
-        "url": "https://fasterthanli.me/blog/2020/working-with-strings-in-rust/",
+        "url": "https://fasterthanli.me/articles/working-with-strings-in-rust",
         "description": "fasterthanli.me's Working with strings in Rust"
     },
     {


### PR DESCRIPTION
Hey! 

Just fixed the link, the current one shows 404.