### PR TITLE
mise: add task to update all templated exercises

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -18,6 +18,16 @@ run = "cd rust-tooling/generate; cargo run --quiet --release -- add"
 depends = "symlink-problem-specifications"
 run = "cd rust-tooling/generate; cargo run --quiet --release -- update"
 
+[tasks.update-all-templated-exercise]
+depends = "symlink-problem-specifications"
+run = """
+for p in ./exercises/practice/*/.meta/test_template.tera ; do
+  slug="$(basename $(dirname $(dirname $p)))"
+  mise run update-exercise --slug $slug &
+done
+wait
+"""
+
 [tasks.configlet]
 depends = "fetch-configlet"
 quiet = true


### PR DESCRIPTION
This makes it easier to test changes of the exercise generator against
all exercises that already have a template. Avoiding unnecessary changes
to existing exercises keeps the history clean.
