### PR TITLE
rna-transcription: add test to avoid cheesing

### DIFF
--- a/exercises/practice/rna-transcription/.meta/test_template.tera
+++ b/exercises/practice/rna-transcription/.meta/test_template.tera
@@ -1,4 +1,21 @@
 use rna_transcription::{Dna, Rna};
+
+{#-
+    We usually do not add additional tests directly in the template.
+    In this case however, the structure of the tests is different from the
+    regular ones. Accommodating that in the template would be complicated
+    and unnecessary. We also want to test this early, so that users don't
+    make it through basically all tests without doing anything.
+#}
+
+#[test]
+#[ignore]
+fn different_rna_are_different() {
+    let a = Rna::new("G").unwrap();
+    let b = Rna::new("UGCACCAGAAUU").unwrap();
+    assert_ne!(a, b);
+}
+
 {% for test in cases %}
 #[test]
 #[ignore]

--- a/exercises/practice/rna-transcription/tests/rna_transcription.rs
+++ b/exercises/practice/rna-transcription/tests/rna_transcription.rs
@@ -1,6 +1,14 @@
 use rna_transcription::{Dna, Rna};
 
 #[test]
+fn different_rna_are_different() {
+    let a = Rna::new("G").unwrap();
+    let b = Rna::new("UGCACCAGAAUU").unwrap();
+    assert_ne!(a, b);
+}
+
+#[test]
+#[ignore]
 fn empty_rna_sequence() {
     let input = "";
     let output = Dna::new(input).unwrap().into_rna();


### PR DESCRIPTION
In the normal tests for this exercise, we compare two RNA instances. If the user defines RNA as an empty struct, those instances will always compare equal. This is prevented with the new test to make sure different RNA don't compare equal.

I had to add the `lower` filter to keep the test identifiers stable. It seems the template and the generated tests have drifted a bit. I'll have to investigate and fix that in a separate patch.

Forum post:
https://forum.exercism.org/t/successful-null-solution-for-rna-transcription/63064