### PR TITLE
doubly-linked-list: move clippy config to Cargo.toml

### DIFF
--- a/exercises/practice/doubly-linked-list/Cargo.toml
+++ b/exercises/practice/doubly-linked-list/Cargo.toml
@@ -15,3 +15,4 @@ advanced = []
 [lints.clippy]
 drop_non_drop = "allow" # tests call drop before students have implemented it
 new_without_default = "allow"
+should_implement_trait = "allow"

--- a/exercises/practice/doubly-linked-list/src/lib.rs
+++ b/exercises/practice/doubly-linked-list/src/lib.rs
@@ -53,7 +53,6 @@ impl<T> Cursor<'_, T> {
 
     /// Move one position forward (towards the back) and
     /// return a reference to the new position
-    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<&mut T> {
         todo!()
     }


### PR DESCRIPTION
This is just a little cleaner, reducing distractions for users.