### PR TITLE
Ensure problem-specifications is symlinked

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,8 +23,11 @@ test:
     cd rust-tooling && cargo test
     ./bin/format_exercises.sh ; git diff --exit-code
 
-add-exercise *args="":
+symlink-problem-specifications:
+    @ [ -L problem-specifications ] || ./bin/symlink_problem_specifications.sh
+
+add-exercise *args="": symlink-problem-specifications
     cd rust-tooling/generate; cargo run --quiet --release -- add {{ args }}
 
-update-exercise *args="":
+update-exercise *args="": symlink-problem-specifications
     cd rust-tooling/generate; cargo run --quiet --release -- update {{ args }}


### PR DESCRIPTION
This is especially relevant for the add-exercise workflow, which will suggest slugs of unimplemented exercises from problem-specifications only if the symlink exists. Otherwise no suggestions are made without any hint that something went wrong.