### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Implementation
+## Unicode and lifetimes
 
 The Rust track extends the possible letters to be any unicode character, not just ASCII alphabetic ones.
 

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 The Rust track extends the possible letters to be any unicode character, not just ASCII alphabetic ones.
 
 You are going to have to adjust the function signature provided in the stub in order for the lifetimes to work out properly.

--- a/exercises/practice/forth/.docs/instructions.append.md
+++ b/exercises/practice/forth/.docs/instructions.append.md
@@ -1,7 +1,7 @@
 # Instructions append
 
-## Implementation
+## Efficient Allocation
 
-Note the additional test case in `tests/alloc-attack.rs`.
-It tests against algorithmically inefficient implementations.
-Because of that, it usually times out online instead of outright failing, leading to a less helpful error message.
+Note the additional test case in `tests/alloc-attack.rs`. It tests against
+algorithmically inefficient implementations. Because of that, it usually times
+out online instead of outright failing, leading to a less helpful error message.

--- a/exercises/practice/forth/.docs/instructions.append.md
+++ b/exercises/practice/forth/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
-Note the additional test case in `tests/alloc-attack.rs`. It tests against
-algorithmically inefficient implementations. Because of that, it usually times
-out online instead of outright failing, leading to a less helpful error message.
+## Implementation
+
+Note the additional test case in `tests/alloc-attack.rs`.
+It tests against algorithmically inefficient implementations.
+Because of that, it usually times out online instead of outright failing, leading to a less helpful error message.

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Implementation
+## The time crate
 
 If you're unsure what operations you can perform on `PrimitiveDateTime` take a look at the [time crate](https://docs.rs/time) which is listed as a dependency in the `Cargo.toml` file for this exercise.

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 If you're unsure what operations you can perform on `PrimitiveDateTime` take a look at the [time crate](https://docs.rs/time) which is listed as a dependency in the `Cargo.toml` file for this exercise.

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Implementation
+## Running tests
 
 In the Rust track, tests are run using the command `cargo test`.

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 In the Rust track, tests are run using the command `cargo test`.

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Implementation
+## Remainder operation
 
 You may use the [`arithmetic remainder` operator](https://doc.rust-lang.org/book/appendix-02-operators.html) to test for divisibility.

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 You may use the [`arithmetic remainder` operator](https://doc.rust-lang.org/book/appendix-02-operators.html) to test for divisibility.

--- a/exercises/practice/nth-prime/.docs/instructions.append.md
+++ b/exercises/practice/nth-prime/.docs/instructions.append.md
@@ -1,6 +1,5 @@
 # Instructions append
 
-## Implementation
+## Zero based indexing
 
-Remember that while people commonly count with 1-based indexing (i.e. "the 6th prime is 13"), many programming languages, including Rust, use 0-based indexing (i.e. `primes[5] == 13`).
-Use 0-based indexing for your implementation.
+Remember that while people commonly count with 1-based indexing (i.e. "the 6th prime is 13"), many programming languages, including Rust, use 0-based indexing (i.e. `primes[5] == 13`). Use 0-based indexing for your implementation.

--- a/exercises/practice/nth-prime/.docs/instructions.append.md
+++ b/exercises/practice/nth-prime/.docs/instructions.append.md
@@ -1,3 +1,6 @@
 # Instructions append
 
-Remember that while people commonly count with 1-based indexing (i.e. "the 6th prime is 13"), many programming languages, including Rust, use 0-based indexing (i.e. `primes[5] == 13`). Use 0-based indexing for your implementation.
+## Implementation
+
+Remember that while people commonly count with 1-based indexing (i.e. "the 6th prime is 13"), many programming languages, including Rust, use 0-based indexing (i.e. `primes[5] == 13`).
+Use 0-based indexing for your implementation.

--- a/exercises/practice/series/.docs/instructions.append.md
+++ b/exercises/practice/series/.docs/instructions.append.md
@@ -1,9 +1,12 @@
 # Instructions append
 
+## Implementation
+
 Different languages on Exercism have different expectations about what the result should be if the length of the substrings is zero.
 On the Rust track, we don't have a test for that case, so you are free to do what you feel is most appropriate.
 
 Consider the advantages and disadvantages of the following possibilities:
+
 - Crash the program with `panic!`.
 - Return a `Result::Err`. (not possible here, because the function signature is given)
 - Return an empty vector.

--- a/exercises/practice/series/.docs/instructions.append.md
+++ b/exercises/practice/series/.docs/instructions.append.md
@@ -1,12 +1,11 @@
 # Instructions append
 
-## Implementation
+## Handling edge cases
 
 Different languages on Exercism have different expectations about what the result should be if the length of the substrings is zero.
 On the Rust track, we don't have a test for that case, so you are free to do what you feel is most appropriate.
 
 Consider the advantages and disadvantages of the following possibilities:
-
 - Crash the program with `panic!`.
 - Return a `Result::Err`. (not possible here, because the function signature is given)
 - Return an empty vector.

--- a/exercises/practice/wordy/.docs/instructions.append.md
+++ b/exercises/practice/wordy/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 To get the bonus tests to run, execute the tests with:
 
 ```bash

--- a/exercises/practice/wordy/.docs/instructions.append.md
+++ b/exercises/practice/wordy/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Implementation
+## Bonus tests
 
 To get the bonus tests to run, execute the tests with:
 


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.