### PR TITLE
Fix appended instructions for Say exercise

### DIFF
--- a/exercises/practice/say/.docs/instructions.append.md
+++ b/exercises/practice/say/.docs/instructions.append.md
@@ -8,8 +8,6 @@ errors for out of range, we are using Rust's strong type system to limit
 input.  It is much easier to make a function deal with all valid inputs,
 rather than requiring the user of your module to handle errors.
 
-Adding 'and' into number text has not been implemented in test cases.
-
 ### Extension
 
 Add capability of converting up to the max value for u64: `18_446_744_073_709_551_615`.

--- a/exercises/practice/say/.docs/instructions.append.md
+++ b/exercises/practice/say/.docs/instructions.append.md
@@ -8,9 +8,6 @@ errors for out of range, we are using Rust's strong type system to limit
 input.  It is much easier to make a function deal with all valid inputs,
 rather than requiring the user of your module to handle errors.
 
-There is a -1 version of a test case, but it is commented out.
-If your function is implemented properly, the -1 test case should not compile.
-
 Adding 'and' into number text has not been implemented in test cases.
 
 ### Extension


### PR DESCRIPTION
The "Say" exercise contains the statement that is not true, at least no longer:

> There is a -1 version of a test case, but it is commented out. If your function is implemented properly, the -1 test case should not compile.

Remove this paragraph to avoid confusion.