### PR TITLE
Point to the forum instead of GitHub for feedback and help.

### DIFF
--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -11,7 +11,6 @@ Generally you should submit all files in which you implemented your solution (`s
 
 ## Feedback, Issues, Pull Requests
 
-Head to [the forum](https://forum.exercism.org/c/112) to provide feedback about an exercise or if you want help to implement new exercise. Members of the rust track team are happy to help!
 
 The GitHub [track repository][github] is the home for all of the Rust exercises.
 

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -11,7 +11,9 @@ Generally you should submit all files in which you implemented your solution (`s
 
 ## Feedback, Issues, Pull Requests
 
-The GitHub [track repository][github] is the home for all of the Rust exercises. If you have feedback about an exercise, or want to help implement new exercises, head over there and create an issue. Members of the rust track team are happy to help!
+Head to [the forum](https://forum.exercism.org/c/112) to provide feedback about an exercise or if you want help to implement new exercise. Members of the rust track team are happy to help!
+
+The GitHub [track repository][github] is the home for all of the Rust exercises.
 
 If you want to know more about Exercism, take a look at the [contribution guide].
 

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -11,6 +11,8 @@ Generally you should submit all files in which you implemented your solution (`s
 
 ## Feedback, Issues, Pull Requests
 
+Head to [the forum](https://forum.exercism.org/c/programming/rust/) and create a post to provide feedback about an exercise or if you want to help implement new exercises.
+Members of the rust track team are happy to help!
 
 The GitHub [track repository][github] is the home for all of the Rust exercises.
 


### PR DESCRIPTION
When on an exercise (for example
[this one](https://exercism.org/tracks/rust/exercises/paasio/edit)) in the `Get help` tab, in the `Feedback, Issues, Pull Requests` paragraph, there's a link to GitHub `track repository` for `feedback about an exercise, or want to help implement new exercises`

However, when such an issue is opened it is automatically closed, redirecting to this forum ([example](https://github.com/exercism/rust/issues/2087)).