### PR TITLE
hide import statements from doctests

### DIFF
--- a/exercises/practice/doubly-linked-list/src/pre_implemented.rs
+++ b/exercises/practice/doubly-linked-list/src/pre_implemented.rs
@@ -61,7 +61,7 @@ impl<T> Cursor<'_, T> {
 #[allow(unused)]
 #[cfg(feature = "advanced")]
 /// ```compile_fail
-/// use doubly_linked_list::LinkedList;
+/// # use doubly_linked_list::LinkedList;
 /// trait AssertSend: Send {}
 /// impl<T> AssertSend for LinkedList<T> {}
 /// ```
@@ -70,7 +70,7 @@ const _ILLEGAL_SEND: () = ();
 #[allow(unused)]
 #[cfg(feature = "advanced")]
 /// ```compile_fail
-/// use doubly_linked_list::LinkedList;
+/// # use doubly_linked_list::LinkedList;
 /// trait AssertSync: Sync {}
 /// impl<T> AssertSync for LinkedList<T> {}
 /// ```

--- a/exercises/practice/macros/src/compile_fail_tests.rs
+++ b/exercises/practice/macros/src/compile_fail_tests.rs
@@ -1,8 +1,8 @@
 // To activate a doctest locally, remove ",ignore" from the code block.
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // using only commas is invalid
 /// let _hm: HashMap<_, _> = hashmap!('a', 1);
@@ -10,8 +10,8 @@
 const _COMMA_SEPARATOR: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // a single trailing comma is okay, but two is not
 /// let _hm: HashMap<_, _> = hashmap!('a' => 2, ,);
@@ -19,8 +19,8 @@ const _COMMA_SEPARATOR: () = ();
 const _DOUBLE_TRAILING_COMMAS: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // a single random comma is not valid
 /// let _hm: HashMap<(), ()> = hashmap!(,);
@@ -28,8 +28,8 @@ const _DOUBLE_TRAILING_COMMAS: () = ();
 const _ONLY_COMMA: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // a single argument is invalid
 /// let _hm: HashMap<_, _> = hashmap!('a');
@@ -37,8 +37,8 @@ const _ONLY_COMMA: () = ();
 const _SINGLE_ARGUMENT: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // three arguments are invalid
 /// hashmap!('a' => 1, 'b');
@@ -46,8 +46,8 @@ const _SINGLE_ARGUMENT: () = ();
 const _TRIPLE_ARGUMENTS: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // a single random arrow is not valid
 /// let _hm: HashMap<(), ()> = hashmap!(=>);
@@ -55,8 +55,8 @@ const _TRIPLE_ARGUMENTS: () = ();
 const _ONLY_ARROW: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // a trailing => isn't valid either
 /// hashmap!('a' => 2, =>);
@@ -64,8 +64,8 @@ const _ONLY_ARROW: () = ();
 const _TRAILING_ARROW: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // leading commas are not valid
 /// let _hm: HashMap<_, _> = hashmap!(, 'a' => 2);
@@ -73,8 +73,8 @@ const _TRAILING_ARROW: () = ();
 const _LEADING_COMMA: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // Key value pairs must be separated by commas
 /// let _hm: HashMap<_, _> = hashmap!('a' => 1 'b' => 2);
@@ -82,8 +82,8 @@ const _LEADING_COMMA: () = ();
 const _MISSING_COMMA: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // an argument should come between each pair of commas
 /// let _hm: HashMap<_, _> = hashmap!('a' => 1, , 'b' => 2);


### PR DESCRIPTION
The test runner recently gained the ability to strip hidden lines from extracted test source code just like rustdoc does.[^1] Hiding import lines from doctests makes them easier to read when solving exercises in the web editor.

[no important files changed]

[^1]: https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#hiding-portions-of-the-example