### PR TITLE
grade-school: trigger test rerun

### DIFF
--- a/exercises/practice/grade-school/.meta/test_template.tera
+++ b/exercises/practice/grade-school/.meta/test_template.tera
@@ -35,12 +35,12 @@ fn {{ test.description | make_ident }}() {
         {% else -%}
             vec!{{ test.expected | json_encode() }}
         {% endif -%}
-    )
+    );
     {% elif test.property == "grades" -%}
     assert_eq!(
         s.grades(),
         vec!{{ test.expected | json_encode() }}
-    )
+    );
     {% endif -%}
 }
 {% endfor -%}

--- a/exercises/practice/grade-school/tests/grade_school.rs
+++ b/exercises/practice/grade-school/tests/grade_school.rs
@@ -3,7 +3,7 @@ use grade_school::*;
 #[test]
 fn grade_is_empty_if_no_students_in_the_roster() {
     let s = School::new();
-    assert_eq!(s.grade(1), Vec::<String>::new())
+    assert_eq!(s.grade(1), Vec::<String>::new());
 }
 
 #[test]
@@ -14,7 +14,7 @@ fn grade_is_empty_if_no_students_in_that_grade() {
     s.add(2, "Zoe");
     s.add(2, "Alex");
     s.add(3, "Jim");
-    assert_eq!(s.grade(1), Vec::<String>::new())
+    assert_eq!(s.grade(1), Vec::<String>::new());
 }
 
 #[test]
@@ -25,7 +25,7 @@ fn student_not_added_to_same_grade_more_than_once() {
     s.add(2, "James");
     s.add(2, "James");
     s.add(2, "Paul");
-    assert_eq!(s.grade(2), vec!["Blair", "James", "Paul"])
+    assert_eq!(s.grade(2), vec!["Blair", "James", "Paul"]);
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn student_not_added_to_multiple_grades() {
     s.add(2, "James");
     s.add(3, "James");
     s.add(3, "Paul");
-    assert_eq!(s.grade(2), vec!["Blair", "James"])
+    assert_eq!(s.grade(2), vec!["Blair", "James"]);
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn student_not_added_to_other_grade_for_multiple_grades() {
     s.add(2, "James");
     s.add(3, "James");
     s.add(3, "Paul");
-    assert_eq!(s.grade(3), vec!["Paul"])
+    assert_eq!(s.grade(3), vec!["Paul"]);
 }
 
 #[test]
@@ -57,14 +57,14 @@ fn students_are_sorted_by_name_in_a_grade() {
     s.add(5, "Franklin");
     s.add(5, "Bradley");
     s.add(1, "Jeff");
-    assert_eq!(s.grade(5), vec!["Bradley", "Franklin"])
+    assert_eq!(s.grade(5), vec!["Bradley", "Franklin"]);
 }
 
 #[test]
 #[ignore]
 fn grades_for_empty_school() {
     let s = School::new();
-    assert_eq!(s.grades(), vec![])
+    assert_eq!(s.grades(), vec![]);
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn grades_for_empty_school() {
 fn grades_for_one_student() {
     let mut s = School::new();
     s.add(2, "Aimee");
-    assert_eq!(s.grades(), vec![2])
+    assert_eq!(s.grades(), vec![2]);
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn grades_for_several_students_are_sorted() {
     s.add(2, "Aimee");
     s.add(7, "Logan");
     s.add(4, "Blair");
-    assert_eq!(s.grades(), vec![2, 4, 7])
+    assert_eq!(s.grades(), vec![2, 4, 7]);
 }
 
 #[test]
@@ -92,5 +92,5 @@ fn grades_when_several_students_have_the_same_grade() {
     s.add(2, "Aimee");
     s.add(2, "Logan");
     s.add(2, "Blair");
-    assert_eq!(s.grades(), vec![2])
+    assert_eq!(s.grades(), vec![2]);
 }


### PR DESCRIPTION
It was reported that several (top) community solutions for this exercise do not pass the latests tests. Changing the test file slightly (adding some semicolonts) should trigger a rerun and correctly mark the community solutions as failing the latest tests.

forum post:
https://forum.exercism.org/t/grade-school-challenge-not-up-to-date/26896/2