### PR TITLE
flower-field: Avoid confusion in hint

### DIFF
--- a/exercises/practice/flower-field/.docs/instructions.append.md
+++ b/exercises/practice/flower-field/.docs/instructions.append.md
@@ -3,7 +3,7 @@
 ## Performance Hint
 
 All the inputs and outputs are in ASCII.
-Rust `String`s and `&str` are utf8, so while one might expect `"Hello".chars()` to be simple, it actually has to check each char to see if it's 1, 2, 3 or 4 `u8`s long.
+Rust `String`s and `&str` are utf8, so while one might expect `"Hello".chars()` to be simple, it actually has to check each character to see if it's 1, 2, 3 or 4 `u8`s long.
 If we know a `&str` is ASCII then we can call `.as_bytes()` and refer to the underlying data as a `&[u8]` (byte slice).
 Iterating over a slice of ASCII bytes is much quicker as there are no codepoints involved - every ASCII byte is one `u8` long.
 


### PR DESCRIPTION
Using "char" as an abbreviation in this context can lead to confusion. It could be interpreted as the Rust type "char". The size of that type is always 4 bytes. The sentence refers to a character as it is encoded in the UTF-8 string.

Motivated by this forum post:
https://forum.exercism.org/t/flower-field-explains-char-different-from-rust-docs/20304