### PR TITLE
diffie-helman: fix example solution

### DIFF
--- a/exercises/practice/diffie-hellman/.meta/Cargo-example.toml
+++ b/exercises/practice/diffie-hellman/.meta/Cargo-example.toml
@@ -7,7 +7,7 @@ edition = "2024"
 # The full list of available libraries is here:
 # https://github.com/exercism/rust-test-runner/blob/main/local-registry/Cargo.toml
 [dependencies]
-rand = "0.3.18"
+rand = "0.10.0"
 
 [features]
 big-primes = []

--- a/exercises/practice/diffie-hellman/.meta/example.rs
+++ b/exercises/practice/diffie-hellman/.meta/example.rs
@@ -1,7 +1,3 @@
-extern crate rand;
-
-use rand::distributions::{IndependentSample, Range};
-
 /// Right-to-left modular exponentiation implementation
 /// For more information see https://en.wikipedia.org/wiki/Modular_exponentiation
 fn modular_exponentiation(base: u64, exponent: u64, modulus: u64) -> u64 {
@@ -26,7 +22,7 @@ fn modular_exponentiation(base: u64, exponent: u64, modulus: u64) -> u64 {
 }
 
 pub fn private_key(p: u64) -> u64 {
-    Range::new(2, p).ind_sample(&mut rand::thread_rng())
+    rand::random::<u64>() % (p - 2) + 2
 }
 
 pub fn public_key(p: u64, g: u64, a: u64) -> u64 {


### PR DESCRIPTION
The test runner doesn't have such an old version of `rand` anymore, so I updated it.