### PR TITLE
dominoes: make test code more idiomatic

### DIFF
--- a/exercises/practice/dominoes/.meta/test_template.tera
+++ b/exercises/practice/dominoes/.meta/test_template.tera
@@ -15,7 +15,7 @@ fn {{ test.description | make_ident }}() {
         assert!(dominoes::chain(input).is_none());
     {%- endif %}
 }
-{% endfor -%}
+{% endfor %}
 
 type Domino = (u8, u8);
 
@@ -53,9 +53,6 @@ fn assert_correct(input: &[Domino], output: Vec<Domino>) {
     }
 }
 
-fn normalize(d: Domino) -> Domino {
-    match d {
-        (m, n) if m > n => (n, m),
-        (m, n) => (m, n),
-    }
+fn normalize((a, b): Domino) -> Domino {
+    (a.min(b), a.max(b))
 }

--- a/exercises/practice/dominoes/tests/dominoes.rs
+++ b/exercises/practice/dominoes/tests/dominoes.rs
@@ -111,6 +111,7 @@ fn separate_three_domino_loops() {
     let input = &[(1, 2), (2, 3), (3, 1), (4, 5), (5, 6), (6, 4)];
     assert!(dominoes::chain(input).is_none());
 }
+
 type Domino = (u8, u8);
 
 fn assert_correct(input: &[Domino], output: Vec<Domino>) {
@@ -147,9 +148,6 @@ fn assert_correct(input: &[Domino], output: Vec<Domino>) {
     }
 }
 
-fn normalize(d: Domino) -> Domino {
-    match d {
-        (m, n) if m > n => (n, m),
-        (m, n) => (m, n),
-    }
+fn normalize((a, b): Domino) -> Domino {
+    (a.min(b), a.max(b))
 }


### PR DESCRIPTION
I've had a mentee copy the "normalize" function from the test code. I didn't notice at first and explained it's unidiomatic to use a match statement only for the guards, because it's just a weird way of writing an if-else-statement.

This version isn't an if-else-statement (which would've been fine too), but I find it the most readable. I have confirmed that the generated assemply is essentially the same, i.e. this doesn't generate _two_ comparison instructions.

[no important files changed]