### PR TITLE
doubly-linked-list: name doctest items consistently

### DIFF
--- a/exercises/practice/doubly-linked-list/src/pre_implemented.rs
+++ b/exercises/practice/doubly-linked-list/src/pre_implemented.rs
@@ -65,7 +65,7 @@ impl<T> Cursor<'_, T> {
 /// trait AssertSend: Send {}
 /// impl<T> AssertSend for LinkedList<T> {}
 /// ```
-pub struct IllegalSend;
+const _ILLEGAL_SEND: () = ();
 
 #[allow(unused)]
 #[cfg(feature = "advanced")]
@@ -74,4 +74,4 @@ pub struct IllegalSend;
 /// trait AssertSync: Sync {}
 /// impl<T> AssertSync for LinkedList<T> {}
 /// ```
-pub struct IllegalSync;
+const _ILLEGAL_SYNC: () = ();


### PR DESCRIPTION
The test runner will soon be extended to better extract names and source code of doctests. Test name extraction is necessarily based on the name of the item a doctest is attached to. Making the naming of doctest items consistent therefore ensures good test name presentation.