### PR TITLE
decimal: replace try_from with FromStr impl

### DIFF
--- a/exercises/practice/decimal/.meta/example.rs
+++ b/exercises/practice/decimal/.meta/example.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::fmt;
 use std::ops::{Add, Mul, Sub};
+use std::str::FromStr;
 
 extern crate num_bigint;
 use num_bigint::BigInt;
@@ -22,39 +23,6 @@ impl Decimal {
         };
         value.reduce();
         value
-    }
-
-    pub fn try_from(mut input: &str) -> Option<Decimal> {
-        // clear extraneous whitespace
-        input = input.trim();
-
-        // don't bother to trim extraneous zeroes
-        // leave it to users to manage their own memory
-
-        // now build a representation of the number to parse
-        let mut digits = String::with_capacity(input.len());
-        let mut decimal_index = None;
-        for ch in input.chars() {
-            match ch {
-                '0'..='9' | '-' | '+' => {
-                    digits.push(ch);
-                    if let Some(idx) = decimal_index.as_mut() {
-                        *idx += 1;
-                    }
-                }
-                '.' => {
-                    if decimal_index.is_some() {
-                        return None;
-                    }
-                    decimal_index = Some(0)
-                }
-                _ => return None,
-            }
-        }
-        Some(Decimal::new(
-            digits.parse().ok()?,
-            decimal_index.unwrap_or_default(),
-        ))
     }
 
     /// Add precision to the less-precise value until precisions match
@@ -91,6 +59,47 @@ impl Decimal {
             .count();
         self.digits = &self.digits / pow(BigInt::from(10_usize), extra_zeroes);
         self.decimal_index -= extra_zeroes;
+    }
+}
+
+/// Indicates that a string could not be parsed as a `Decimal`
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParseDecimalError;
+
+impl FromStr for Decimal {
+    type Err = ParseDecimalError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        // clear extraneous whitespace
+        let input = input.trim();
+
+        // don't bother to trim extraneous zeroes
+        // leave it to users to manage their own memory
+
+        // now build a representation of the number to parse
+        let mut digits = String::with_capacity(input.len());
+        let mut decimal_index = None;
+        for ch in input.chars() {
+            match ch {
+                '0'..='9' | '-' | '+' => {
+                    digits.push(ch);
+                    if let Some(idx) = decimal_index.as_mut() {
+                        *idx += 1;
+                    }
+                }
+                '.' => {
+                    if decimal_index.is_some() {
+                        return Err(ParseDecimalError);
+                    }
+                    decimal_index = Some(0)
+                }
+                _ => return Err(ParseDecimalError),
+            }
+        }
+        Ok(Decimal::new(
+            digits.parse().map_err(|_| ParseDecimalError)?,
+            decimal_index.unwrap_or_default(),
+        ))
     }
 }
 
@@ -179,11 +188,14 @@ mod tests {
             println!(
                 "Decimal representation of \"{}\": {}",
                 test_str,
-                Decimal::try_from(test_str).expect("This should always become a decimal")
+                test_str
+                    .parse::<Decimal>()
+                    .expect("This should always become a decimal")
             );
             assert_eq!(
                 test_str,
-                Decimal::try_from(test_str)
+                test_str
+                    .parse::<Decimal>()
                     .expect("This should always become a decimal")
                     .to_string()
             )

--- a/exercises/practice/decimal/src/lib.rs
+++ b/exercises/practice/decimal/src/lib.rs
@@ -1,10 +1,15 @@
+use std::str::FromStr;
+
 /// Type implementing arbitrary-precision decimal arithmetic
 pub struct Decimal {
     // implement your type here
 }
 
-impl Decimal {
-    pub fn try_from(input: &str) -> Option<Decimal> {
+impl FromStr for Decimal {
+    // implement your error type here
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         todo!("Create a new decimal with a value of {input}")
     }
 }

--- a/exercises/practice/decimal/tests/decimal.rs
+++ b/exercises/practice/decimal/tests/decimal.rs
@@ -4,7 +4,7 @@ use decimal::Decimal;
 ///
 /// Use only when you _know_ that your value is valid.
 fn decimal(input: &str) -> Decimal {
-    Decimal::try_from(input).expect("That was supposed to be a valid value")
+    input.parse().expect("That was supposed to be a valid value")
 }
 
 /// Some big and precise values we can use for testing. [0] + [1] == [2]
@@ -185,7 +185,7 @@ fn gt_varying_negative_precisions() {
 #[test]
 #[ignore]
 fn negatives() {
-    assert!(Decimal::try_from("-1").is_some());
+    assert!("-1".parse::<Decimal>().is_ok());
     assert_eq!(decimal("0") - decimal("1"), decimal("-1"));
     assert_eq!(decimal("5.5") + decimal("-6.5"), decimal("-1"));
 }


### PR DESCRIPTION
## Summary
Closes #1037.

Replaces the custom `Decimal::try_from` method with `impl FromStr for Decimal`, so parsing goes through the idiomatic `.parse()` rather than a bespoke constructor. Updated the example solution, the student stub, and the test file accordingly.

## Test plan
- [x] `./bin/test_exercise.sh decimal` — all 44 tests pass against the updated example
- [x] `CLIPPY=1 ./bin/test_exercise.sh decimal` — no clippy warnings
- [x] `cargo check --tests` on the unmodified student stub — fails only on the pre-existing intentionally-unimplemented operators (per `config.json`'s `allowed-to-not-compile`), no FromStr-related errors