### PR TITLE
Improve test no_underscore_prefixed_idents

### DIFF
--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -34,6 +34,6 @@
   "source": "Conversation with James Edward Gray II",
   "source_url": "http://graysoftinc.com/",
   "custom": {
-    "allowed-to-not-compile": "Stub doesn't compile because there is no type specified for _function and _closure arguments. This exercise teaches students about the use of function pointers and closures, therefore specifying the type of arguments for them would reduce learning."
+    "allowed-to-not-compile": "Stub doesn't compile because there is no type specified for the `function` argument. This exercise teaches students about the use of function pointers and closures, therefore specifying the type of arguments for them would reduce learning."
   }
 }

--- a/exercises/practice/accumulate/src/lib.rs
+++ b/exercises/practice/accumulate/src/lib.rs
@@ -1,4 +1,4 @@
-/// What should the type of _function be?
-pub fn map(input: Vec<i32>, _function: ???) -> Vec<i32> {
+/// What should the type of function be?
+pub fn map(input: Vec<i32>, function: ???) -> Vec<i32> {
     todo!("Transform input vector {input:?} using passed function");
 }

--- a/exercises/practice/xorcism/src/lib.rs
+++ b/exercises/practice/xorcism/src/lib.rs
@@ -3,7 +3,7 @@
 pub struct Xorcism<'a> {
     // This field is just to suppress compiler complaints;
     // feel free to delete it at any point.
-    _phantom: std::marker::PhantomData<&'a u8>,
+    phantom: std::marker::PhantomData<&'a u8>,
 }
 
 impl<'a> Xorcism<'a> {

--- a/rust-tooling/ci-tests/tests/no_underscore_prefixed_idents.rs
+++ b/rust-tooling/ci-tests/tests/no_underscore_prefixed_idents.rs
@@ -21,7 +21,7 @@
 //!
 //! ```rust
 //! pub fn fn_to_implement(parameter: i32) -> i32 {
-//!    todo!("use {parameter} to solve the exercise")
+//!    todo!("use {parameter:?} to solve the exercise")
 //! }
 //! ```
 //!
@@ -34,7 +34,7 @@
 //!
 //! The second approach does have a disadvantage: it requires the parameter
 //! to be `Debug`. This is usually not a problem, most of our test inputs are
-//! indedd `Debug`, but it becomes a problem with generics. If a parameter is
+//! indeed `Debug`, but it becomes a problem with generics. If a parameter is
 //! generic, there must be a `Debug` bound on it. That would usually be
 //! fulfilled, but it could be confusing to the students why the bound exists.
 //! In that case, the first approach may be used as a fallback.
@@ -46,7 +46,6 @@ use glob::glob;
 use utils::fs::cd_into_repo_root;
 
 static EXCEPTIONS: &[&str] = &[
-    "accumulate",         // has generics (not the stub, but the solution)
     "list-ops",           // has generics
     "circular-buffer",    // has generics
     "custom-set",         // has generics
@@ -57,7 +56,6 @@ static EXCEPTIONS: &[&str] = &[
     "roman-numerals",     // std::fmt::Formatter is not Debug
     "simple-linked-list", // has generics
     "sublist",            // has generics
-    "xorcism",            // has PhantomData
 ];
 
 fn line_is_not_a_comment(line: &&str) -> bool {


### PR DESCRIPTION
* accumulate doesn't need to be in the exceptions list because it doesn't compile independent of the argument name and it is allowed to do so.

* xorcism doesn't need to be in the exceptions list because the compiler doesn't actually complain about the unused field if the name doesn't have a prefix. This only applies to fields of type `PhantomData`. I believe this must be a recent addition. It's nice, because the compiler can know that `PhantomData` is obviously never read.

* Fix some typos in the documentation of the test.