### PR TITLE
Add test for Anagram exercise to cover equivalent code points

### DIFF
--- a/exercises/practice/anagram/tests/anagram.rs
+++ b/exercises/practice/anagram/tests/anagram.rs
@@ -186,3 +186,12 @@ fn different_characters_may_have_the_same_bytes() {
     let expected = HashSet::from_iter([]);
     assert_eq!(output, expected);
 }
+
+#[test]
+fn equivalent_code_points_on_different_letters() {
+    let word = "āae";
+    let inputs = &["aeā", "aāe", "ēaa"];
+    let output = anagrams_for(word, inputs);
+    let expected = HashSet::from_iter(["aeā", "aāe"]);
+    assert_eq!(output, expected);
+}


### PR DESCRIPTION
### Description

[Anagram problem](https://exercism.org/tracks/rust/exercises/anagram) states that

> The Rust track extends the possible letters to be any unicode character, not just ASCII alphabetic ones.

at the same time allowing naive solution to pass all the test cases

```rust
word.chars().flat_map(|c| c.to_lowercase()).collect();
```

This PR adds a test to specifically target [unicode macron](https://en.wikipedia.org/wiki/Macron_(diacritic)) symbol 
that belongs to the `ā` grapheme and should not consider this code point applied to different letters as anagrams.

