### PR TITLE
pig-latin: fix example solution

### DIFF
--- a/exercises/practice/pig-latin/.meta/Cargo-example.toml
+++ b/exercises/practice/pig-latin/.meta/Cargo-example.toml
@@ -7,4 +7,4 @@ edition = "2024"
 # The full list of available libraries is here:
 # https://github.com/exercism/rust-test-runner/blob/main/local-registry/Cargo.toml
 [dependencies]
-regex = "0.2"
+regex-lite = "0.1"

--- a/exercises/practice/pig-latin/.meta/example.rs
+++ b/exercises/practice/pig-latin/.meta/example.rs
@@ -1,6 +1,6 @@
 use std::sync::LazyLock;
 
-use regex::Regex;
+use regex_lite::Regex;
 
 // Regular expressions from Python version of exercism
 


### PR DESCRIPTION
The test runner doesn't have the regex crate, because it is so slow to compile that most user-provided solution immediately time out just from including that dependency. regex-lite does the job just as well here.