### PR TITLE
tooling: fix serializing of custom metadata

### DIFF
--- a/rust-tooling/models/src/exercise_config.rs
+++ b/rust-tooling/models/src/exercise_config.rs
@@ -58,9 +58,15 @@ pub struct PracticeFiles {
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Custom {
-    #[serde(rename = "allowed-to-not-compile")]
+    #[serde(
+        rename = "allowed-to-not-compile",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub allowed_to_not_compile: Option<String>,
-    #[serde(rename = "test-in-release-mode")]
+    #[serde(
+        rename = "test-in-release-mode",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub test_in_release_mode: Option<bool>,
 }
 


### PR DESCRIPTION
The struct `Custom` contains two fields. If one of them is set, the
other will also be serialized with a `null` value, which we don't want.
The attribute `skip_serializing_if = "Option::is_none"` prevents that.
