### PR TITLE
verify_exercises_in_docker: fix handling of example Cargo files

### DIFF
--- a/bin/verify_exercises_in_docker.sh
+++ b/bin/verify_exercises_in_docker.sh
@@ -27,6 +27,9 @@ copy_example_or_examplar_to_solution() {
     | while read -r src_and_dst; do
         cp "$(jq -r '.src' <<< "${src_and_dst}")" "$(jq -r '.dst' <<< "${src_and_dst}")"
     done
+    if test -f Cargo-example.toml ; then
+        mv Cargo-example.toml Cargo.toml
+    fi
 }
 
 pull_docker_image() {

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -32,7 +32,8 @@
       "tests/alphametics.rs"
     ],
     "example": [
-      ".meta/example.rs"
+      ".meta/example.rs",
+      ".meta/Cargo-example.toml"
     ]
   },
   "blurb": "Given an alphametics puzzle, find the correct solution.",

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -23,7 +23,8 @@
       "tests/book_store.rs"
     ],
     "example": [
-      ".meta/example.rs"
+      ".meta/example.rs",
+      ".meta/Cargo-example.toml"
     ]
   },
   "blurb": "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases.",

--- a/exercises/practice/decimal/.meta/config.json
+++ b/exercises/practice/decimal/.meta/config.json
@@ -24,7 +24,8 @@
       "tests/decimal.rs"
     ],
     "example": [
-      ".meta/example.rs"
+      ".meta/example.rs",
+      ".meta/Cargo-example.toml"
     ]
   },
   "blurb": "Implement a Decimal type",

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -26,7 +26,8 @@
       "tests/diffie_hellman.rs"
     ],
     "example": [
-      ".meta/example.rs"
+      ".meta/example.rs",
+      ".meta/Cargo-example.toml"
     ]
   },
   "blurb": "Diffie-Hellman key exchange.",

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -23,7 +23,8 @@
       "tests/grep.rs"
     ],
     "example": [
-      ".meta/example.rs"
+      ".meta/example.rs",
+      ".meta/Cargo-example.toml"
     ]
   },
   "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -27,7 +27,8 @@
       "tests/pig_latin.rs"
     ],
     "example": [
-      ".meta/example.rs"
+      ".meta/example.rs",
+      ".meta/Cargo-example.toml"
     ]
   },
   "blurb": "Implement a program that translates from English to Pig Latin.",

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -27,7 +27,8 @@
       "tests/poker.rs"
     ],
     "example": [
-      ".meta/example.rs"
+      ".meta/example.rs",
+      ".meta/Cargo-example.toml"
     ]
   },
   "blurb": "Pick the best hand(s) from a list of poker hands.",


### PR DESCRIPTION
Solutions that used different dependencies than the ones specified in the template Cargo.toml would fail in the verify_exercises_in_docker script. To fix that, the file is included in the "filed.example" list, such that it is copied into the temporary solution directory, and moved to Cargo.toml.