### PR TITLE
macros: attach doctests to separate items

### DIFF
--- a/exercises/practice/macros/src/compile_fail_tests.rs
+++ b/exercises/practice/macros/src/compile_fail_tests.rs
@@ -1,7 +1,5 @@
-/// To activate a doctest locally, remove ",ignore" from the code block.
-///
-/// # Comma separator
-///
+// To activate a doctest locally, remove ",ignore" from the code block.
+
 /// ```compile_fail,ignore
 /// use macros::hashmap;
 /// use std::collections::HashMap;
@@ -9,9 +7,8 @@
 /// // using only commas is invalid
 /// let _hm: HashMap<_, _> = hashmap!('a', 1);
 /// ```
-///
-/// # Double trailing commas
-///
+const _COMMA_SEPARATOR: () = ();
+
 /// ```compile_fail,ignore
 /// use macros::hashmap;
 /// use std::collections::HashMap;
@@ -19,9 +16,8 @@
 /// // a single trailing comma is okay, but two is not
 /// let _hm: HashMap<_, _> = hashmap!('a' => 2, ,);
 /// ```
-///
-/// # Only comma
-///
+const _DOUBLE_TRAILING_COMMAS: () = ();
+
 /// ```compile_fail,ignore
 /// use macros::hashmap;
 /// use std::collections::HashMap;
@@ -29,9 +25,8 @@
 /// // a single random comma is not valid
 /// let _hm: HashMap<(), ()> = hashmap!(,);
 /// ```
-///
-/// # Single argument
-///
+const _ONLY_COMMA: () = ();
+
 /// ```compile_fail,ignore
 /// use macros::hashmap;
 /// use std::collections::HashMap;
@@ -39,9 +34,8 @@
 /// // a single argument is invalid
 /// let _hm: HashMap<_, _> = hashmap!('a');
 /// ```
-///
-/// # Triple arguments
-///
+const _SINGLE_ARGUMENT: () = ();
+
 /// ```compile_fail,ignore
 /// use macros::hashmap;
 /// use std::collections::HashMap;
@@ -49,9 +43,8 @@
 /// // three arguments are invalid
 /// hashmap!('a' => 1, 'b');
 /// ```
-///
-/// # Only arrow
-///
+const _TRIPLE_ARGUMENTS: () = ();
+
 /// ```compile_fail,ignore
 /// use macros::hashmap;
 /// use std::collections::HashMap;
@@ -59,9 +52,8 @@
 /// // a single random arrow is not valid
 /// let _hm: HashMap<(), ()> = hashmap!(=>);
 /// ```
-///
-/// # Trailing arrow
-///
+const _ONLY_ARROW: () = ();
+
 /// ```compile_fail,ignore
 /// use macros::hashmap;
 /// use std::collections::HashMap;
@@ -69,9 +61,8 @@
 /// // a trailing => isn't valid either
 /// hashmap!('a' => 2, =>);
 /// ```
-///
-/// # Leading comma
-///
+const _TRAILING_ARROW: () = ();
+
 /// ```compile_fail,ignore
 /// use macros::hashmap;
 /// use std::collections::HashMap;
@@ -79,9 +70,8 @@
 /// // leading commas are not valid
 /// let _hm: HashMap<_, _> = hashmap!(, 'a' => 2);
 /// ```
-///
-/// # Missing comma
-///
+const _LEADING_COMMA: () = ();
+
 /// ```compile_fail,ignore
 /// use macros::hashmap;
 /// use std::collections::HashMap;
@@ -89,9 +79,8 @@
 /// // Key value pairs must be separated by commas
 /// let _hm: HashMap<_, _> = hashmap!('a' => 1 'b' => 2);
 /// ```
-///
-/// # Missing argument
-///
+const _MISSING_COMMA: () = ();
+
 /// ```compile_fail,ignore
 /// use macros::hashmap;
 /// use std::collections::HashMap;
@@ -99,5 +88,4 @@
 /// // an argument should come between each pair of commas
 /// let _hm: HashMap<_, _> = hashmap!('a' => 1, , 'b' => 2);
 /// ```
-///
-const _TESTS: () = ();
+const _MISSING_ARGUMENT: () = ();

--- a/exercises/practice/macros/src/lib.rs
+++ b/exercises/practice/macros/src/lib.rs
@@ -7,5 +7,5 @@ macro_rules! hashmap {
 
 /// This module contains doctests, which allows writing tests where a code
 /// snippet is supposed to fail to compile. These tests also have "ignore"
-/// attributes, makes sure to remove them when solving this exercise locally.
+/// attributes, make sure to remove them when solving this exercise locally.
 pub mod compile_fail_tests;


### PR DESCRIPTION
Cargo emits the item name in the test output for doctests. In the future, we can use this in the test runner to display a better name.

[no important files changed]