### PR TITLE
fix acronym-handling of make_ident filter

### DIFF
--- a/rust-tooling/generate/src/custom_filters.rs
+++ b/rust-tooling/generate/src/custom_filters.rs
@@ -27,7 +27,7 @@ pub fn make_ident(value: &Value, _args: &HashMap<String, Value>) -> Result<Value
             "serde_json::value::Value::as_str",
         ));
     };
-    let value = camel_to_snake_case(value);
+    let value = split_camel_case_with_underscore(value);
     let value = slug::slugify(value).replace('-', "_");
     if !value.chars().next().unwrap_or_default().is_alphabetic() {
         // identifiers cannot start with digits etc.
@@ -36,18 +36,15 @@ pub fn make_ident(value: &Value, _args: &HashMap<String, Value>) -> Result<Value
     Ok(Value::String(value))
 }
 
-fn camel_to_snake_case(input: &str) -> String {
+fn split_camel_case_with_underscore(input: &str) -> String {
     let mut chars: Vec<_> = input.chars().collect();
-    let mut i = 0;
-    while i + 1 < chars.len() {
-        let (left, right) = (chars[i], chars[i + 1]);
-        if right.is_ascii_uppercase() {
-            chars[i + 1] = right.to_ascii_lowercase();
-            if left.is_ascii_alphabetic() {
-                chars.insert(i + 1, '_');
-            }
+    let mut i = chars.len() - 1;
+    while i > 0 {
+        let (left, right) = (chars[i - 1], chars[i]);
+        if left.is_ascii_lowercase() && right.is_ascii_uppercase() {
+            chars.insert(i, '_');
         }
-        i += 1;
+        i -= 1;
     }
     chars.into_iter().collect()
 }


### PR DESCRIPTION
When this function was added to the make_ident filter, it wasn't tested
with existing templated exercises. For ones with acronyms in the test
descriptions, those acronyms would be split by this function. (example:
RNA -> r_n_a). This fixes that. The function doesn't perform full
conversion to snake case anymore, which we don't need anyway, so it
is renamed to reflect that.
