### PR TITLE
verify_exercises_in_docker: avoid version mismatch

### DIFF
--- a/bin/verify_exercises_in_docker.sh
+++ b/bin/verify_exercises_in_docker.sh
@@ -63,6 +63,8 @@ verify_exercise() {
         trap 'rm -rf "$tmp_dir"' EXIT    # remove tempdir when subshell ends
         cp -r "${dir}/." "${tmp_dir}"
         cd "${tmp_dir}"
+        # avoid version mismatch between lockfile and test runner
+        rm Cargo.lock 2> /dev/null || true
 
         copy_example_or_examplar_to_solution
         run_tests "${slug}" || { cat "${PWD}/results.json"; exit 1; }


### PR DESCRIPTION
The versions are pinned in the test runner. Hopefully they are not too
outdated, but they can easily be a few patch versions behind. If the
solution directory contains a lock file, these requirements often won't
be satisfied in the test runner.
