### PR TITLE
Update instructions to match tests and function signature.

### DIFF
--- a/exercises/practice/say/.docs/instructions.md
+++ b/exercises/practice/say/.docs/instructions.md
@@ -1,6 +1,7 @@
 # Instructions
 
-Given a positive integer from 0 to u64::MAX, spell out that number in English.
+Given a positive integer from 0 to u64::MAX (a bit more than 18 quintillion),
+spell out that number in English.
 
 ## Step 1
 

--- a/exercises/practice/say/.docs/instructions.md
+++ b/exercises/practice/say/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-Given a number from 0 to 999,999,999,999, spell out that number in English.
+Given a positive integer from 0 to u64::MAX, spell out that number in English.
 
 ## Step 1
 
@@ -16,7 +16,6 @@ Some good test cases for this program are:
 - 14
 - 50
 - 98
-- -1
 - 100
 
 ### Extension

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -32,7 +32,7 @@
       ".meta/example.rs"
     ]
   },
-  "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
+  "blurb": "Given a number from 0 to u64::MAX, spell out that number in English.",
   "source": "A variation on the JavaRanch CattleDrive, Assignment 4",
   "source_url": "https://web.archive.org/web/20240907035912/https://coderanch.com/wiki/718804"
 }


### PR DESCRIPTION
Tests are verifying that the function works with i64::MAX and u64::MAX so it needs to go beyond 999_999_999_999.

The function signature takes a u64 so saying to test with -1 doesn't make sense.

https://forum.exercism.org/t/say-instructions-are-inconsistent-with-test/18695