### PR TITLE
bottle-song: bring tests and template in sync

### DIFF
--- a/exercises/practice/bottle-song/.meta/test_template.tera
+++ b/exercises/practice/bottle-song/.meta/test_template.tera
@@ -1,4 +1,5 @@
 use bottle_song::*;
+use pretty_assertions::assert_eq;
 
 {% for group in cases %}
 {% for subgroup in group.cases %}


### PR DESCRIPTION
The pretty_assertions import was mistakenly added to the test file
directly, instead of going through the template:
7978fdb604d9ea713de0a4105a8d56587ff56d16
