### PR TITLE
Do not hide test output in log file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,7 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           toolchain: stable
+          components: clippy
 
       - name: Setup compilation cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0

--- a/rust-tooling/ci-tests/tests/stubs_are_warning_free.rs
+++ b/rust-tooling/ci-tests/tests/stubs_are_warning_free.rs
@@ -73,12 +73,5 @@ fn stubs_are_warning_free() {
     if !log.is_empty() {
         std::fs::write("clippy.log", &log).expect("should write clippy.log");
     }
-    assert!(
-        log.is_empty(),
-        "
-    ╔═════════════════════════════════════════╗
-    ║ clippy found warnings, check clippy.log ║
-    ╚═════════════════════════════════════════╝
-    "
-    );
+    assert!(log.is_empty(), "{log}");
 }


### PR DESCRIPTION
Putting the clippy output in a log file is somewhat convenient for local use. But if there's a failure in CI that's difficult to reproduce locally, it only makes things harder to debug.

The actual problem must've been that clippy used to be installed in the GitHub Actions environment by default (but not anymore), so we didn't notice that it's not explicitly requested in our workflow.