### PR TITLE
verify_exercises_in_docker: allow using podman

### DIFF
--- a/bin/verify_exercises_in_docker.sh
+++ b/bin/verify_exercises_in_docker.sh
@@ -20,7 +20,20 @@ required_tool() {
         die "${1} is required but not installed. Please install it and make sure it's in your PATH."
 }
 
-required_tool docker
+# prefer podman over docker if it's installed
+if which podman &> /dev/null ; then
+    docker() {
+        podman "$@"
+    }
+    # for SELinux systems, permit container access to mounted directories
+    podman_mount_opt=",Z"
+    # use same user ID for container, avoids file ownership problems
+    podman_run_opt="--userns=keep-id"
+else
+    required_tool docker
+    podman_mount_opt=""
+    podman_run_opt=""
+fi
 
 copy_example_or_examplar_to_solution() {
     jq -c '[.files.solution, .files.exemplar // .files.example] | transpose | map(select(.[0] and .[1]) | {src: .[1], dst: .[0]}) | .[]' .meta/config.json \
@@ -45,9 +58,10 @@ run_tests() {
         -u "$(id -u):$(id -g)" \
         --rm \
         --network none \
-        --mount type=bind,src="${PWD}",dst=/solution \
-        --mount type=bind,src="${PWD}",dst=/output \
+        --mount type=bind,src="${PWD}",dst=/solution${podman_mount_opt} \
+        --mount type=bind,src="${PWD}",dst=/output${podman_mount_opt} \
         --mount type=tmpfs,dst=/tmp \
+        ${podman_run_opt} \
         "${image}" "${slug}" /solution /output
     jq -e '.status == "pass"' "${PWD}/results.json" >/dev/null 2>&1
 }
@@ -99,7 +113,7 @@ done
 shift "$((OPTIND - 1))"
 
 if [[ -z "${image}" ]]; then
-    image="exercism/rust-test-runner"
+    image="docker.io/exercism/rust-test-runner"
     pull_docker_image
 fi
 


### PR DESCRIPTION
Podman is a container runtime with several advantages over docker:

- It's fully open-source. Beyond the ethics, that comes with practical benefts. For example, more Linux distributions carry Podman in their official package repositories. The installation of Docker, on the other hand, can be a pain.

- It's designed to run in rootless mode. That means "sudo" is not required to run this test script. Actually, the test script doesn't use sudo, because it assumes that people add themselves to the docker group, allowing themselves to use the docker command without sudo. This is a privilege escalation vulnerability: An attacker who gains RCE with that user can easily upgrade to root privileges via docker. Exercism contributors should not be required to lower their system's security to contribute.

There are slight incompatibilities, which are addressed:

- The bind mounts require the "Z" option to permit the container access to these directories on systems using SELinux, like Fedora.

- Podman maps user IDs to a separate namespace per container. In order to keep the mounted directories owned and writable by the normal local user, this mapping is suppressed with the `--userns=keep-id` option.