### PR TITLE
bottle-song: Use pretty_assertions

### DIFF
--- a/exercises/practice/bottle-song/Cargo.toml
+++ b/exercises/practice/bottle-song/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2024"
 # The full list of available libraries is here:
 # https://github.com/exercism/rust-test-runner/blob/main/local-registry/Cargo.toml
 [dependencies]
+
+[dev-dependencies]
+pretty_assertions = "*"

--- a/exercises/practice/bottle-song/tests/bottle_song.rs
+++ b/exercises/practice/bottle-song/tests/bottle_song.rs
@@ -1,4 +1,5 @@
 use bottle_song::*;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn first_generic_verse() {


### PR DESCRIPTION
The strings being compared in the tests are rather long. If they don't match, it can be difficult to spot what's wrong from the output of the regular assert_eq macro. Using pretty_assertions solves this problem.

[no important files changed]